### PR TITLE
Cleanup

### DIFF
--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.11.0.23194" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.11.0.23202" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -1305,33 +1305,6 @@ public class ShellViewModel : ObservableRecipient
         }
     }
 
-    private async void GeneratePrintReports()
-    {
-        PrintReportDialogVM _reportVM = Ioc.Default.GetRequiredService<PrintReportDialogVM>();
-        if (_canExecuteCommands)
-        {
-            if (Ioc.Default.GetRequiredService<ShellViewModel>().DataSource == null)
-            {
-                Messenger.Send(new StatusChangedMessage(new("You need to load a Story first!", LogLevel.Warn)));
-                return;
-            }
-            _canExecuteCommands = false;
-            Messenger.Send(new StatusChangedMessage(new("Generate Print Reports executing", LogLevel.Info, true)));
-
-            SaveModel();
-
-            // Run reports dialog
-            _reportVM.Dialog = new()
-            {
-                Title = "Generate Reports",
-                XamlRoot = GlobalData.XamlRoot,
-                Content = new PrintReportsDialog()
-            };
-            await _reportVM.Dialog.ShowAsync();
-            _canExecuteCommands = true;
-
-        }
-    }
 
     private async void GenerateScrivenerReports()
     {
@@ -1375,12 +1348,10 @@ public class ShellViewModel : ObservableRecipient
         _canExecuteCommands = false;
         Messenger.Send(new StatusChangedMessage(new("Launching GitHub Pages User Manual", LogLevel.Info, true)));
 
-        ProcessStartInfo _psi = new()
-        {
+        Process.Start(new ProcessStartInfo(){
             FileName = @"https://Storybuilder-org.github.io/StoryCAD/",
             UseShellExecute = true
-        };
-        Process.Start(_psi);
+        });
 
         Messenger.Send(new StatusChangedMessage(new("Launch default browser completed", LogLevel.Info, true)));
 
@@ -1394,12 +1365,11 @@ public class ShellViewModel : ObservableRecipient
     /// <param name="nodeRequired">A node (right-clicked or clicked) must be present</param>
     /// <param name="checkOutlineIsOpen">A checks an outline is open (defaults to true)</param>
     /// <returns>true if prerequisites are met</returns>
-    private bool VerifyToolUse(bool explorerViewOnly, bool nodeRequired, bool checkOutlineIsOpen = true)
+    public bool VerifyToolUse(bool explorerViewOnly, bool nodeRequired, bool checkOutlineIsOpen = true)
     {
         try
         {
-
-            if (explorerViewOnly && !IsExplorerView())
+            if (explorerViewOnly && CurrentViewType != StoryViewType.ExplorerView)
             {
                 Messenger.Send(new StatusChangedMessage(new("This tool can only be run in Story Explorer view", LogLevel.Warn)));
                 return false;
@@ -1744,7 +1714,6 @@ public class ShellViewModel : ObservableRecipient
     private void AddFolder()
     {
         TreeViewNodeClicked(AddStoryElement(StoryItemType.Folder));
-
     }
 
     private void AddSection()
@@ -2028,7 +1997,7 @@ public class ShellViewModel : ObservableRecipient
         
         #endregion
 
-        public void ViewChanged()
+    public void ViewChanged()
     {
         if (DataSource == null || DataSource.Count == 0)
         {
@@ -2124,8 +2093,6 @@ public class ShellViewModel : ObservableRecipient
              Logger.Log(LogLevel.Error, "An error occurred inShowFlyouttButtons() - For reference RightTappedNode is " + RightTappedNode);
         }
 
-
-
     }
 
     public void ShowConnectionStatus()
@@ -2175,10 +2142,6 @@ public class ShellViewModel : ObservableRecipient
         //Set window Title.
         GlobalData.MainWindow.Title = BaseTitle;
     }
-
-    private bool IsExplorerView() => CurrentViewType == StoryViewType.ExplorerView;
-    // ReSharper disable once UnusedMember.Local
-    private bool IsNarratorView() => CurrentViewType == StoryViewType.NarratorView;
 
     #region MVVM  processing
     private void IsChangedMessageReceived(IsChangedMessage isDirty)
@@ -2307,7 +2270,7 @@ public class ShellViewModel : ObservableRecipient
         TogglePaneCommand = new RelayCommand(TogglePane, () => _canExecuteCommands);
         OpenUnifiedCommand = new RelayCommand(async () => await OpenUnifiedMenu(), () => _canExecuteCommands);
         CloseUnifiedCommand = new RelayCommand(CloseUnifiedMenu, () => _canExecuteCommands);
-        NarrativeToolCommand = new RelayCommand(async () => await OpenNarrativeTool(), () => _canExecuteCommands);
+        NarrativeToolCommand = new RelayCommand(async () => await Ioc.Default.GetRequiredService<NarrativeToolVM>().OpenNarrativeTool(), () => _canExecuteCommands);
         PrintNodeCommand = new RelayCommand(async () => await PrintCurrentNodeAsync(), () => _canExecuteCommands);
         OpenFileCommand = new RelayCommand(async () => await OpenFile(), () => _canExecuteCommands);
         SaveFileCommand = new RelayCommand(async () => await SaveFile(), () => _canExecuteCommands);
@@ -2324,7 +2287,7 @@ public class ShellViewModel : ObservableRecipient
 
         PreferencesCommand = new RelayCommand(Preferences, () => _canExecuteCommands);
 
-        PrintReportsCommand = new RelayCommand(GeneratePrintReports, () => _canExecuteCommands);
+        PrintReportsCommand = new RelayCommand(Ioc.Default.GetRequiredService<PrintReportDialogVM>().OpenPrintReportDialog, () => _canExecuteCommands);
         ScrivenerReportsCommand = new RelayCommand(GenerateScrivenerReports, () => _canExecuteCommands);
 
         HelpCommand = new RelayCommand(LaunchGitHubPages, () => _canExecuteCommands);
@@ -2360,31 +2323,6 @@ public class ShellViewModel : ObservableRecipient
         ChangeStatusColor = Colors.Green;
 
         ShellInstance = this;
-    }
-
-    private async Task OpenNarrativeTool()
-    {
-        if (VerifyToolUse(false, false) && _canExecuteCommands)
-        {
-            _canExecuteCommands = false;
-            try
-            {
-                ContentDialog _dialog = new()
-                {
-                    XamlRoot = GlobalData.XamlRoot,
-                    Title = "Narrative Editor",
-                    PrimaryButtonText = "Done",
-                    Content = new NarrativeTool()
-                };
-                await _dialog.ShowAsync();
-            }
-            catch (Exception ex)
-            {
-                Logger.LogException(LogLevel.Error, ex, "Error in ShellVM.OpenNarrativeTool()");
-            }
-
-            _canExecuteCommands = true;
-        }
     }
 
     public void SearchNodes()

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -1308,6 +1308,13 @@ public class ShellViewModel : ObservableRecipient
 
     private async void GenerateScrivenerReports()
     {
+        if (DataSource == null || DataSource.Count == 0)
+        {
+            Messenger.Send(new StatusChangedMessage(new("You need to open a story first!", LogLevel.Info)));
+            Logger.Log(LogLevel.Info, $"Scrivener Report cancelled (DataSource was null or empty)");
+            return;
+        }
+
         //TODO: revamp this to be more user friendly.
         _canExecuteCommands = false;
         Messenger.Send(new StatusChangedMessage(new("Generate Scrivener Reports executing", LogLevel.Info, true)));

--- a/StoryCADLib/ViewModels/Tools/NarrativeToolVM.cs
+++ b/StoryCADLib/ViewModels/Tools/NarrativeToolVM.cs
@@ -2,10 +2,13 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Xaml.Controls;
 using StoryCAD.Models;
+using StoryCAD.Services.Dialogs.Tools;
 using StoryCAD.Services.Logging;
 
 namespace StoryCAD.ViewModels.Tools;
@@ -65,6 +68,35 @@ public class NarrativeToolVM: ObservableRecipient
         CopyAllUnusedCommand = new RelayCommand(CopyAllUnused);
         DeleteCommand = new RelayCommand(Delete);
     }
+
+    /// <summary>
+    /// This opens the Narrative Tool Content Dialog.
+    /// </summary>
+    public async Task OpenNarrativeTool()
+    {
+        if (_shellVM.VerifyToolUse(false, false) && _shellVM._canExecuteCommands)
+        {
+            _shellVM._canExecuteCommands = false;
+            try
+            {
+                ContentDialog _dialog = new()
+                {
+                    XamlRoot = GlobalData.XamlRoot,
+                    Title = "Narrative Editor",
+                    PrimaryButtonText = "Done",
+                    Content = new NarrativeTool()
+                };
+                await _dialog.ShowAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogException(LogLevel.Error, ex, "Error in ShellVM.OpenNarrativeTool()");
+            }
+
+            _shellVM._canExecuteCommands = true;
+        }
+    }
+
 
     /// <summary>
     /// Deletes a node from the tree.

--- a/StoryCADLib/ViewModels/Tools/PrintReportDialogVM.cs
+++ b/StoryCADLib/ViewModels/Tools/PrintReportDialogVM.cs
@@ -11,7 +11,10 @@ using Microsoft.UI.Xaml.Printing;
 using StoryCAD.Models;
 using StoryCAD.Services.Reports;
 using Windows.Graphics.Printing;
-using Microsoft.UI.Dispatching;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using StoryCAD.Services.Dialogs.Tools;
+using StoryCAD.Services.Messages;
+using StoryCAD.Services.Logging;
 
 namespace StoryCAD.ViewModels.Tools;
 
@@ -158,6 +161,35 @@ public class PrintReportDialogVM : ObservableRecipient
         set => SetProperty(ref _webNodes, value);
     }
     #endregion
+
+    public async void OpenPrintReportDialog()
+    {
+        ShellViewModel ShellVM = Ioc.Default.GetRequiredService<ShellViewModel>();
+        if (ShellVM._canExecuteCommands)
+        {
+            if (Ioc.Default.GetRequiredService<ShellViewModel>().DataSource == null)
+            {
+                ShellVM.ShowMessage(LogLevel.Warn, "You need to load a Story first!", false);
+                return;
+            }
+            
+            ShellVM._canExecuteCommands = false;
+            ShellVM.ShowMessage(LogLevel.Info, "Generate Print Reports executing",  true);
+
+            ShellVM.SaveModel();
+
+            // Run reports dialog
+            Dialog = new()
+            {
+                Title = "Generate Reports",
+                XamlRoot = GlobalData.XamlRoot,
+                Content = new PrintReportsDialog()
+            };
+            await Dialog.ShowAsync();
+            ShellVM._canExecuteCommands = true;
+
+        }
+    }
 
     /// <summary>
     /// This traverses a node and adds it to the relevant list.


### PR DESCRIPTION
This PR does some slight cleanup on ShellVM by moving some stuff that shouldn't be in ShellVM out of it such as code to open the print report dialog and narrative tool dialog.

This PR also fixes a potential issue with generate scrivener reports by adding a check that the story is loaded first.