### PR TITLE
Split name pref into a first and last name box

### DIFF
--- a/StoryCAD/Views/PreferencesInitialization.xaml
+++ b/StoryCAD/Views/PreferencesInitialization.xaml
@@ -25,7 +25,8 @@
 
                 <StackPanel Grid.Row="1" VerticalAlignment="Stretch">
                     <Border Height="50"/>
-                    <TextBox PlaceholderText="What's your name?" Margin="15" VerticalAlignment="Center" Text="{x:Bind _initVM.Preferences.Name, Mode=TwoWay}"/>
+                    <TextBox PlaceholderText="What's your first name?" Margin="15" VerticalAlignment="Center" Text="{x:Bind _initVM.Preferences.FirstName, Mode=TwoWay}"/>
+                    <TextBox PlaceholderText="What's your surname?" Margin="15" VerticalAlignment="Center" Text="{x:Bind _initVM.Preferences.LastName, Mode=TwoWay}"/>
                     <TextBox PlaceholderText="What's your email address?" IsSpellCheckEnabled="False"  Margin="15" VerticalAlignment="Center"  Text="{x:Bind _initVM.Preferences.Email, Mode=TwoWay}"/>
                     <StackPanel Orientation="Horizontal">
                         <TextBox IsReadOnly="True" PlaceholderText="Select a folder to hold your story outlines." Name="ProjPath" Margin="15" VerticalAlignment="Center" Width="435" HorizontalAlignment="Left" 

