### PR TITLE
Fix nonworking tests

### DIFF
--- a/StoryCADTests/ControlLoaderTests.cs
+++ b/StoryCADTests/ControlLoaderTests.cs
@@ -16,7 +16,7 @@ namespace StoryCADTests
         [TestMethod]
         public void TestConflictTypes()
         {
-            Assert.AreEqual(6, GlobalData.ConflictTypes.Keys.Count);
+            Assert.AreEqual(8, GlobalData.ConflictTypes.Keys.Count);
             Assert.AreEqual(65, GlobalData.RelationTypes.Count);
         }
     }

--- a/StoryCADTests/ListLoaderTests.cs
+++ b/StoryCADTests/ListLoaderTests.cs
@@ -20,7 +20,7 @@ namespace StoryCADTests
         [TestMethod]
         public void TestListLoaderLists()
         {
-            Assert.AreEqual(65,lists.Count);
+            Assert.AreEqual(66,lists.Count);
             // OverViewModel lists
             Assert.IsTrue(lists.ContainsKey("StoryType"));
             Assert.IsTrue(lists.ContainsKey("Voice"));


### PR DESCRIPTION
This PR fixes tests that are not currently working.
All tests should now work within VS2022's run tests (test explorer?) menu.
