### PR TITLE
Cleaning up

### DIFF
--- a/StoryBuilder/App.xaml.cs
+++ b/StoryBuilder/App.xaml.cs
@@ -139,7 +139,6 @@ namespace StoryBuilder
             _log.Log(LogLevel.Info, "StoryBuilder.App launched");
 
             StoryController story = Ioc.Default.GetService<StoryController>();
-            //string localPath = $"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}";
             string localPath = ApplicationData.Current.RoamingFolder.Path.ToString();
             localPath = System.IO.Path.Combine(localPath, "StoryBuilder");
             StorageFolder localFolder = await StorageFolder.GetFolderFromPathAsync(localPath);
@@ -150,22 +149,11 @@ namespace StoryBuilder
             Trace.Indent();
             Trace.WriteLine(pathMsg);
 
-            // We need to preserve user Preferences settings across ProcessInstallationFiles.
-            // The installation file location may be empty or update, and one of those
-            // updates might be a new Preferences file if options are added. 
-            // To preserve user-set values, we read the existing Preferences file into GlobalData,
-            // run any updates (including to Preferences), and then save the preferences
-            // back to disk. Both the load and save are field-by-field updates.
-
-            // Load Preferences before processing the installation files
+            // Load Preferences
             PreferencesService pref = Ioc.Default.GetService<PreferencesService>();
             await pref.LoadPreferences(localPath, story);
 
             await ProcessInstallationFiles();
-
-            string path = GlobalData.Preferences.InstallationDirectory;
-            PreferencesIO loader = new(GlobalData.Preferences, path);
-            await loader.UpdateFile();
 
             await LoadControls(localFolder.Path, story);
 
@@ -177,7 +165,7 @@ namespace StoryBuilder
 
             m_window = new MainWindow();
             // Create a Frame to act as the navigation context and navigate to the first page (Shell)
-            Frame rootFrame = new Frame();
+            Frame rootFrame = new();
             if (rootFrame.Content == null)
             {
                 if (GlobalData.Preferences.Initalised) { rootFrame.Navigate(typeof(Shell)); }
@@ -189,7 +177,7 @@ namespace StoryBuilder
 
             //Get the Window's HWND
             m_windowHandle = PInvoke.User32.GetActiveWindow();
-            m_window.Title = "StoryBuilder";
+            m_window.Title = "StoryBuilder.";
             GlobalData.WindowHandle = m_windowHandle;
             // The Window object doesn't (yet) have Width and Height properties in WInUI 3 Desktop yet.
             // To set the Width and Height, you can use the Win32 API SetWindowPos.

--- a/StoryBuilder/Views/ScenePage.xaml
+++ b/StoryBuilder/Views/ScenePage.xaml
@@ -97,7 +97,7 @@
                                                       RtfText="{x:Bind SceneVm.Remarks, Mode=TwoWay}"
                                                       AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
-                                                      ScrollViewer.VerticalScrollBarVisibility="Visible" />
+                                                      ScrollViewer.VerticalScrollBarVisibility="Visible"/>
                 </Grid>
             </PivotItem>
             <PivotItem Header="Development">

--- a/StoryBuilder/Views/Shell.xaml
+++ b/StoryBuilder/Views/Shell.xaml
@@ -83,7 +83,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <!-- Command Bar -->
-        <CommandBar  Background="{x:Bind ShellVm.SecondaryColor}" IsOpen="False">
+        <CommandBar  Background="{x:Bind ShellVm.UserPreferences.PrimaryColor}" IsOpen="False">
             <CommandBar.Content>
                 <StackPanel Orientation="Horizontal">
                     <TextBox PlaceholderText="Enter text to search for here" Width="285" Margin="0,8" Text="{x:Bind ShellVm.FilterText, Mode=TwoWay}" VerticalAlignment="Center"/>
@@ -258,7 +258,7 @@
             </SplitView.Content>
         </SplitView>
         <!-- Status Bar -->
-        <StackPanel Grid.Row="2" Orientation="Horizontal" Background="{x:Bind ShellVm.SecondaryColor}" Margin="0,10,0,0">
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Background="{x:Bind ShellVm.UserPreferences.PrimaryColor}" Margin="0,10,0,0">
             <ComboBox IsEditable="False" Width="200"  Margin="10" ItemsSource="{x:Bind ShellVm.ViewList}" 
                       SelectionChanged="{x:Bind ShellVm.ViewChanged, Mode=OneWay}"
                       SelectedItem="{x:Bind ShellVm.SelectedView, Mode=TwoWay}" />

--- a/StoryBuilder/Views/Shell.xaml.cs
+++ b/StoryBuilder/Views/Shell.xaml.cs
@@ -40,9 +40,6 @@ namespace StoryBuilder.Views
                 // Handle exception
             }
             ShellVm.SplitViewFrame = SplitViewFrame;
