### PR TITLE
Saveas exception (Issue #76)

### DIFF
--- a/StoryBuilderLib/Services/Dialogs/SaveAsDialog.xaml
+++ b/StoryBuilderLib/Services/Dialogs/SaveAsDialog.xaml
@@ -6,12 +6,13 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-    
+
     <StackPanel Padding="14,14,14,24">
+
         <TextBox x:Name="ProjectName" Margin="10"  x:FieldModifier="public" Width="400" HorizontalAlignment="Left" Header="New project Name" Text="{x:Bind SaveAsVm.ProjectName, Mode=TwoWay}" />
         <StackPanel Orientation="Horizontal" Margin="14">
             <TextBox x:Name="ProjectPathName" Header="Parent Folder Path" Width="330" Text="{x:Bind SaveAsVm.ProjectPathName, Mode=TwoWay}" Margin="0,0,5,0"/>
-            <Button Content="Browse" Click="OnClick" VerticalAlignment="Bottom"/>
+            <Button Content="Browse" Click="OnBrowse" VerticalAlignment="Bottom"/>
         </StackPanel>
     </StackPanel>
 </Page>

--- a/StoryBuilderLib/Services/Dialogs/SaveAsDialog.xaml.cs
+++ b/StoryBuilderLib/Services/Dialogs/SaveAsDialog.xaml.cs
@@ -1,20 +1,11 @@
 ﻿using CommunityToolkit.Mvvm.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
+using StoryBuilder.Models;
 using StoryBuilder.ViewModels;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using WinRT;
@@ -32,6 +23,7 @@ namespace StoryBuilder.Services.Dialogs
         public SaveAsDialog()
         {
             InitializeComponent();
+            ProjectPathName.IsReadOnly = true;
         }
 
         public SaveAsViewModel SaveAsVm
@@ -42,36 +34,37 @@ namespace StoryBuilder.Services.Dialogs
             }
         }
 
-        public bool BrowseButtonClicked { get; set; }
-        public bool ProjectFolderExists { get; set; }
         public StorageFolder ParentFolder { get; set; }
         public string ParentFolderPath { get; set; }
         public string ProjectFolderPath { get; set; }
 
-        private async void OnClick(object sender, RoutedEventArgs e)
+        private async void OnBrowse(object sender, RoutedEventArgs e)
         {
+            ProjectPathName.IsReadOnly = false;
             // may throw error if invalid folder location
             var folderPicker = new FolderPicker();
+            WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, GlobalData.WindowHandle);
 
             //Make FolderPicker work in Win32
-            if (Window.Current == null)
-            {
-                IntPtr hwnd = GetActiveWindow();
-                var initializeWithWindow = folderPicker.As<IInitializeWithWindow>();
-                initializeWithWindow.Initialize(hwnd);
-            }
+            //if (Window.Current == null)
+            //{
+            //    IntPtr hwnd = GetActiveWindow();
+            //    var initializeWithWindow = folderPicker.As<IInitializeWithWindow>();
+            //    initializeWithWindow.Initialize(hwnd);
+            //}
             folderPicker.CommitButtonText = "Project Parent Folder:";
             folderPicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
             folderPicker.FileTypeFilter.Add(("*"));
 
             ParentFolder = await folderPicker.PickSingleFolderAsync();
+            SaveAsVm.ParentFolder = ParentFolder;
+
             //TODO: Test for cancelled FolderPicker via 'if Parentfolder =! null {} else {}
-            ProjectFolderExists = await ParentFolder.TryGetItemAsync(ProjectName.Text) != null;
             
             ProjectFolderPath = Path.Combine(ParentFolder.Path, ProjectName.Text);
             ProjectPathName.Text = ProjectFolderPath;
             SaveAsVm.ProjectPathName = ProjectFolderPath;
-            BrowseButtonClicked = true;
+            ProjectPathName.IsReadOnly = true;
         }
 
         [ComImport]

--- a/StoryBuilderLib/ViewModels/SaveAsViewModel.cs
+++ b/StoryBuilderLib/ViewModels/SaveAsViewModel.cs
@@ -24,18 +24,18 @@ namespace StoryBuilder.ViewModels
             set => SetProperty(ref _projectPathName, value);
         }
 
-        private bool _saveAsProjectFolderExists;
-        public bool SaveAsProjectFolderExists 
+        private bool _projectFolderExists;
+        public bool ProjectFolderExists 
         {
-            get => _saveAsProjectFolderExists;
-            set => _saveAsProjectFolderExists = value;
+            get => _projectFolderExists;
+            set => _projectFolderExists = value;
         }
         
-        private StorageFolder _saveAsParentFolder;
-        public StorageFolder SaveAsParentFolder 
+        private StorageFolder _parentFolder;
+        public StorageFolder ParentFolder 
         {
-            get => _saveAsParentFolder;
-            set => _saveAsParentFolder = value; 
+            get => _parentFolder;
+            set => _parentFolder = value; 
         }
 
         private StorageFolder _saveAsProjectFolder;


### PR DESCRIPTION
Changes were primarily to SaveAsDialog.Xaml.cs; the content dialog values weren't being passed to ShellViewModel.SaveFileAs(), which called it. I used SaveAsViewModel to pass the changes (the new Project Name and Path.) Made the dialog Path name IsReadOnly and only able to be set in the FilePicker browse button.
Added code to add the renamed file to the list of recents. 
Several other miscellaneous changes.

Please review.