### PR TITLE
Hide changelog for dev builds

### DIFF
--- a/StoryCADLib/Services/Dialogs/Changelog.cs
+++ b/StoryCADLib/Services/Dialogs/Changelog.cs
@@ -54,6 +54,9 @@ namespace StoryCAD.Services.Dialogs
 
         public async Task ShowChangeLog()
         {
+            //Don't Show changelog on dev build's since its pointless.
+            if (GlobalData.DeveloperBuild) { return; }
+
             try
             {
                 ContentDialog _changelogUI = new()


### PR DESCRIPTION
This PR disables the changelog update content dialog for dev builds because it will always a fail to obtain changelog text for developer builds since it doesnt exist.