-
-            if (Application.Current.RequestedTheme == ApplicationTheme.Light) { ShellVm.SecondaryColor = new Microsoft.UI.Xaml.Media.SolidColorBrush(Colors.LightGray); }
-            else { ShellVm.SecondaryColor = new Microsoft.UI.Xaml.Media.SolidColorBrush(Colors.DarkSlateGray); }
         }
 
         private void Shell_Loaded(object sender, RoutedEventArgs e)

--- a/StoryBuilderLib/Models/GlobalData.cs
+++ b/StoryBuilderLib/Models/GlobalData.cs
@@ -3,6 +3,7 @@ using StoryBuilder.Models.Tools;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Windows.Storage;
 
 namespace StoryBuilder.Models
 {
@@ -44,6 +45,9 @@ namespace StoryBuilder.Models
 
         // Preferences data
         public static PreferencesModel Preferences;
+
+        //Path to root directory where data is stored
+        public static string RootDirectory = System.IO.Path.Combine(ApplicationData.Current.RoamingFolder.Path, "Storybuilder");
 
         // A defect in preview WinUI 3 Win32 code is that ContentDialog controls don't have an
         // established XamlRoot. A workaround is to assign the dialog's XamlRoot to 

--- a/StoryBuilderLib/Models/Tools/PreferencesModel.cs
+++ b/StoryBuilderLib/Models/Tools/PreferencesModel.cs
@@ -26,7 +26,8 @@
         public bool Initalised { get; set; } //this decides if the user should be shown the initalisation window
 
         // Visual changes
-        public bool ForceDarkmode { get; set; }
+        public Microsoft.UI.Xaml.Media.SolidColorBrush PrimaryColor { get; set; } //Sets UI Color
+        public Microsoft.UI.Xaml.Media.SolidColorBrush SecondaryColor { get; set; } //Sets Text Color
         public bool QuoteOnStartup { get; set; }
 
         // Backup Information
@@ -35,10 +36,8 @@
         public int TimedBackupInterval { get; set; }
 
         //Directorys
-        public string InstallationDirectory { get; set; }
         public string ProjectDirectory { get; set; }
         public string BackupDirectory { get; set; }
-        public string LogDirectory { get; set; }
 
         // Recent files (set automatically)
         public string LastFile1 { get; set; }
@@ -52,7 +51,6 @@
         #region Constructor
         public PreferencesModel()
         {
-            InstallationDirectory = string.Empty;
             LastFile1 = string.Empty;
             LastFile2 = string.Empty;
             LastFile3 = string.Empty;

--- a/StoryBuilderLib/Services/Installation/InstallationService.cs
+++ b/StoryBuilderLib/Services/Installation/InstallationService.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using StoryBuilder.Models;
 using StoryBuilder.Services.Logging;
 using System;
 using System.Collections.Generic;
@@ -52,9 +53,11 @@ namespace StoryBuilder.Services.Installation
         /// <returns></returns>
         private async Task DeleteFiles()
         {
-            StorageFolder ParentFolder = ApplicationData.Current.RoamingFolder;
+            StorageFolder ParentFolder = await StorageFolder.GetFolderFromPathAsync(GlobalData.RootDirectory);
             foreach (StorageFile Item in await ParentFolder.GetFilesAsync())
             {
+                if (Item.Name == "StoryBuilder.prf") { continue; } //Doesnt delete prf
+
                 try { await Item.DeleteAsync(); }
                 catch (Exception ex)
                 {
@@ -64,6 +67,8 @@ namespace StoryBuilder.Services.Installation
             }
             foreach (StorageFolder Item in await ParentFolder.GetFoldersAsync())
             {
+                if (Item.Name == "logs") { continue; }
+
                 try { await Item.DeleteAsync(); }
                 catch (Exception ex)
                 {

--- a/StoryBuilderLib/Services/Preferences/PreferencesService.cs
+++ b/StoryBuilderLib/Services/Preferences/PreferencesService.cs
@@ -22,12 +22,6 @@ namespace StoryBuilder.Services.Preferences
                 PreferencesModel model = new PreferencesModel();
                 PreferencesIO loader = new PreferencesIO(model, path);
                 await loader.UpdateModel();
-                // When ran from the app, the app's local folder is the 
-                // installation directory
-                if (model.InstallationDirectory.CompareTo(path) != 0)
-                {
-                    model.InstallationDirectory = path;
-                }
                 
                 GlobalData.Preferences = model;
             }

--- a/StoryBuilderLib/ViewModels/SceneViewModel.cs
+++ b/StoryBuilderLib/ViewModels/SceneViewModel.cs
@@ -27,7 +27,7 @@ namespace StoryBuilder.ViewModels
         StatusMessage _smsg;
         private bool _changeable; // process property changes for this story element
         private bool _changed;    // this story element has changed
-   
+
         #endregion
 
         #region Properties

--- a/StoryBuilderLib/ViewModels/ShellViewModel.cs
+++ b/StoryBuilderLib/ViewModels/ShellViewModel.cs
@@ -138,19 +138,6 @@ namespace StoryBuilder.ViewModels
         #region Shell binding properties
 
         /// <summary>
-        /// This is secondary color it controls the background color of some elements
-        /// this is changed depending on the theme, this is used because the default background#
-        /// for light mode makes the UI look bad, for dark theme its alright
-        /// </summary>
-        private SolidColorBrush _SecondaryColor;
-        public SolidColorBrush SecondaryColor
-        {
-            get => _SecondaryColor;
-            set => SetProperty(ref _SecondaryColor, value);
-        }
-
-
-        /// <summary>
         /// DataSource is bound to Shell's NavigationTree TreeView control and
         /// contains either the StoryExplorer (ExplorerView) or StoryNarrator (NarratorView)
         /// ObservableCollection of StoryNodeItem instances.
@@ -167,6 +154,11 @@ namespace StoryBuilder.ViewModels
                 _canExecuteCommands = true;
             }
         }
+
+        /// <summary>
+        /// Used for theming
+        /// </summary>
+        public PreferencesModel UserPreferences = GlobalData.Preferences;
 
         private string _title;
         public string Title

--- a/StoryBuilderLib/ViewModels/UnifiedVM.cs
+++ b/StoryBuilderLib/ViewModels/UnifiedVM.cs
@@ -165,8 +165,7 @@ namespace StoryBuilder.ViewModels
                 else if (Path == GlobalData.Preferences.LastFile5) { NewRecents = new List<string>() { GlobalData.Preferences.LastFile5, GlobalData.Preferences.LastFile1, GlobalData.Preferences.LastFile2, GlobalData.Preferences.LastFile3, GlobalData.Preferences.LastFile4 }; }
             }
 
-            string path = GlobalData.Preferences.InstallationDirectory;
-            PreferencesIO loader = new(GlobalData.Preferences, path);
+            PreferencesIO loader = new(GlobalData.Preferences, GlobalData.RootDirectory);
             await loader.UpdateFile();
         }
 


### PR DESCRIPTION
- Removed Installation Directory and Log Directory from preferences
- Added primarycolor and secondarycolor, currently set when a model is loaded and changes depending on the color theme.

- Updated shell to use primary and secondary color
- Optimized app loading
- Loading now no longer deletes logs subdirectory and storybuilder.prf

- Added rootdirectory in a move to centralize where the app gets the install path from