### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  # NRTFTree project
+  - package-ecosystem: "nuget"
+    directory: "/NRtfTree/NRTFTree.csproj"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    versioning-strategy: "auto"
+    ignore:
+      - dependency-name: "Syncfusion.Editors.WinUI"
+    commit-message:
+      prefix: "NRTFTree"
+
+  # StoryCAD project
+  - package-ecosystem: "nuget"
+    directory: "/StoryCAD/StoryCAD.csproj"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    versioning-strategy: "auto"
+    ignore:
+      - dependency-name: "Syncfusion.Editors.WinUI"
+    commit-message:
+      prefix: "StoryCAD"
+
+  # StoryCADLib project
+  - package-ecosystem: "nuget"
+    directory: "/StoryCADLib/StoryCADLib.csproj"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    versioning-strategy: "auto"
+    ignore:
+      - dependency-name: "Syncfusion.Editors.WinUI"
+    commit-message:
+      prefix: "StoryCADLib"
+
+  # StoryCADTests project
+  - package-ecosystem: "nuget"
+    directory: "/StoryCADTests/StoryCADTests.csproj"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    versioning-strategy: "auto"
+    ignore:
+      - dependency-name: "Syncfusion.Editors.WinUI"
+    commit-message:
+      prefix: "StoryCADTests"


### PR DESCRIPTION
This PR adds dependabot, it will once a day create PRs to update the dependencies of our projects with the exception of syncfusion.