### PR TITLE
Stop creation of blank traits

### DIFF
--- a/StoryCAD/Views/CharacterPage.xaml
+++ b/StoryCAD/Views/CharacterPage.xaml
@@ -288,7 +288,7 @@
                     <!-- Character traits -->
                     <ListView Header="Traits" Grid.Row="1" MinWidth="300" MinHeight="150" 
                             ItemsSource="{x:Bind CharVm.CharacterTraits, Mode=TwoWay}"
-                            SelectedIndex="{x:Bind CharVm.ExistingTraitIndex, Mode=OneWay}" />
+                            SelectedIndex="{x:Bind CharVm.ExistingTraitIndex, Mode=TwoWay}" />
                     <Grid Grid.Row="2" HorizontalAlignment="Left">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="2*"/>

--- a/StoryCADLib/ViewModels/CharacterViewModel.cs
+++ b/StoryCADLib/ViewModels/CharacterViewModel.cs
@@ -677,9 +677,16 @@ public class CharacterViewModel : ObservableRecipient, INavigable
 
     private void AddTrait()
     {
-        string _trait = "(Other) " + NewTrait;
-        CharacterTraits.Add(_trait);
-        NewTrait = string.Empty;
+        if (!string.IsNullOrEmpty(NewTrait))
+        {
+            string _trait = "(Other) " + NewTrait;
+            CharacterTraits.Add(_trait);
+            NewTrait = string.Empty;
+        }
+        else
+        {
+            Messenger.Send(new StatusChangedMessage(new("You can't add an empty trait!", LogLevel.Warn)));
+        }
     }
         
     private void RemoveTrait() 


### PR DESCRIPTION
This PR stops the user from adding new traits if the New Trait box is empty. (fixes #590 