### PR TITLE
Fix title not tracking right

### DIFF
--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.11.0.23194" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.11.0.23202" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -781,7 +781,7 @@ public class ShellViewModel : ObservableRecipient
                 Messenger.Send(new StatusChangedMessage(new("Open Story completed", LogLevel.Info)));
             }
 
-            GlobalData.MainWindow.Title = $"StoryCAD - Editing {StoryModel.ProjectFilename.Replace(".stbx", "")}";
+            UpdateWindowTitle();
             new UnifiedVM().UpdateRecents(Path.Combine(StoryModel.ProjectFolder.Path, StoryModel.ProjectFile.Name));
 
             if (GlobalData.Preferences.TimedBackup)


### PR DESCRIPTION
This PR fixes an issue where the StoryCAD title wouldn't always track properly in cases where the stories were changed under some circumstances