### PR TITLE
Automatically navigate to newly added Treeview nodes

### DIFF
--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23138" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23139" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23135" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23136" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23136" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23138" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23129" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23135" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCAD/Properties/launchSettings.json
+++ b/StoryCAD/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "StoryCAD (Package)": {
       "commandName": "MsixPackage",
       "hotReloadEnabled": false,
-      "nativeDebugging": false
+      "nativeDebugging": true
     },
     "StoryCAD (Unpackaged)": {
       "commandName": "Project"

--- a/StoryCAD/Views/CharacterPage.xaml
+++ b/StoryCAD/Views/CharacterPage.xaml
@@ -4,14 +4,17 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:editors="using:Syncfusion.UI.Xaml.Editors"
     xmlns:local="using:StoryCAD.Views"
-    xmlns:usercontrols="using:StoryCAD.Controls" >
+    xmlns:usercontrols="using:StoryCAD.Controls"
+    xmlns:viewModels="using:StoryCAD.ViewModels">
 
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <TextBox Header="Name" Text="{x:Bind CharVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,10,10,0" />
+        <TextBox Header="Name" Text="{x:Bind CharVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                 viewModels:TextBoxFocus.IsFocused="{x:Bind CharVm.IsTextBoxFocused, Mode=TwoWay}"
+                 Margin="10,10,10,0" />
         <Pivot Grid.Row="1">
             <PivotItem Header="Role">
                 <Grid>

--- a/StoryCAD/Views/FolderPage.xaml
+++ b/StoryCAD/Views/FolderPage.xaml
@@ -17,7 +17,9 @@
         <TextBox Header="Name" Grid.Row="0" Text="{x:Bind FolderVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
                  viewModels:TextBoxFocus.IsFocused="{x:Bind FolderVm.IsTextBoxFocused, Mode=TwoWay}"
                  Margin="10,10,10,0" />
-        <usercontrols:RichEditBoxExtended Header="Notes" Grid.Row="1" RtfText="{x:Bind FolderVm.Notes, Mode=TwoWay}" AcceptsReturn="True" IsSpellCheckEnabled="True" TextWrapping="Wrap" ScrollViewer.VerticalScrollBarVisibility="Visible" Margin="10,10,10,0" />
+        <usercontrols:RichEditBoxExtended Header="Notes" Grid.Row="1" RtfText="{x:Bind FolderVm.Notes, Mode=TwoWay}" 
+                                          AcceptsReturn="True" IsSpellCheckEnabled="True" TextWrapping="Wrap" 
+                                          ScrollViewer.VerticalScrollBarVisibility="Visible" Margin="10,10,10,0" />
     </Grid>   
 
 </local:BindablePage>

--- a/StoryCAD/Views/FolderPage.xaml
+++ b/StoryCAD/Views/FolderPage.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:usercontrols="using:StoryCAD.Controls"
+    xmlns:viewModels="using:StoryCAD.ViewModels"
     mc:Ignorable="d" >
 
     <Grid>
@@ -13,7 +14,9 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <TextBox Header="Name" Grid.Row="0" Text="{x:Bind FolderVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,10,10,0" />
+        <TextBox Header="Name" Grid.Row="0" Text="{x:Bind FolderVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                 viewModels:TextBoxFocus.IsFocused="{x:Bind FolderVm.IsTextBoxFocused, Mode=TwoWay}"
+                 Margin="10,10,10,0" />
         <usercontrols:RichEditBoxExtended Header="Notes" Grid.Row="1" RtfText="{x:Bind FolderVm.Notes, Mode=TwoWay}" AcceptsReturn="True" IsSpellCheckEnabled="True" TextWrapping="Wrap" ScrollViewer.VerticalScrollBarVisibility="Visible" Margin="10,10,10,0" />
     </Grid>   
 

--- a/StoryCAD/Views/ProblemPage.xaml
+++ b/StoryCAD/Views/ProblemPage.xaml
@@ -4,14 +4,17 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:editors="using:Syncfusion.UI.Xaml.Editors"                    
     xmlns:local="using:StoryCAD.Views"
-    xmlns:usercontrols="using:StoryCAD.Controls" >
+    xmlns:usercontrols="using:StoryCAD.Controls"
+    xmlns:viewModels="using:StoryCAD.ViewModels">
 
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <TextBox Header="Name" Text="{x:Bind ProblemVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,10,10,0" />
+        <TextBox Header="Name" Text="{x:Bind ProblemVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                 viewModels:TextBoxFocus.IsFocused="{x:Bind ProblemVm.IsTextBoxFocused, Mode=TwoWay}"
+                 Margin="10,10,10,0" />
         <Pivot Grid.Row="1">
             <PivotItem Header="Problem">
                 <Grid>

--- a/StoryCAD/Views/ScenePage.xaml
+++ b/StoryCAD/Views/ScenePage.xaml
@@ -9,6 +9,7 @@
     xmlns:editors="using:Syncfusion.UI.Xaml.Editors"                    
     xmlns:usercontrols="using:StoryCAD.Controls"
     xmlns:system="using:System"
+    xmlns:viewModels="using:StoryCAD.ViewModels"
     mc:Ignorable="d" >
 
     <Page.Resources>
@@ -26,7 +27,9 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <TextBox Header="Name" Text="{x:Bind SceneVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,10,10,0" />
+        <TextBox Header="Name" Text="{x:Bind SceneVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                 viewModels:TextBoxFocus.IsFocused="{x:Bind SceneVm.IsTextBoxFocused, Mode=TwoWay}"
+                 Margin="10,10,10,0" />
         <Pivot Grid.Row="1">
             <PivotItem Header="Scene">
                 <Grid>

--- a/StoryCAD/Views/SettingPage.xaml
+++ b/StoryCAD/Views/SettingPage.xaml
@@ -7,6 +7,7 @@
     xmlns:local="using:StoryCAD.Views"
     xmlns:usercontrols="using:StoryCAD.Controls"
     xmlns:editors="using:Syncfusion.UI.Xaml.Editors"
+    xmlns:viewModels="using:StoryCAD.ViewModels"
     mc:Ignorable="d" >
 
     <Grid>
@@ -14,7 +15,9 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <TextBox Header="Name" Text="{x:Bind SettingVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,10,10,0" />
+        <TextBox Header="Name" Text="{x:Bind SettingVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                 viewModels:TextBoxFocus.IsFocused="{x:Bind SettingVm.IsTextBoxFocused, Mode=TwoWay}"
+                 Margin="10,10,10,0" />
         <Pivot Grid.Row="1">
             <PivotItem Header="Setting">
                 <Grid>

--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -8,6 +8,15 @@
     xmlns:viewmodels="using:StoryCAD.ViewModels"   
     mc:Ignorable="d">
     <Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Default">
+                    <SolidColorBrush x:Key="TreeViewItemBackgroundPointerOver" Color="{x:Bind Preferences.AccentColor, Mode=OneWay}"/>
+                    <!-- <SolidColorBrush x:Key="TreeViewItemForegroundPointerOver" Color="Red"/>-->
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+
+
         <CommandBarFlyout x:Key="AddStoryElementFlyout" Placement="Right" x:Name="AddStoryElementCommandBarFlyout" >
             <CommandBarFlyout.SecondaryCommands>
                 <AppBarButton Icon="Add" Label="Add Elements" >
@@ -70,6 +79,7 @@
                 </AppBarButton>
             </CommandBarFlyout.SecondaryCommands>
         </CommandBarFlyout>
+        </ResourceDictionary>
     </Page.Resources>
 
     <Grid>
@@ -304,6 +314,7 @@
                    OpenPaneLength="340"
                    DisplayMode="Inline"
                    FontFamily="Segoe UI">
+            <!-- Nav tree -->
             <SplitView.Pane>
                 <Grid>
                     <Grid.RowDefinitions>
@@ -317,12 +328,12 @@
                                    SelectionMode="Single"
                                    DragLeave="TreeView_OnDragLeave"
                                    DragItemsStarting="TreeView_DragItemsStarting"
-                                   ItemInvoked="TreeViewItem_Invoked" >
+                                   ItemInvoked="TreeViewItem_Invoked">
                         <muxc:TreeView.ItemTemplate>
                             <DataTemplate  x:DataType="viewmodels:StoryNodeItem">
                                 <muxc:TreeViewItem ItemsSource="{x:Bind Children}" 
                                                    Background="{x:Bind Background, Mode=OneWay}" 
-                                                   IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}" 
+                                                   IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}"
                                                    DragOver="TreeViewItem_OnDragOver"
                                                    RightTapped="TreeViewItem_RightTapped" >
                                     <StackPanel Orientation="Horizontal">

