### PR TITLE
Show warning if synopsis is empty

### DIFF
--- a/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml
@@ -11,7 +11,7 @@
         <StackPanel HorizontalAlignment="Center" Margin="0,15">
             <TextBlock Text="Create reports for the following:"/>
             <CheckBox Content="Story Overview" IsChecked="{x:Bind PrintVM.CreateOverview, Mode=TwoWay}" />
-            <CheckBox Content="Story Synopsis" IsChecked="{x:Bind PrintVM.CreateSummary, Mode=TwoWay}"/>
+            <CheckBox Content="Story Synopsis" IsChecked="{x:Bind PrintVM.CreateSummary, Mode=TwoWay}" Checked="EmptySynopsisWarningCheck"/>
         </StackPanel>
 
         
@@ -52,6 +52,7 @@
                 </StackPanel>
             </PivotItem>
         </Pivot>
+        <InfoBar IsOpen="False" Name="SynopsisWarning" Severity="Warning" Message="No scenes have been added to Narrative view, your synopsis will be empty." Height="auto"/>
         <ProgressBar Width="300" IsIndeterminate="True" Opacity="0" Margin="5" Name="LoadingBar"/>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
             <Button Content="Generate" Margin="10,5,0,0" Click="StartPrintMenu"/>

--- a/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml.cs
@@ -8,6 +8,7 @@ using StoryCAD.ViewModels;
 using StoryCAD.ViewModels.Tools;
 using Windows.Graphics.Printing;
 using Microsoft.UI.Dispatching;
+using CommunityToolkit.WinUI.UI.Controls;
 
 namespace StoryCAD.Services.Dialogs.Tools;
 public sealed partial class PrintReportsDialog
@@ -163,6 +164,20 @@ public sealed partial class PrintReportsDialog
             PrintVM.ShowLoadingBar = false;
             PrintVM.CloseDialog();
             Ioc.Default.GetRequiredService<ShellViewModel>().ShowMessage(LogLevel.Info, "Generate Print Reports complete", true);
+        }
+    }
+
+    /// <summary>
+    /// This will show the user a warning if synopsis is checked but
+    /// narrative view, which is used to build a synopsis, is empty.
+    /// </summary>
+    private void EmptySynopsisWarningCheck(object sender, RoutedEventArgs e)
+    {
+        //Check Narrative View is empty
+        if (ShellViewModel.GetModel().NarratorView[0].Children.Count == 0)
+        {
+            //Show warning
+            SynopsisWarning.IsOpen = true;
         }
     }
 }

--- a/StoryCADLib/Services/Reports/ReportFormatter.cs
+++ b/StoryCADLib/Services/Reports/ReportFormatter.cs
@@ -9,6 +9,7 @@ using StoryCAD.DAL;
 using StoryCAD.Models;
 using StoryCAD.Services.Logging;
 using StoryCAD.ViewModels;
+using static System.Formats.Asn1.AsnWriter;
 
 namespace StoryCAD.Services.Reports;
 
@@ -650,6 +651,12 @@ public class ReportFormatter
                     doc.AddText(sb.ToString());
                     doc.AddNewLine();
                     doc.AddText(scene.Remarks);
+                    doc.AddNewLine();
+                }
+
+                if (_model.NarratorView[0].Children.Count == 0)
+                {
+                    doc.AddText("You currently have no scenes within your narrative view, add some to see them here.");
                     doc.AddNewLine();
                 }
             }


### PR DESCRIPTION
This PR fixes #547 it adds a warning to the print dialog if synopsis is selected for printing but no nodes are inside the narrative view.
![image](https://github.com/storybuilder-org/StoryCAD/assets/49795711/daa135da-5389-4f17-9bf8-a38adc43a4ae)

if the synopsis is printed anyway it will now look like the following:
![image](https://github.com/storybuilder-org/StoryCAD/assets/49795711/07dc91e9-2662-49a5-819a-f5eae37319c6)
