### PR TITLE
make changes to PrintVM to fix two crashes

### DIFF
--- a/StoryCADLib/ViewModels/Tools/PrintReportDialogVM.cs
+++ b/StoryCADLib/ViewModels/Tools/PrintReportDialogVM.cs
@@ -11,7 +11,8 @@ using Microsoft.UI.Xaml.Printing;
 using StoryCAD.Models;
 using StoryCAD.Services.Reports;
 using Windows.Graphics.Printing;
-using Microsoft.UI.Dispatching;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using StoryCAD.Services.Logging;
 
 namespace StoryCAD.ViewModels.Tools;
 
@@ -308,7 +309,7 @@ public class PrintReportDialogVM : ObservableRecipient
 
     private void AddPages(object sender, AddPagesEventArgs e)
     {
-        //Treat each page break as
+        //Treat each page break as a new page
         foreach (StackPanel page in _printPreviewCache) { Document.AddPage(page); }
 
         //All text has been handled, so we mark add pages as complete.
@@ -324,8 +325,15 @@ public class PrintReportDialogVM : ObservableRecipient
     /// </summary>
     private void PrintTaskRequested(PrintManager sender, PrintTaskRequestedEventArgs args)
     {
-        PrintJobManager = args.Request.CreatePrintTask("StoryCAD - " + ShellViewModel.GetModel().ProjectFilename, PrintSourceRequested);
-        PrintJobManager.Completed += PrintTaskCompleted; //Show message if job failed.
+        try
+        {
+            PrintJobManager = args.Request.CreatePrintTask("StoryCAD - " + ShellViewModel.GetModel().ProjectFilename, PrintSourceRequested);
+            PrintJobManager.Completed += PrintTaskCompleted; //Show message if job failed.
+        }
+        catch (Exception e)
+        {
+            Ioc.Default.GetService<LogService>().LogException(LogLevel.Error, e, "Error trying to print report");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
This PR fixes 2 Crashes
 - fixes a crash that can occur when a user accidentally prints a report on windows 11 that has no nodes selected, windows 10 versions previously just created a blank page. Now the user is prevented from printing a blank report
 - fixes a crash that could occur if the user somehow manages to click generate twice.

The latter can occur easily on laptops with tap to click as I found it by accidentally tapping my trackpad twice.