--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -11,8 +11,9 @@
         <ResourceDictionary>
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Default">
-                    <SolidColorBrush x:Key="TreeViewItemBackgroundPointerOver" Color="{x:Bind Preferences.AccentColor, Mode=OneWay}"/>
-                    <!-- <SolidColorBrush x:Key="TreeViewItemForegroundPointerOver" Color="Red"/>-->
+                    <SolidColorBrush x:Key="TreeViewItemBackgroundPointerOver" Color="{ThemeResource SystemAccentColor}" />
+                    <SolidColorBrush x:Key="TreeViewItemBackgroundSelected" Color="{ThemeResource SystemAccentColor}"  />
+                    <!-- Replace #FF00FF with your color -->
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
 

--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -328,7 +328,7 @@
                                    SelectionMode="Single"
                                    DragLeave="TreeView_OnDragLeave"
                                    DragItemsStarting="TreeView_DragItemsStarting"
-                                   ItemInvoked="TreeViewItem_Invoked">
+                                   ItemInvoked="TreeViewItem_Invoked"> 
                         <muxc:TreeView.ItemTemplate>
                             <DataTemplate  x:DataType="viewmodels:StoryNodeItem">
                                 <muxc:TreeViewItem ItemsSource="{x:Bind Children}" 

--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -338,7 +338,8 @@
                                                    RightTapped="TreeViewItem_RightTapped" >
                                     <StackPanel Orientation="Horizontal">
                                         <SymbolIcon Symbol="{x:Bind Symbol, Mode=OneWay}" Width="20" Height="20"/>
