### PR TITLE
Only print Scenes in Story Synopsis

### DIFF
--- a/StoryBuilderLib/Services/Reports/ReportFormatter.cs
+++ b/StoryBuilderLib/Services/Reports/ReportFormatter.cs
@@ -568,6 +568,8 @@ public class ReportFormatter
                 foreach (StoryNodeItem child in _model.NarratorView[0].Children)
                 {
                     StoryElement scn = _model.StoryElements.StoryElementGuids[child.Uuid];
+                    if (scn.Type != StoryItemType.Scene)
+                        continue;
                     SceneModel scene = (SceneModel)scn;
                     StringBuilder sb = new(line);
                     string saveRemarks = scene.Remarks;


### PR DESCRIPTION
ReportFormatter::FormatSynopsisReport() assumed a default narrative with only one section at the beginning of the report.
Added a StoryItemType check to only add Scene summaries to the synopsis and skip all Section story elements.
Fixes Issue #87 