### PR TITLE
Fix some bugs with file creation

### DIFF
--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -370,7 +370,6 @@ public class ShellViewModel : ObservableRecipient
     public async Task UnifiedNewFile(UnifiedVM dialogVM)
     {
         Logger.Log(LogLevel.Info, "FileOpenVM - New File starting");
-
         _canExecuteCommands = false;
 
         try
@@ -384,9 +383,9 @@ public class ShellViewModel : ObservableRecipient
                 await WriteModel();
             }
 
-            // Start with a blank StoryModel and populate it
-            // using the new project dialog's settings
+            // Start with a blank StoryModel and populate it using the new project dialog's 
             ResetModel();
+            ShowHomePage();
 
             if (!Path.GetExtension(dialogVM.ProjectName)!.Equals(".stbx")) { dialogVM.ProjectName += ".stbx"; }
             StoryModel.ProjectFilename = dialogVM.ProjectName;
@@ -531,7 +530,10 @@ public class ShellViewModel : ObservableRecipient
             if (GlobalData.Preferences.AutoSave)
             {
                 Ioc.Default.GetRequiredService<AutoSaveService>().StartAutoSave();
-            }   
+            }
+
+            TreeViewNodeClicked(StoryModel.ExplorerView[0]);
+            UpdateWindowTitle();
 
             Messenger.Send(new StatusChangedMessage(new("New project command completed", LogLevel.Info, true)));
         }


### PR DESCRIPTION
This PR tweaks file creation code to fix the following two issues:
- If a story is opened and another one is created some files from the old story could persist. (fixes #617)
- The title does not update in the above scenario.
This PR fixes these issues.