### PR TITLE
update manual to hide links to the front page image.

### DIFF
--- a/docs/Front_Matter.md
+++ b/docs/Front_Matter.md
@@ -4,4 +4,4 @@
 [Legal Matters](Legal_Matters.md) <br/><br/>
 [Getting Help](Getting_Help.md) <br/><br/>
  <br/><br/>
-[Next up - Front Page (Image)](Front_Page_(Image).md)
+[Next up - Preface](Preface.md)

--- a/docs/Preface.md
+++ b/docs/Preface.md
@@ -13,5 +13,5 @@ StoryCAD frees your creativity and makes it fun. Mistakes in a StoryCAD outline 
 
 We hope you enjoy StoryCAD and find it useful to your craft.  <br/>
  <br/><br/>
-[Previous - Front Page (Image)](Front_Page_(Image).md) <br/><br/>
+[Previous - Front matter](Front_Matter.md) <br/><br/>
 [Next up - Legal Matters](Legal_Matters.md)


### PR DESCRIPTION
this pr simply updates the manual to hide links to the front page in the manual as its just an image.
fixes #613