-                                        <TextBlock Text="{x:Bind Name, Mode=TwoWay}" TextWrapping="{Binding  TextWrapping}" MaxWidth="220" Margin="10,0,10,0"/>
+                                        <TextBlock Text="{x:Bind Name, Mode=TwoWay}"          
+                                                   TextWrapping="{x:Bind TextWrapping}" MaxWidth="220" Margin="10,0,10,0"/>
                                     </StackPanel>
                                 </muxc:TreeViewItem>
                             </DataTemplate>

--- a/StoryCAD/Views/WebPage.xaml
+++ b/StoryCAD/Views/WebPage.xaml
@@ -2,7 +2,8 @@
                     x:Class="StoryCAD.Views.WebPage"
                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:views="using:StoryCAD.Views">
+                    xmlns:views="using:StoryCAD.Views"
+                    xmlns:viewModels="using:StoryCAD.ViewModels">
 
     <Grid Margin="8,10">
         <Grid.RowDefinitions>
@@ -10,7 +11,9 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <TextBox Header="Name" Text="{x:Bind WebVM.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Grid.Row="0"/>
+        <TextBox Header="Name" Text="{x:Bind WebVM.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                 viewModels:TextBoxFocus.IsFocused="{x:Bind WebVM.IsTextBoxFocused, Mode=TwoWay}"
+                 Grid.Row="0"/>
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>

--- a/StoryCADLib/DAL/PreferencesIO.cs
+++ b/StoryCADLib/DAL/PreferencesIO.cs
@@ -9,6 +9,8 @@ using Microsoft.UI.Xaml.Media;
 using StoryCAD.Models;
 using StoryCAD.Models.Tools;
 using StoryCAD.Services.Logging;
+using Windows.UI.ViewManagement;
+using System.Diagnostics;
 
 namespace StoryCAD.DAL;
 
@@ -170,6 +172,8 @@ public class PreferencesIo
             _model.PrimaryColor = new SolidColorBrush(Colors.DarkSlateGray);
             _model.SecondaryColor = new SolidColorBrush(Colors.White);
         }
+
+        _model.AccentColor = new UISettings().GetColorValue(UIColorType.Accent);
     }
 
     /// <summary>

--- a/StoryCADLib/Models/Tools/PreferencesModel.cs
+++ b/StoryCADLib/Models/Tools/PreferencesModel.cs
@@ -38,7 +38,8 @@ public class PreferencesModel : ObservableRecipient
 
     // Visual changes
     public SolidColorBrush PrimaryColor { get; set; } //Sets UI Color
