### PR TITLE
Update problem page conflict boxes to use full space available

### DIFF
--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23132" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23147" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCAD/Views/ProblemPage.xaml
+++ b/StoryCAD/Views/ProblemPage.xaml
@@ -58,7 +58,7 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <usercontrols:CharacterName Header="Protagonist" Grid.Row="0" IsEditable="False" MinWidth="300"
                               DisplayMemberPath="Name"
@@ -71,8 +71,8 @@
                                     Text="{x:Bind ProblemVm.ProtMotive, Mode=TwoWay}" />
                     <Button  Content="Conflict Builder" Grid.Row="3" HorizontalAlignment="Left" Margin="0,10,10,10" 
                              Command="{x:Bind ProblemVm.ConflictCommand, Mode=OneWay}" />
-                    <TextBox Header="Conflict" Grid.Row="4" MinWidth="300" TextWrapping="Wrap" AcceptsReturn="True"
-                             Text="{x:Bind ProblemVm.ProtConflict, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <usercontrols:RichEditBoxExtended Header="Conflict" Grid.Row="4" MinWidth="300" TextWrapping="Wrap" AcceptsReturn="True" VerticalAlignment="Stretch"
+                                                      RtfText="{x:Bind ProblemVm.ProtConflict, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </Grid>
             </PivotItem>
             <PivotItem Header="Antagonist">
@@ -82,7 +82,7 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <usercontrols:CharacterName Header="Antagonist" Grid.Row="0" IsEditable="False" MinWidth="300"
                               DisplayMemberPath="Name"
@@ -95,8 +95,8 @@
                               Text="{x:Bind ProblemVm.AntagMotive, Mode=TwoWay}" />
                     <Button  Content="Conflict Builder" Grid.Row="3" HorizontalAlignment="Left" Margin="0,10,10,10" 
                              Command="{x:Bind ProblemVm.ConflictCommand, Mode=OneWay}" />
-                    <TextBox Header="Conflict" Grid.Row="4" MinWidth="300" TextWrapping="Wrap" AcceptsReturn="True"
-                             Text="{x:Bind ProblemVm.AntagConflict, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <usercontrols:RichEditBoxExtended Header="Conflict" Grid.Row="4" MinWidth="300" TextWrapping="Wrap" AcceptsReturn="True" VerticalAlignment="Stretch"
+                                                      RtfText="{x:Bind ProblemVm.AntagConflict, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </Grid>
             </PivotItem>
             <PivotItem Header="Resolution">


### PR DESCRIPTION
This PR updates the problem page antagonist and protagonist tabs to make the conflict boxes take up the remaining space on the page instead of being roughly one line tall.


Fixes #569