### PR TITLE
If switching to a new scene and CastSource is assigned the same value…

### DIFF
--- a/StoryCADLib/ViewModels/SceneViewModel.cs
+++ b/StoryCADLib/ViewModels/SceneViewModel.cs
@@ -425,6 +425,7 @@ public class SceneViewModel : ObservableRecipient, INavigable
 
     private void InitializeCharacterList()
     {
+        CastSource = null;    // Insure CastList setter invokes OnPropertyChanged   
         if (AllCharacters)    //Display all characters from the StoryModel's character list
         {
             CastSource = CharacterList;


### PR DESCRIPTION
If CastSource (either AllCharacters or CastList) is the same as it was from the previous scene, SetProperty's EqualityComparer will return false and OnPropertyChanged will not be called. This results in the UI not being updated. InitializeCharcterList was updated to set CastSource to null at its start, so that OnPropertyChanged (and the UI update) take place.