-    public SolidColorBrush SecondaryColor = new(new UISettings().GetColorValue(UIColorType.Accent)); //Sets Text Color
+    public SolidColorBrush SecondaryColor { get; set; } //Sets Text Color
+    public Windows.UI.Color AccentColor { get; set; } //Sets Text Color
     public TextWrapping WrapNodeNames { get; set; }
 
     // Backup Information

--- a/StoryCADLib/Services/Dialogs/Tools/NarrativeTool.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/NarrativeTool.xaml
@@ -33,7 +33,8 @@
                 </TreeView.ItemTemplate>
             </TreeView>
 
-            <TextBlock Text="NarratorView View" Grid.Column="1" Grid.Row="0" HorizontalAlignment="Center"/>
+            <TextBlock Text="NarratorView View"  Grid.Row="0" Grid.Column="1" HorizontalAlignment="Center"/>
+
             <TreeView ItemsSource="{x:Bind ShellVM.StoryModel.NarratorView, Mode=TwoWay}" Margin="0,5" Grid.Row="1" Grid.Column="1">
                 <TreeView.ItemTemplate>
                     <DataTemplate x:DataType="viewModels:StoryNodeItem">
@@ -44,7 +45,8 @@
                 </TreeView.ItemTemplate>
             </TreeView>
 
-            <TextBlock Grid.Row="2" Margin="0,0,0,5" Text="{x:Bind ToolVM.Message, Mode=OneWay}" HorizontalAlignment="Center" Grid.ColumnSpan="22" TextWrapping="Wrap"/>
+            <TextBlock Grid.Column="0"  Grid.Row="1" Margin="0,0,0,5" Text="{x:Bind ToolVM.Message, Mode=OneWay}" HorizontalAlignment="Center" 
+                       Grid.ColumnSpan="2" TextWrapping="Wrap"/>
         </Grid>
 
         <StackPanel Grid.Column="0" Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Center">

--- a/StoryCADLib/StoryCADLib.csproj
+++ b/StoryCADLib/StoryCADLib.csproj
@@ -50,6 +50,7 @@
     <None Remove="Services\Dialogs\Tools\NarrativeTool.xaml" />
     <None Remove="Services\Dialogs\Tools\PrintReportsDialog.xaml" />
     <None Remove="Services\Dialogs\UnifiedMenu.xaml" />
+    <None Remove="ViewModels\Shell.xaml" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Assets\Install\**" />
@@ -157,6 +158,9 @@
   <ItemGroup>
     <Page Update="Controls\RelationshipView.xaml">
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="ViewModels\Shell.xaml">
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </Page>
   </ItemGroup>
 

--- a/StoryCADLib/ViewModels/CharacterViewModel.cs
+++ b/StoryCADLib/ViewModels/CharacterViewModel.cs
@@ -67,6 +67,13 @@ public class CharacterViewModel : ObservableRecipient, INavigable
         }
     }
 
+    private bool _isTextBoxFocused;
+    public bool IsTextBoxFocused
+    {
+        get => _isTextBoxFocused;
+        set => SetProperty(ref _isTextBoxFocused, value);
+    }
+
     // Character role data
 
     private string _role;
@@ -536,6 +543,8 @@ public class CharacterViewModel : ObservableRecipient, INavigable
 
         Uuid = Model.Uuid;
         Name = Model.Name;
+        if (Name.Equals("New Character"))
+            IsTextBoxFocused = true;
         Role = Model.Role;
         StoryRole = Model.StoryRole;
         Archetype = Model.Archetype;
@@ -604,6 +613,7 @@ public class CharacterViewModel : ObservableRecipient, INavigable
         {
             // Story.Uuid is read-only and cannot be set
             Model.Name = Name;
+            IsTextBoxFocused = false;
             Model.Role = Role;
             Model.StoryRole = StoryRole;
             Model.Archetype = Archetype;

--- a/StoryCADLib/ViewModels/FolderViewModel.cs
+++ b/StoryCADLib/ViewModels/FolderViewModel.cs
@@ -112,6 +112,8 @@ public class FolderViewModel : ObservableRecipient, INavigable
         Name = Model.Name;
         if (Name.Equals("New Folder") || Name.Equals("New Note"))
             IsTextBoxFocused = true;
+        if (Name.Equals("New Section"))
+            IsTextBoxFocused = true;
         Notes = Model.Notes;
 
         _changeable = true;

--- a/StoryCADLib/ViewModels/FolderViewModel.cs
+++ b/StoryCADLib/ViewModels/FolderViewModel.cs
@@ -55,6 +55,13 @@ public class FolderViewModel : ObservableRecipient, INavigable
         }
     }
 
