### PR TITLE
Downgrade Sync Fusion

### DIFF
--- a/StoryCAD/StoryCAD.csproj
+++ b/StoryCAD/StoryCAD.csproj
@@ -43,7 +43,7 @@
 		<PackageReference Include="NLog" Version="5.1.3" />
 		<PackageReference Include="NLog.Extensions.Logging" Version="5.2.3" />
 		<PackageReference Include="PInvoke.User32" Version="0.7.124" />
-		<PackageReference Include="Syncfusion.Editors.WinUI" Version="20.2.0.40" />
+		<PackageReference Include="Syncfusion.Editors.WinUI" Version="19.4.0.56" />
 		<PackageReference Include="WinUIEx" Version="2.1.0" />
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>

--- a/StoryCADLib/StoryCADLib.csproj
+++ b/StoryCADLib/StoryCADLib.csproj
@@ -74,7 +74,7 @@
     <PackageReference Include="NLog" Version="5.1.3" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.2.3" />
     <PackageReference Include="Octokit" Version="5.0.4" />
-    <PackageReference Include="Syncfusion.Editors.WinUI" Version="20.2.0.40" />
+    <PackageReference Include="Syncfusion.Editors.WinUI" Version="19.4.0.56" />
     <PackageReference Include="WinUIEx" Version="2.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR Downgrades SF to the correct version of SF.

This fixes #556 