### PR TITLE
Enable new printing manager for builds 19045 and higher

### DIFF
--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.11.0.23194" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.11.0.23199" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml
@@ -7,7 +7,7 @@
     mc:Ignorable="d">
 
     <StackPanel HorizontalAlignment="Center">
-        <InfoBar IsOpen="False" Name="Win10Warning" Severity="Warning" Message="You are using Windows 10, please upgrade to Windows 11 for a better printing experience."/>
+        <InfoBar IsOpen="False" Name="OldW10Warning" Severity="Warning" Message="You are using an outdated version of Windows 10, please upgrade to Windows 10 22H2 or Windows 11 for a better printing experience."/>
         <StackPanel HorizontalAlignment="Center" Margin="0,15">
             <TextBlock Text="Create reports for the following:"/>
             <CheckBox Content="Story Overview" IsChecked="{x:Bind PrintVM.CreateOverview, Mode=TwoWay}" />

--- a/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml.cs
@@ -7,8 +7,6 @@ using StoryCAD.Services.Logging;
 using StoryCAD.ViewModels;
 using StoryCAD.ViewModels.Tools;
 using Windows.Graphics.Printing;
-using Microsoft.UI.Dispatching;
-using CommunityToolkit.WinUI.UI.Controls;
 
 namespace StoryCAD.Services.Dialogs.Tools;
 public sealed partial class PrintReportsDialog
@@ -39,7 +37,7 @@ public sealed partial class PrintReportsDialog
         PrintVM.WebList = false;
 
         //Warn user if they are on win10 as print manager can't be used.
-        if (Environment.OSVersion.Version.Build <= 22000) { Win10Warning.IsOpen = true; }
+        if (Environment.OSVersion.Version.Build <= 19045) { OldW10Warning.IsOpen = true; }
 
         //Gets all nodes that aren't deleted
         try
@@ -120,13 +118,13 @@ public sealed partial class PrintReportsDialog
         PrintVM.GeneratePrintDocumentReport();
         PrintVM.PrintDocSource = PrintVM.Document.DocumentSource;
 
-        //Device has to support printing AND run windows 11 (Win11's RTM Build was build 22000 and Win10 Build will ever be above 22000)
-        //Windows 10 currently does not support PrintManagers due to a bug in windows 10, however this should get fixed soon (hopefully)
-        if (PrintManager.IsSupported() && Environment.OSVersion.Version.Build >= 22000) 
+        //Device has to support printing AND run a build of Windows above 19045 (W10 22h2)
+        //Windows 10 builds below 19045 have bug that prevent us from using the new print manager
+        //TODO: gut old print stuff after oct 2023 since only 22h2 will be offically supported.
+        if (PrintManager.IsSupported() && Environment.OSVersion.Version.Build >= 19045) 
         {
             try
-            {
-                // Show print UI
+            {   // Show print UI
                 await PrintManagerInterop.ShowPrintUIForWindowAsync(GlobalData.WindowHandle);
             }
             catch (Exception ex) //Error setting up printer


### PR DESCRIPTION
This PR enables the new printing UI that was previously enabled for only windows 11 for windows 10 versions that are 22h2 and higher (spesifically build 19045) as build 19045 appears to not crash when trying to access the print manager UI.

The text shown to user has also been updated to reflect these changes if they don't meet these requirements
![image](https://github.com/storybuilder-org/StoryCAD/assets/49795711/870ebcb2-410f-4f0f-867c-e5422b1506b2)

We may remove the older printing stuff at a later date to reduce code complexity i.e when all other versions except 22h2 are out of support or at some later date.