### PR TITLE
Fix right click menu visibility issue

### DIFF
--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23142" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23147" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -13,7 +13,6 @@
                 <ResourceDictionary x:Key="Default">
                     <SolidColorBrush x:Key="TreeViewItemBackgroundPointerOver" Color="{ThemeResource SystemAccentColor}" />
                     <SolidColorBrush x:Key="TreeViewItemBackgroundSelected" Color="{ThemeResource SystemAccentColor}"  />
-                    <!-- Replace #FF00FF with your color -->
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
 
@@ -361,7 +360,7 @@
         <!-- Status Bar -->
         <StackPanel Grid.Row="2" Orientation="Horizontal" Background="{x:Bind ShellVm.UserPreferences.PrimaryColor}">
             <ComboBox IsEditable="False" Width="200"  Margin="10" ItemsSource="{x:Bind ShellVm.ViewList}" 
-                      SelectionChanged="{x:Bind ShellVm.ViewChanged, Mode=OneWay}"
+                      SelectionChanged="{x:Bind ShellVm.ViewChanged, Mode=OneWay}" 
                       SelectedItem="{x:Bind ShellVm.SelectedView, Mode=TwoWay}" />
             <TextBlock Text="{x:Bind ShellVm.StatusMessage, Mode=OneWay}"
                        Foreground="{x:Bind ShellVm.StatusColor, Mode=OneWay}"

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -2078,10 +2078,29 @@ public class ShellViewModel : ObservableRecipient
     /// </summary>
     public void ShowFlyoutButtons()
     {
-        switch (RootNodeType(RightTappedNode))
+        //Trash Can - View Hide all buttons except Empty Trash.
+        if (RootNodeType(RightTappedNode) == StoryItemType.TrashCan)
         {
-            case StoryItemType.StoryOverview:   // ExplorerView tree
-                AddFolderVisibility = Visibility.Visible;
+            AddFolderVisibility = Visibility.Collapsed;
+            AddSectionVisibility = Visibility.Collapsed;
+            AddProblemVisibility = Visibility.Collapsed;
+            AddCharacterVisibility = Visibility.Collapsed;
+            AddSettingVisibility = Visibility.Collapsed;
+            AddSceneVisibility = Visibility.Collapsed;
+            RemoveStoryElementVisibility = Visibility.Collapsed;
+            AddToNarrativeVisibility = Visibility.Collapsed;
+            RemoveFromNarrativeVisibility = Visibility.Collapsed;
+            PrintNodeVisibility = Visibility.Collapsed;
+
+            RestoreStoryElementVisibility = Visibility.Visible;
+            EmptyTrashVisibility = Visibility.Visible;
+        }
+        else
+        {
+            //Explorer tree, show everything but empty trash and add section
+            if (SelectedView == ViewList[0])
+            {
+                AddFolderVisibility = Visibility.Visible; 
                 AddSectionVisibility = Visibility.Collapsed;
                 AddProblemVisibility = Visibility.Visible;
                 AddCharacterVisibility = Visibility.Visible;
@@ -2091,40 +2110,28 @@ public class ShellViewModel : ObservableRecipient
                 //TODO: Use correct values (bug with this)
                 //RestoreStoryElementVisibility = Visibility.Collapsed;
                 RestoreStoryElementVisibility = Visibility.Visible;
-                AddToNarrativeVisibility = Visibility.Visible;
+                AddToNarrativeVisibility = Visibility.Visible; 
                 //RemoveFromNarrativeVisibility = Visibility.Collapsed;
                 RestoreStoryElementVisibility = Visibility.Visible;
                 PrintNodeVisibility = Visibility.Visible;
                 EmptyTrashVisibility = Visibility.Collapsed;
-                break;
-            case StoryItemType.Section:         // NarratorView tree
-                AddFolderVisibility = Visibility.Collapsed;
+            }
+            else //Narrator Tree, hide most things.
+            {
+                RemoveStoryElementVisibility = Visibility.Visible;
+                RemoveFromNarrativeVisibility = Visibility.Visible;
                 AddSectionVisibility = Visibility.Visible;
+                PrintNodeVisibility = Visibility.Visible;
+
+                AddFolderVisibility = Visibility.Collapsed; 
                 AddProblemVisibility = Visibility.Collapsed;
                 AddCharacterVisibility = Visibility.Collapsed;
                 AddSettingVisibility = Visibility.Collapsed;
                 AddSceneVisibility = Visibility.Collapsed;
-                RemoveStoryElementVisibility = Visibility.Visible;
                 RestoreStoryElementVisibility = Visibility.Collapsed;
                 AddToNarrativeVisibility = Visibility.Collapsed;
-                RemoveFromNarrativeVisibility = Visibility.Visible;
-                PrintNodeVisibility = Visibility.Visible;
                 EmptyTrashVisibility = Visibility.Collapsed;
-                break;
-            case StoryItemType.TrashCan:        // Trashcan tree (either view)
-                AddFolderVisibility = Visibility.Collapsed;
-                AddSectionVisibility = Visibility.Collapsed;
-                AddProblemVisibility = Visibility.Collapsed;
-                AddCharacterVisibility = Visibility.Collapsed;
-                AddSettingVisibility = Visibility.Collapsed;
-                AddSceneVisibility = Visibility.Collapsed;
-                RemoveStoryElementVisibility = Visibility.Collapsed;
-                RestoreStoryElementVisibility = Visibility.Visible;
-                AddToNarrativeVisibility = Visibility.Collapsed;
-                RemoveFromNarrativeVisibility = Visibility.Collapsed;
-                PrintNodeVisibility = Visibility.Collapsed;
-                EmptyTrashVisibility = Visibility.Visible;
-                break;
+            }
         }
     }
 
@@ -2143,11 +2150,13 @@ public class ShellViewModel : ObservableRecipient
         if (view == StoryViewType.ExplorerView)
         {
             DataSource = StoryModel.ExplorerView;
+            SelectedView = ViewList[0];
             CurrentViewType = StoryViewType.ExplorerView;
         }
         else if (view == StoryViewType.NarratorView)
         {
             DataSource = StoryModel.NarratorView;
+            SelectedView = ViewList[1];
             CurrentViewType = StoryViewType.NarratorView;
         }
     }


### PR DESCRIPTION
This PR fixes two issues
- Fixes rare occurance where the right click menu may allow nodes that are not section nodes to be added to narrator view (fixes #559)
- Fixes issue where if a story is loaded in narrator view the view is reset to the explorer view but the view combobox is not updated to reflect this.