### PR TITLE
Fix an issue within root node type crash

### DIFF
--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23157" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23170" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>


### PR DESCRIPTION
This PR fixes a possible crash with RootNodeType,
this is fixed through by try catching the function and logging the error to further understand the error.
            catch (Exception ex)
            {
                //return overview node to prevent a possible crash.
                Ioc.Default.GetRequiredService<LogService>().LogException(LogLevel.Warn, ex,
                    "Exception within RootNodeType, substituting for an overview node)");
                return StoryItemType.StoryOverview;
            }
