### PR TITLE
Fix quickstart Initalisation URL

### DIFF
--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23132" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23139" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCAD/Views/PreferencesInitialization.xaml
+++ b/StoryCAD/Views/PreferencesInitialization.xaml
@@ -49,7 +49,7 @@
 
                 <!--Target on the button but it causes a crash.-->
                 <TeachingTip Title="First time using StoryCAD?" PreferredPlacement="BottomLeft" PlacementMargin="10" IsOpen="True" IsLightDismissEnabled="False" CloseButtonContent="Not now">
-                    <TextBlock TextWrapping="WrapWholeWords" Margin="0,5,0,0">Why not check out the <Hyperlink NavigateUri="https://storybuilder-org.github.io/StoryCAD-2/Quick_Start.html">Quick start guide?</Hyperlink>
+                    <TextBlock TextWrapping="WrapWholeWords" Margin="0,5,0,0">Why not check out the <Hyperlink NavigateUri="https://storybuilder-org.github.io/StoryCAD/Quick_Start.html">Quick start guide?</Hyperlink>
                     You can view the manual by clicking the ? icon.</TextBlock>
                 </TeachingTip>
             </Grid>


### PR DESCRIPTION
This PR fixes a URL issue within the initalisation page of the app where the quickstart link is broken and doesn't work due to the app being renamed and github removing the temporary redirects,  (fixes #557)