### PR TITLE
Standardize XAML for Problem Protagonist and Antagonist conflict properties

### DIFF
--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23147" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23150" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCAD/Views/ProblemPage.xaml
+++ b/StoryCAD/Views/ProblemPage.xaml
@@ -74,8 +74,10 @@
                                     Text="{x:Bind ProblemVm.ProtMotive, Mode=TwoWay}" />
                     <Button  Content="Conflict Builder" Grid.Row="3" HorizontalAlignment="Left" Margin="0,10,10,10" 
                              Command="{x:Bind ProblemVm.ConflictCommand, Mode=OneWay}" />
-                    <usercontrols:RichEditBoxExtended Header="Conflict" Grid.Row="4" MinWidth="300" TextWrapping="Wrap" AcceptsReturn="True" VerticalAlignment="Stretch"
-                                                      RtfText="{x:Bind ProblemVm.ProtConflict, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <usercontrols:RichEditBoxExtended Header="Conflict" Grid.Row="4"  
+                                                      RtfText="{x:Bind ProblemVm.ProtConflict, Mode=TwoWay}" AcceptsReturn="True"
+                                                      IsSpellCheckEnabled="True" TextWrapping="Wrap" 
+                                                      ScrollViewer.VerticalScrollBarVisibility="Visible" />
                 </Grid>
             </PivotItem>
             <PivotItem Header="Antagonist">
@@ -98,8 +100,10 @@
                               Text="{x:Bind ProblemVm.AntagMotive, Mode=TwoWay}" />
                     <Button  Content="Conflict Builder" Grid.Row="3" HorizontalAlignment="Left" Margin="0,10,10,10" 
                              Command="{x:Bind ProblemVm.ConflictCommand, Mode=OneWay}" />
-                    <usercontrols:RichEditBoxExtended Header="Conflict" Grid.Row="4" MinWidth="300" TextWrapping="Wrap" AcceptsReturn="True" VerticalAlignment="Stretch"
-                                                      RtfText="{x:Bind ProblemVm.AntagConflict, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <usercontrols:RichEditBoxExtended Header="Conflict" Grid.Row="4"  
+                                                      RtfText="{x:Bind ProblemVm.AntagConflict, Mode=TwoWay}" AcceptsReturn="True"
+                                                      IsSpellCheckEnabled="True" TextWrapping="Wrap" 
+                                                      ScrollViewer.VerticalScrollBarVisibility="Visible" />
                 </Grid>
             </PivotItem>
             <PivotItem Header="Resolution">

--- a/StoryCADLib/ViewModels/CharacterViewModel.cs
+++ b/StoryCADLib/ViewModels/CharacterViewModel.cs
@@ -532,6 +532,7 @@ public class CharacterViewModel : ObservableRecipient, INavigable
         if (_changeable)
         {
             _changed = true;
+            _logger.Log(LogLevel.Info, $"CharacterViewModel.OnPropertyChanged: {args.PropertyName} changed");
             ShellViewModel.ShowChange();
         }
     }

--- a/StoryCADLib/ViewModels/FolderViewModel.cs
+++ b/StoryCADLib/ViewModels/FolderViewModel.cs
@@ -99,6 +99,7 @@ public class FolderViewModel : ObservableRecipient, INavigable
         if (_changeable)
         {
             _changed = true;
+            _logger.Log(LogLevel.Info, $"FolderViewModel.OnPropertyChanged: {args.PropertyName} changed"); 
             ShellViewModel.ShowChange();
         }
     }

--- a/StoryCADLib/ViewModels/OverviewViewModel.cs
+++ b/StoryCADLib/ViewModels/OverviewViewModel.cs
@@ -252,6 +252,7 @@ public class OverviewViewModel : ObservableRecipient, INavigable
         if (_changeable)
         {
             _changed = true;
+            _logger.Log(LogLevel.Info, $"OverviewViewModel.OnPropertyChanged: {args.PropertyName} changed");
             ShellViewModel.ShowChange();
         }
     }

--- a/StoryCADLib/ViewModels/ProblemViewModel.cs
+++ b/StoryCADLib/ViewModels/ProblemViewModel.cs
@@ -244,6 +244,7 @@ public class ProblemViewModel : ObservableRecipient, INavigable
         if (_changeable)
         {
             _changed = true;
+            _logger.Log(LogLevel.Info, $"ProblemViewModel.OnPropertyChanged: {args.PropertyName} changed");
             ShellViewModel.ShowChange();
         }
     }

--- a/StoryCADLib/ViewModels/SceneViewModel.cs
+++ b/StoryCADLib/ViewModels/SceneViewModel.cs
@@ -339,6 +339,7 @@ public class SceneViewModel : ObservableRecipient, INavigable
         if (_changeable)
         {
             _changed = true;
+            _logger.Log(LogLevel.Info, $"SceneViewModel.OnPropertyChanged: {args.PropertyName} changed");
             ShellViewModel.ShowChange();
         }
     }

--- a/StoryCADLib/ViewModels/SettingViewModel.cs
+++ b/StoryCADLib/ViewModels/SettingViewModel.cs
@@ -183,6 +183,7 @@ public class SettingViewModel : ObservableRecipient, INavigable
         if (_changeable)
         {
             _changed = true;
+            _logger.Log(LogLevel.Info, $"SettingViewModel.OnPropertyChanged: {args.PropertyName} changed");
             ShellViewModel.ShowChange();
         }
     }

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -660,7 +660,7 @@ public class ShellViewModel : ObservableRecipient
     {
         if (SplitViewFrame.CurrentSourcePageType is null) { return; }
 
-        Logger.Log(LogLevel.Trace, $"WritePreferences- Page type={SplitViewFrame.CurrentSourcePageType}");
+        Logger.Log(LogLevel.Trace, $"SaveModel Page type={SplitViewFrame.CurrentSourcePageType}");
 
         switch (SplitViewFrame.CurrentSourcePageType.ToString())
         {


### PR DESCRIPTION
Standardize RichEditBox XAML for Problem Page conflict properties
Correct logging for SaveModel, SaveFile
Add logging to OnPropertyChanged events in viewmodels, to track which property is changed and when