### PR TITLE
Code cleanup (Issue #12)

### DIFF
--- a/StoryBuilderLib/ViewModels/ShellViewModel.cs
+++ b/StoryBuilderLib/ViewModels/ShellViewModel.cs
@@ -370,10 +370,10 @@ namespace StoryBuilder.ViewModels
             StoryModel.ProjectFile = file;
             // Make sure files folder exists...
             StoryModel.FilesFolder = await StoryModel.ProjectFolder.CreateFolderAsync("files", CreationCollisionOption.OpenIfExists);
-            //TODO: Back up at the right place (after open?)
             await BackupProject();
             StoryReader rdr = Ioc.Default.GetService<StoryReader>();
             StoryModel = await rdr.ReadFile(file);
+            await BackupProject();
             if (StoryModel.ExplorerView.Count > 0)
             {
                 SetCurrentView(StoryViewType.ExplorerView);
@@ -479,6 +479,8 @@ namespace StoryBuilder.ViewModels
 
                 // Save the new project
                 await SaveFile();
+                await BackupProject();
+
 
                 StatusMessage = "New project ready.";
                 Logger.Log(LogLevel.Info, "Unity - NewFile command completed");
@@ -637,14 +639,8 @@ namespace StoryBuilder.ViewModels
                 //var window = new Window();
                 //var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
                 FolderPicker folderPicker = new();
+                //Make folder Picker work in Win32
                 WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, GlobalData.WindowHandle);
-                //Make folder Picker works in Win32
-                //if (Window.Current == null)
-                //{
-                //    IntPtr hwnd = GetActiveWindow();
-                //    var initializeWithWindow = folderPicker.As<IInitializeWithWindow>();
-                //    initializeWithWindow.Initialize(hwnd);
-                //}
                 folderPicker.CommitButtonText = "Project Folder";
                 PreferencesModel prefs = GlobalData.Preferences;
                 //TODO: Use preferences project folder instead of DocumentsLibrary
@@ -659,8 +655,6 @@ namespace StoryBuilder.ViewModels
                     _canExecuteCommands = true;  // unblock other commands
                     return;
                 }
-                //StoryModel.ProjectPath = StoryModel.ProjectFolder.Path;
-                //StoryModel.ProjectFilename = StoryModel.ProjectFolder.DisplayName;
 
                 IReadOnlyList<StorageFile> files = await StoryModel.ProjectFolder.GetFilesAsync();
                 StorageFile file = files[0];
@@ -668,10 +662,10 @@ namespace StoryBuilder.ViewModels
 
                 if (file.FileType.ToLower().Equals(".stbx"))
                 {
-                    //TODO: Back up at the right place (after open?)
                     await BackupProject();
                     StoryReader rdr = Ioc.Default.GetService<StoryReader>();
                     StoryModel = await rdr.ReadFile(file);
+                    await BackupProject();
                     if (StoryModel.ExplorerView.Count > 0)
                     {
                         SetCurrentView(StoryViewType.ExplorerView);


### PR DESCRIPTION
Correct UnifiedNewFile 'Protagonist and Antagonist' template issue. An empty new project was created without the two Character Story Elements. The template name from the dialog did not match the case statement label.
Added a backup after the UnifiedNewFIle project creation and before any subsequent user edits. All project open paths (new project, both file open paths, sample opens, and recent file opens, now take backups.