### PR TITLE
Build number update

### DIFF
--- a/.github/workflows/AutoBuilder.yml
+++ b/.github/workflows/AutoBuilder.yml
@@ -46,7 +46,7 @@ jobs:
         $VersionRegex = "\d+\.\d+\.\d+\.\d+"
         $LastVer = "${{ steps.testtag.outputs.tag }}"
         $VersionSplit = $LastVer.Split(".")
-        $BUILD_BUILDNUMBER = $VersionSplit[0] + "." + $VersionSplit[1] + ".${{ github.run_number }}.0"
+        $BUILD_BUILDNUMBER = $VersionSplit[0] + "." + $VersionSplit[1] + ".${{ github.run_number }}.65535"
         $ManifestVersionRegex = " Version=""\d+\.\d+\.\d+\.\d+"""
         $ScriptPath = $null
         try
@@ -107,9 +107,9 @@ jobs:
       run: |
         $LastVer = "${{ steps.testtag.outputs.tag }}"
         $VersionSplit = $LastVer.Split(".")
-        $BUILD_BUILDNUMBER = $VersionSplit[0] + "." + $VersionSplit[1] + ".${{ github.run_number }}.0"
+        $BUILD_BUILDNUMBER = $VersionSplit[0] + "." + $VersionSplit[1] + ".${{ github.run_number }}.65535"
       
-        "Hello, Thank you for testing StoryCAD " + $VersionSplit[0] + "." + $VersionSplit[1] + ".${{ github.run_number }}.0" + " Alpha 
+        "Hello, Thank you for testing StoryCAD " + $VersionSplit[0] + "." + $VersionSplit[1] + ".${{ github.run_number }}.65535" + " Alpha 
         1) Open StoryCAD.cer, this should bring up the certificate import wizard
         2) Press install certificate, and change store location to Local Machine, then press next
         3) Change the option to Place All Certificates in the following store and click browse

--- a/StoryCAD/App.xaml.cs
+++ b/StoryCAD/App.xaml.cs
@@ -35,6 +35,8 @@ using Windows.Storage;
   using Microsoft.UI.Dispatching;
   using StoryCAD.Services.Backup;
   using LaunchActivatedEventArgs = Microsoft.UI.Xaml.LaunchActivatedEventArgs;
+using System.Globalization;
+using System.Reflection;
 
   namespace StoryCAD;
 
@@ -65,7 +67,23 @@ public partial class App
         CheckForOtherInstances(); //Check other instances aren't already open.
         
         ConfigureIoc();
-        GlobalData.Version = "Version: " + Package.Current.Id.Version.Major + "." + Package.Current.Id.Version.Minor + "." + Package.Current.Id.Version.Build + "." + Package.Current.Id.Version.Revision;
+        if (Package.Current.Id.Version.Revision == 65535) //Read the StoryCAD.csproj manifest for a build time instead.
+        {
+
+            string StoryCADManifestVersion = System.Reflection.Assembly.GetExecutingAssembly()
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion
+                .Split("build")[1];
+
+            GlobalData.Version = $"Version: {Package.Current.Id.Version.Major}.{Package.Current.Id.Version.Minor}." +
+                $"{Package.Current.Id.Version.Build} Built on: { StoryCADManifestVersion}";
+        }
+        else
+        {
+            GlobalData.Version = $"Version: {Package.Current.Id.Version.Major}.{Package.Current.Id.Version.Minor}" +
+                $".{Package.Current.Id.Version.Build}.{Package.Current.Id.Version.Revision}";
+
+        }
+
         string path = Path.Combine(Package.Current.InstalledLocation.Path, ".env");
         DotEnvOptions options = new(false, new[] { path });
         

--- a/StoryCAD/BuildIncrement.ps1
+++ b/StoryCAD/BuildIncrement.ps1
@@ -12,9 +12,8 @@ if ($env:CI -eq $null) {
 
 	# Get current date in yyddd format
 	$currentDate = Get-Date
-	$dateRevision = [int]($currentDate.ToString("yy") + $currentDate.DayOfYear.ToString("D3"))
 
-	$newVersion = New-Object Version ($currentVersion.Major, $currentVersion.Minor, $currentVersion.Build, $dateRevision)
+	$newVersion = New-Object Version ($currentVersion.Major, $currentVersion.Minor, $currentVersion.Build, "65535")
 	$identityNode.Version = $newVersion.ToString()
 	$manifest.Save('Package.appxmanifest')
 }

--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.11.0.23202" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.11.0.65535" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCAD/StoryCAD.csproj
+++ b/StoryCAD/StoryCAD.csproj
@@ -25,7 +25,9 @@
 		<RunAnalyzersDuringBuild>False</RunAnalyzersDuringBuild>
 		<PackageCertificateKeyFile>StoryCAD_TemporaryKey.pfx</PackageCertificateKeyFile>
 	</PropertyGroup>
-
+	<PropertyGroup>
+		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ss:fffZ"))</SourceRevisionId>
+	</PropertyGroup>
 	<ItemGroup>
 		<Content Include="Assets\SplashScreen.scale-200.png" />
 		<Content Include="Assets\Square150x150Logo.scale-200.png" />


### PR DESCRIPTION
This PR updates the StoryCAD Versioning system slightly to be more informative and prevent almost garanteeed merge confllicts on the appx manifest.


Just for a refresher this is how the versioning system works
Major - 2 (this will probably never change.)
Minor  - 12 (this is increases every official release)
Build - 0 (On release builds this indicates a point fix and will usually be 0 or if a point fix has been released a 1, development builds made by auto build will have the run number here.)
Revision - 65535 ( this is only used on development builds as the MS store rejects builds that have revisions other than 0)

what has changed here is that if the revision is 65535 storycad will subsitute that number for the exact build time to nearist 10ms.