### PR TITLE
Fix MasterPlots

### DIFF
--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.10.0.23180" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.11.0.23192" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -1195,10 +1195,9 @@ public class ShellViewModel : ObservableRecipient
                     ShowChange();
                     Logger.Log(LogLevel.Info, "MasterPlot complete");
                 }
-                _canExecuteCommands = true;
             }
         }
-
+        _canExecuteCommands = true;
     }
 
     private async void DramaticSituationsTool()


### PR DESCRIPTION
This PR fixes #597 by moving the placement of _CanExecuteCommands = true to run no matter what when the function exits
(This PR also bumps the app manifest version to 2.11.x.x to reflect the released version app).