### PR TITLE
Fix deletion of outer traits nodes

### DIFF
--- a/StoryCAD/Views/CharacterPage.xaml
+++ b/StoryCAD/Views/CharacterPage.xaml
@@ -288,7 +288,7 @@
                     <!-- Character traits -->
                     <ListView Header="Traits" Grid.Row="1" MinWidth="300" MinHeight="150" 
                             ItemsSource="{x:Bind CharVm.CharacterTraits, Mode=TwoWay}"
-                            SelectedIndex="{x:Bind CharVm.ExistingTraitIndex, Mode=OneWay}" />
+                            SelectedIndex="{x:Bind CharVm.ExistingTraitIndex, Mode=TwoWay}" />
                     <Grid Grid.Row="2" HorizontalAlignment="Left">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="2*"/>


### PR DESCRIPTION
This PR fixes #591 where the top most node was getting deleted instead of the selected node.
The code was already there however it appears that by setting the selected index to be two way instead of one way as it was originally, the nodes now delete correctly