--- a/StoryCAD/Views/PreferencesInitialization.xaml.cs
+++ b/StoryCAD/Views/PreferencesInitialization.xaml.cs
@@ -97,9 +97,14 @@ public sealed partial class PreferencesInitialization
     /// </summary>
     public void Check(object sender, RoutedEventArgs e)
     {
-        if (string.IsNullOrWhiteSpace(_initVM.Preferences.Name))
+        if (string.IsNullOrWhiteSpace(_initVM.Preferences.FirstName))
         {
-            _initVM.ErrorMessage = "Please enter your Name";
+            _initVM.ErrorMessage = "Please enter your first name";
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(_initVM.Preferences.LastName))
+        {
+            _initVM.ErrorMessage = "Please enter your last name";
             return;
         }
         if (string.IsNullOrWhiteSpace(_initVM.Preferences.Email))

--- a/StoryCADLib/DAL/PreferencesIO.cs
+++ b/StoryCADLib/DAL/PreferencesIO.cs
@@ -56,10 +56,27 @@ public class PreferencesIo
                 string[] _tokens = _line.Split(new[] { '=' });
                 switch (_tokens[0])
                 {
+                    //TODO: Remove this case after March 2024.
+                    //This case can only ever execute on PRF files created pre-2.13
                     case "Name":
-                        _model.Name = _tokens[1];
+                        string[] names = _tokens[1].Split(" ");
+                        if (names.Length == 2)
+                        {
+                            _model.FirstName = names[0];
+                            _model.LastName = names[1];
+                        }
+                        else
+                        {
+                            _model.FirstName = _tokens[1];
+                            _model.LastName = "";
+                        }
                         break;
-
+                    case "FirstName":
+                        _model.FirstName = _tokens[1];
+                        break;
+                    case "LastName":
+                        _model.LastName = _tokens[1];
+                        break;
                     case "Email":
                         _model.Email = _tokens[1];
                         break;
@@ -187,7 +204,8 @@ public class PreferencesIo
         StorageFile _preferencesFile = await _preferencesFolder.CreateFileAsync("StoryCAD.prf", CreationCollisionOption.ReplaceExisting);
 
         string _newPreferences = $"""
-            Name={_model.Name}
+            FirstName={_model.FirstName}
+            LastName={_model.LastName}
             Email={_model.Email}
             ErrorCollectionConsent={_model.ErrorCollectionConsent}
             Newsletter={_model.Newsletter}

--- a/StoryCADLib/Models/AppState.cs
+++ b/StoryCADLib/Models/AppState.cs
@@ -148,7 +148,7 @@ public class AppState
                      Core Count - {Environment.ProcessorCount}
 
                      === User Prefs ===
-                     Name - {Preferences.Name}
+                     Name - {Preferences.FirstName}  {Preferences.LastName}
                      Email - {Preferences.Email}
                      Elmah Consent - {Preferences.ErrorCollectionConsent}
                      Theme - {Preferences.PrimaryColor.Color.ToHex()}

--- a/StoryCADLib/Models/Tools/PreferencesModel.cs
+++ b/StoryCADLib/Models/Tools/PreferencesModel.cs
@@ -26,7 +26,8 @@ public class PreferencesModel : ObservableObject
     #region Properties
 
     //User information
-    public string Name { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
     public string Email { get; set; }
     public bool ErrorCollectionConsent { get; set; }
     public bool Newsletter { get; set; }
@@ -91,7 +92,8 @@ public class PreferencesModel : ObservableObject
     #region Constructor
     public PreferencesModel()
     {
-        Name = string.Empty;
+        FirstName = string.Empty;
+        LastName = string.Empty;
         Email = string.Empty;
         ErrorCollectionConsent = false;
         Newsletter = false;

--- a/StoryCADLib/Services/Backend/BackendService.cs
+++ b/StoryCADLib/Services/Backend/BackendService.cs
@@ -112,7 +112,7 @@ namespace StoryCAD.Services.Backend
             {
                 await conn.OpenAsync();
 
-                string name = preferences.Name;
+                string name = preferences.FirstName + " " + preferences.LastName;
                 string email = preferences.Email;
                 int id = await sql.AddOrUpdateUser(conn, name, email);
                 log.Log(LogLevel.Info, "Name: " + name + " userId: " + id);
@@ -158,7 +158,7 @@ namespace StoryCAD.Services.Backend
             {
                 await conn.OpenAsync();
 
-                string name = preferences.Name;
+                string name = preferences.FirstName + " " + preferences.LastName;
                 string email = preferences.Email;
                 int id = await sql.AddOrUpdateUser(conn, name, email);
                 log.Log(LogLevel.Info, "User Name: " + name + " userId: " + id);

--- a/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
@@ -3,11 +3,12 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <StackPanel Width="500" Height="350">
-        <Pivot Name="PivotView" Height="315" Width="500" VerticalAlignment="Stretch">
+    <StackPanel Width="500" Height="400">
+        <Pivot Name="PivotView" Height="355" Width="500" VerticalAlignment="Stretch">
             <PivotItem Header="General" VerticalContentAlignment="Stretch" VerticalAlignment="Center">
                 <StackPanel>
-                    <TextBox Header="Your name:" PlaceholderText="Put the name want to publish under here" HorizontalAlignment="Center" Margin="8" Width="300" Text="{x:Bind PreferencesVm.Name, Mode=TwoWay}"/>
+                    <TextBox Header="Your first name:" PlaceholderText="Put the first name want to publish under here" HorizontalAlignment="Center" Margin="8" Width="300" Text="{x:Bind PreferencesVm.FirstName, Mode=TwoWay}"/>
+                    <TextBox Header="Your surname:" PlaceholderText="Put the surname want to publish under here" HorizontalAlignment="Center" Margin="8" Width="300" Text="{x:Bind PreferencesVm.LastName, Mode=TwoWay}"/>
                     <TextBox Header="Your email:" PlaceholderText="Put your email here" Margin="8" Width="300" Text="{x:Bind PreferencesVm.Email, Mode=TwoWay}"/>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                         <TextBox IsReadOnly="True" Name="ProjDirBox" Header="Project directory:" PlaceholderText="Where do you want to store your stories?" Margin="8" Width="300" VerticalAlignment="Center" Text="{x:Bind PreferencesVm.ProjectDirectory, Mode=OneWay}"/>

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -399,7 +399,7 @@ public class ShellViewModel : ObservableRecipient
             StoryModel.ProjectPath = StoryModel.ProjectFolder.Path;
 
             OverviewModel _overview = new(Path.GetFileNameWithoutExtension(dialogVM.ProjectName), StoryModel)
-            { DateCreated = DateTime.Today.ToString("yyyy-MM-dd"), Author = State.Preferences.Name };
+            { DateCreated = DateTime.Today.ToString("yyyy-MM-dd"), Author = State.Preferences.FirstName + " " + State.Preferences.LastName };
 
             StoryNodeItem _overviewNode = new(_overview, null) { IsExpanded = true, IsRoot = true };
             StoryModel.ExplorerView.Add(_overviewNode);

--- a/StoryCADLib/ViewModels/Tools/PreferencesViewModel.cs
+++ b/StoryCADLib/ViewModels/Tools/PreferencesViewModel.cs
@@ -42,13 +42,22 @@ public class PreferencesViewModel : ObservableValidator
     
     //User information tab
 
-    private string _name;
-    [Required(ErrorMessage = "Name is required.")]
-    [MinLength(2, ErrorMessage = "Name should be longer than one character")]
-    public string Name
+    private string _firstName;
+    [Required(ErrorMessage = "First name is required.")]
+    [MinLength(2, ErrorMessage = "First name should be longer than one character")]
+    public string FirstName
     {
-        get => _name;
-        set => SetProperty(ref _name, value, false);
+        get => _firstName;
+        set => SetProperty(ref _firstName, value, false);
+    }
+
+    private string _lastName;
+    [Required(ErrorMessage = "First name is required.")]
+    [MinLength(2, ErrorMessage = "First name should be longer than one character")]
+    public string LastName
+    {
+        get => _lastName;
+        set => SetProperty(ref _lastName, value, false);
     }
 
     [EmailAddress(ErrorMessage = "Must be a valid email address")]
@@ -181,7 +190,8 @@ public class PreferencesViewModel : ObservableValidator
 
     internal void LoadModel()
     {
-        Name = CurrentModel.Name;
+        FirstName = CurrentModel.FirstName;
+        LastName = CurrentModel.LastName;
         Email = CurrentModel.Email;
         ErrorCollectionConsent = CurrentModel.ErrorCollectionConsent;
         Newsletter = CurrentModel.Newsletter;
@@ -214,7 +224,8 @@ public class PreferencesViewModel : ObservableValidator
 
     internal void SaveModel()
     {
-        CurrentModel.Name = Name;
+        CurrentModel.FirstName = FirstName;
+        CurrentModel.LastName = LastName;
         CurrentModel.Email = Email;
         CurrentModel.ErrorCollectionConsent = ErrorCollectionConsent;
         CurrentModel.Newsletter = Newsletter;


### PR DESCRIPTION
This PR updates the name preference and splits it into two a first name and surname preference and all usages of it.
(Backend calls may need updating at a later date)

Fixes #525