### PR TITLE
Fix possible DND crash

### DIFF
--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23157" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23180" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCAD/Views/Shell.xaml.cs
+++ b/StoryCAD/Views/Shell.xaml.cs
@@ -224,12 +224,27 @@ public sealed partial class Shell
             ShellVm.ShowMessage(LogLevel.Warn, "Invalid drag target", false);
             return;
         }
+
+        if (args.Data == null)
+        {
+            ShellVm.ShowMessage(LogLevel.Info, "Drag and drop failed", true);
+            Logger.Log(LogLevel.Error, "Failed to drag n drop - arg.data is null (may be a file and not a story element)");
+            return;
+        }
+
         // Move is valid, allow the drop operation.  
         args.Data.RequestedOperation = DataPackageOperation.Move;
     }
 
     private void TreeView_OnDragLeave(object sender, DragEventArgs e)
     {
+        if (e.Data == null)
+        {
+            ShellVm.ShowMessage(LogLevel.Info, "Drag and drop failed", true);
+            Logger.Log(LogLevel.Error, "Failed to drag n drop - e.data is null (may be a file and not a story element)");
+            return;
+        }
+
         // If the drag target identified in OnDragOver was valid, 
         // the drag operation is allowed. Indicate a change too place
         // and report it. 


### PR DESCRIPTION
This PR fixes #593, which occurs when a non storycad object is dragged over the the tree.