+    private bool _isTextBoxFocused;
+    public bool IsTextBoxFocused
+    {
+        get => _isTextBoxFocused;
+        set => SetProperty(ref _isTextBoxFocused, value);
+    }
+
     // Folder data
 
     private string _notes;
@@ -103,6 +110,8 @@ public class FolderViewModel : ObservableRecipient, INavigable
 
         Uuid = Model.Uuid;
         Name = Model.Name;
+        if (Name.Equals("New Folder"))
+            IsTextBoxFocused = true;
         Notes = Model.Notes;
 
         _changeable = true;
@@ -114,6 +123,7 @@ public class FolderViewModel : ObservableRecipient, INavigable
         {
             // Story.Uuid is read-only; no need to save
             Model.Name = Name;
+            IsTextBoxFocused = false;   
 
             // Write RYG file
             Model.Notes = Notes;

--- a/StoryCADLib/ViewModels/FolderViewModel.cs
+++ b/StoryCADLib/ViewModels/FolderViewModel.cs
@@ -110,7 +110,7 @@ public class FolderViewModel : ObservableRecipient, INavigable
 
         Uuid = Model.Uuid;
         Name = Model.Name;
-        if (Name.Equals("New Folder"))
+        if (Name.Equals("New Folder") || Name.Equals("New Note"))
             IsTextBoxFocused = true;
         Notes = Model.Notes;
 

--- a/StoryCADLib/ViewModels/OverviewViewModel.cs
+++ b/StoryCADLib/ViewModels/OverviewViewModel.cs
@@ -68,6 +68,13 @@ public class OverviewViewModel : ObservableRecipient, INavigable
         }
     }
 
+    private bool _isTextBoxFocused;
+    public bool IsTextBoxFocused
+    {
+        get => _isTextBoxFocused;
+        set => SetProperty(ref _isTextBoxFocused, value);
+    }
+
     // Overview data
 
     private string _dateCreated;
@@ -256,6 +263,7 @@ public class OverviewViewModel : ObservableRecipient, INavigable
 
         Uuid = Model.Uuid;
         Name = Model.Name;
+        if (Name.Equals("New Outline"))
         DateCreated = Model.DateCreated;
         Author = Model.Author;
         DateModified = Model.DateModified;
@@ -285,6 +293,7 @@ public class OverviewViewModel : ObservableRecipient, INavigable
         {
             // Story.Uuid is read-only and cannot be assigned
             Model.Name = Name;
+            IsTextBoxFocused = false;
             Model.DateCreated = DateCreated;
             Model.Author = Author;
             Model.DateModified = DateModified;

--- a/StoryCADLib/ViewModels/ProblemViewModel.cs
+++ b/StoryCADLib/ViewModels/ProblemViewModel.cs
@@ -62,6 +62,13 @@ public class ProblemViewModel : ObservableRecipient, INavigable
         }
     }
 
+    private bool _isTextBoxFocused;
+    public bool IsTextBoxFocused
+    {
+        get => _isTextBoxFocused;
+        set => SetProperty(ref _isTextBoxFocused, value);
+    }
+
     // Problem problem data
     private string _problemType;
     public string ProblemType
@@ -248,6 +255,8 @@ public class ProblemViewModel : ObservableRecipient, INavigable
 
         Uuid = Model.Uuid;
         Name = Model.Name;
+        if (Name.Equals("New Problem"))
+            IsTextBoxFocused = true;    
         ProblemType = Model.ProblemType;
         ConflictType = Model.ConflictType;
         ProblemCategory = Model.ProblemCategory;
@@ -285,6 +294,7 @@ public class ProblemViewModel : ObservableRecipient, INavigable
     {
         if (_changed)
         {
+            IsTextBoxFocused = false;
             // Story.Uuid is read-only and cannot be assigned
             Model.Name = Name;
             Model.ProblemType = ProblemType;

--- a/StoryCADLib/ViewModels/SceneViewModel.cs
+++ b/StoryCADLib/ViewModels/SceneViewModel.cs
@@ -57,6 +57,13 @@ public class SceneViewModel : ObservableRecipient, INavigable
         }
     }
 
+    private bool _isTextBoxFocused;
+    public bool IsTextBoxFocused
+    {
+        get => _isTextBoxFocused;
+        set => SetProperty(ref _isTextBoxFocused, value);
+    }
+
     private bool _showCastSelection;
     public bool ShowCastSelection
     {
@@ -343,6 +350,8 @@ public class SceneViewModel : ObservableRecipient, INavigable
 
         Uuid = Model.Uuid;
         Name = Model.Name;
+        if (Name.Equals("New Scene"))
+            IsTextBoxFocused = true;
         Description = Model.Description;
         Date = Model.Date;
         Time = Model.Time;
@@ -433,6 +442,7 @@ public class SceneViewModel : ObservableRecipient, INavigable
         {
             // Story.Uuid is read-only and cannot be assigned
             Model.Name = Name;
+            IsTextBoxFocused = false;
             Model.Description = Description;
             Model.ViewpointCharacter = ViewpointCharacter;
             Model.Date = Date;

--- a/StoryCADLib/ViewModels/SettingViewModel.cs
+++ b/StoryCADLib/ViewModels/SettingViewModel.cs
@@ -51,6 +51,13 @@ public class SettingViewModel : ObservableRecipient, INavigable
         }
     }
 
+    private bool _isTextBoxFocused;
+    public bool IsTextBoxFocused
+    {
+        get => _isTextBoxFocused;
+        set => SetProperty(ref _isTextBoxFocused, value);
+    }
+
     // Setting (General) data
 
     private string _locale;
@@ -187,6 +194,8 @@ public class SettingViewModel : ObservableRecipient, INavigable
 
         Uuid = Model.Uuid;
         Name = Model.Name;
+        if (Name.Equals("New Setting"))
+            IsTextBoxFocused = true;
         Locale = Model.Locale;
         Season = Model.Season;
         Period = Model.Period;
@@ -210,6 +219,7 @@ public class SettingViewModel : ObservableRecipient, INavigable
         {
             // Story.Uuid is read-only and cannot be assigned
             Model.Name = Name;
+            IsTextBoxFocused = false;
             Model.Locale = Locale;
             Model.Season = Season;
             Model.Period = Period;

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -516,7 +516,10 @@ public class ShellViewModel : ObservableRecipient
             return;
         }
         Logger.Log(LogLevel.Info, $"TreeViewNodeClicked for {selectedItem}");
-        //RightClickedTreeviewItem.Background = null;
+        
+
+        if (RightClickedTreeviewItem != null) { RightClickedTreeviewItem.Background = null; }
+        
         try
         {
             NavigationService _nav = Ioc.Default.GetRequiredService<NavigationService>();

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -516,7 +516,7 @@ public class ShellViewModel : ObservableRecipient
             return;
         }
         Logger.Log(LogLevel.Info, $"TreeViewNodeClicked for {selectedItem}");
-        RightClickedTreeviewItem.Background = null;
+        //RightClickedTreeviewItem.Background = null;
         try
         {
             NavigationService _nav = Ioc.Default.GetRequiredService<NavigationService>();
@@ -1771,6 +1771,7 @@ public class ShellViewModel : ObservableRecipient
         {
             _newNode.Parent.IsExpanded = true;
             _newNode.IsRoot = false; //Only an overview node can be a root, which cant be created normally
+            _newNode.IsSelected = true;
         }
         else { return null; }
 
@@ -2195,6 +2196,13 @@ public class ShellViewModel : ObservableRecipient
                 break;
         }
     }
+
+    #endregion
+
+    #region Attched Properties
+
+
+
 
     #endregion
 

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -1679,7 +1679,8 @@ public class ShellViewModel : ObservableRecipient
 
     private void AddFolder()
     {
-        TreeViewNodeClicked(AddStoryElement(StoryItemType.Folder));
+        var z = AddStoryElement(StoryItemType.Folder);
+        TreeViewNodeClicked(z);
     }
 
     private void AddSection()
@@ -1771,12 +1772,13 @@ public class ShellViewModel : ObservableRecipient
             _newNode.Parent.IsExpanded = true;
             _newNode.IsRoot = false; //Only an overview node can be a root, which cant be created normally
         }
+        else { return null; }
 
         Messenger.Send(new IsChangedMessage(true));
         Messenger.Send(new StatusChangedMessage(new($"Added new {typeToAdd}", LogLevel.Info, true)));
         _canExecuteCommands = true;
 
-        return null;
+        return _newNode;
     }
 
     private async void RemoveStoryElement()

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -516,7 +516,7 @@ public class ShellViewModel : ObservableRecipient
             return;
         }
         Logger.Log(LogLevel.Info, $"TreeViewNodeClicked for {selectedItem}");
-
+        RightClickedTreeviewItem.Background = null;
         try
         {
             NavigationService _nav = Ioc.Default.GetRequiredService<NavigationService>();
@@ -1679,8 +1679,8 @@ public class ShellViewModel : ObservableRecipient
 
     private void AddFolder()
     {
-        var z = AddStoryElement(StoryItemType.Folder);
-        TreeViewNodeClicked(z);
+        TreeViewNodeClicked(AddStoryElement(StoryItemType.Folder));
+
     }
 
     private void AddSection()

--- a/StoryCADLib/ViewModels/TextBoxFocus.cs
+++ b/StoryCADLib/ViewModels/TextBoxFocus.cs
@@ -1,0 +1,44 @@
+﻿    using Microsoft.UI.Xaml.Controls;
+    using Microsoft.UI.Xaml;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    namespace StoryCAD.ViewModels
+    {
+        public static class TextBoxFocus
+        {
+            public static bool GetIsFocused(DependencyObject obj)
+            {
+                return (bool)obj.GetValue(IsFocusedProperty);
+            }
+
+            public static void SetIsFocused(DependencyObject obj, bool value)
+            {
+                obj.SetValue(IsFocusedProperty, value);
+            }
+
+            public static readonly DependencyProperty IsFocusedProperty =
+                DependencyProperty.RegisterAttached("IsFocused", typeof(bool), typeof(TextBoxFocus), new PropertyMetadata(false, OnIsFocusedPropertyChanged));
+
+            private static void OnIsFocusedPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+            {
+                if ((bool)e.NewValue)
+                {
+                    ((TextBox)d).Loaded += TextBox_Loaded;
+                }
+                else
+                {
+                    ((TextBox)d).Loaded -= TextBox_Loaded;
+                }
+            }
+
+            private static void TextBox_Loaded(object sender, RoutedEventArgs e)
+            {
+                ((TextBox)sender).Focus(FocusState.Programmatic);
+                ((TextBox)sender).SelectAll();
+            }
+        }
+    }

--- a/StoryCADLib/ViewModels/WebViewModel.cs
+++ b/StoryCADLib/ViewModels/WebViewModel.cs
@@ -49,6 +49,13 @@ public class WebViewModel : ObservableRecipient, INavigable
         }
     }
 
+    private bool _isTextBoxFocused;
+    public bool IsTextBoxFocused
+    {
+        get => _isTextBoxFocused;
+        set => SetProperty(ref _isTextBoxFocused, value);
+    }
+
     private Guid _uuid;
     public Guid Guid
     {
@@ -224,6 +231,8 @@ public class WebViewModel : ObservableRecipient, INavigable
         
         Guid = Model.Uuid;
         Name = Model.Name;
+        if (Name.Equals("New Webpage"))
+            IsTextBoxFocused = true;
         Url = Model.URL;
         Timestamp = Model.Timestamp;
 
@@ -236,6 +245,7 @@ public class WebViewModel : ObservableRecipient, INavigable
         {
             // Story.Uuid is read-only and cannot be assigned
             Model.Name = Name;
+            IsTextBoxFocused = false;
             Model.URL = Url;
             Model.Timestamp = Timestamp;
 


### PR DESCRIPTION
Reduce user effort to add nodes by invoking the newly added node.
Also, set focus to the Name field on the new node and select its text, so that the user can simply key in the new node's name without clicks and selection dragging. 
Set TreeviewItem background color for the selected item to the system accent color (same as PointerOver.)

Per issue #501 