### PR TITLE
Update dependencies and requirements

### DIFF
--- a/NRtfTree/NRtfTree.csproj
+++ b/NRtfTree/NRtfTree.csproj
@@ -3,8 +3,8 @@
 	<PropertyGroup>
 		<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
 		<TargetFramework>net7.0</TargetFramework>
-		<TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
-		<TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
+		<TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
+		<TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
 		<OutputType>Library</OutputType>
 		<TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
 		<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>

--- a/StoryCAD/App.xaml.cs
+++ b/StoryCAD/App.xaml.cs
@@ -148,10 +148,14 @@ public partial class App
         AppState AppDat = Ioc.Default.GetRequiredService<AppState>();
         string pathMsg = string.Format("Configuration data location = " + AppDat.RootDirectory);
         _log.Log(LogLevel.Info, pathMsg);
+        
         Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));
         Trace.AutoFlush = true;
         Trace.Indent();
         Trace.WriteLine(pathMsg);
+
+        //Load user preferences or atleast initalise them.
+        await Ioc.Default.GetService<AppState>().LoadPreferences();
 
         if (Debugger.IsAttached) {_log.Log(LogLevel.Info, "Bypassing elmah.io as debugger is attached.");}
         else
@@ -167,9 +171,8 @@ public partial class App
                 _log.Log(LogLevel.Info, "elmah.io log target bypassed");
             }
         }
-        
+
         Ioc.Default.GetService<BackendService>()!.StartupRecording();
-        await Ioc.Default.GetService<AppState>().LoadPreferences();
         ConfigureNavigation();
 
         // Construct a Window to hold our Pages

--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.11.0.65535" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.13.0.65535" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>StoryBuilder</PublisherDisplayName>

--- a/StoryCAD/StoryCAD.csproj
+++ b/StoryCAD/StoryCAD.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-		<TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
+		<TargetFramework>net7.0-windows10.0.22621.0</TargetFramework>
+		<TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
+		<TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
 		<TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
 		<RootNamespace>StoryCAD</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
@@ -21,8 +21,8 @@
 		<AppxBundle>Auto</AppxBundle>
 		<AppInstallerUri>C:\msixs\</AppInstallerUri>
 		<HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
-		<AppxPackageDir>C:\Users\Jaker\Desktop\cadapp\</AppxPackageDir>
-		<AppxBundlePlatforms>arm64</AppxBundlePlatforms>
+		<AppxPackageDir>C:\Users\RARI\Desktop\cadapp\</AppxPackageDir>
+		<AppxBundlePlatforms>x64</AppxBundlePlatforms>
 		<RunAnalyzersDuringLiveAnalysis>False</RunAnalyzersDuringLiveAnalysis>
 		<RunAnalyzersDuringBuild>False</RunAnalyzersDuringBuild>
 		<PackageCertificateKeyFile>StoryCAD_TemporaryKey.pfx</PackageCertificateKeyFile>
@@ -39,16 +39,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="dotenv.net" Version="3.1.2" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.230822000" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+		<PackageReference Include="dotenv.net" Version="3.1.3" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Core" Version="7.1.2" />
-		<PackageReference Include="NLog" Version="5.2.4" />
-		<PackageReference Include="NLog.Extensions.Logging" Version="5.3.4" />
+		<PackageReference Include="NLog" Version="5.2.5" />
+		<PackageReference Include="NLog.Extensions.Logging" Version="5.3.5" />
 		<PackageReference Include="PInvoke.User32" Version="0.7.124" />
 		<PackageReference Include="Syncfusion.Editors.WinUI" Version="23.1.36" />
-		<PackageReference Include="WinUIEx" Version="2.3.0" />
+		<PackageReference Include="WinUIEx" Version="2.3.2" />
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 

--- a/StoryCADLib/StoryCADLib.csproj
+++ b/StoryCADLib/StoryCADLib.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	  <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
+	  <TargetFramework>net7.0-windows10.0.22621.0</TargetFramework>
 	  <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-	<TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
+	<TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
     <RootNamespace>StoryCAD</RootNamespace>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <Platforms>x86;x64;arm64</Platforms>
@@ -74,17 +74,17 @@
 
   <ItemGroup>
     <PackageReference Include="CommonServiceLocator" Version="2.0.7" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Core" Version="7.1.2" />
-    <PackageReference Include="dotenv.net" Version="3.1.2" />
+    <PackageReference Include="dotenv.net" Version="3.1.3" />
     <PackageReference Include="Elmah.Io.NLog" Version="5.1.42" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.230822000" />
-    <PackageReference Include="MySql.Data" Version="8.1.0" />
-	<PackageReference Include="NLog" Version="5.2.4" />
-	<PackageReference Include="NLog.Extensions.Logging" Version="5.3.4" />
-	<PackageReference Include="Octokit" Version="7.1.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
+    <PackageReference Include="MySql.Data" Version="8.2.0" />
+	<PackageReference Include="NLog" Version="5.2.5" />
+	<PackageReference Include="NLog.Extensions.Logging" Version="5.3.5" />
+	<PackageReference Include="Octokit" Version="9.0.0" />
 	<PackageReference Include="Syncfusion.Editors.WinUI" Version="23.1.36" />
-    <PackageReference Include="WinUIEx" Version="2.3.0" />
+    <PackageReference Include="WinUIEx" Version="2.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/StoryCADTests/StoryCADTests.csproj
+++ b/StoryCADTests/StoryCADTests.csproj
@@ -3,8 +3,8 @@
 		<OutputType>WinExe</OutputType>
 		<TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
 		<TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
-		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-		<TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
+		<TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
+		<TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
 		<RootNamespace>StoryCADTests</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<Platforms>x86;x64;arm64</Platforms>
@@ -42,9 +42,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.230822000" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Core" Version="7.1.2" />
 		<PackageReference Include="MSTest.TestAdapter">
 			<Version>3.1.1</Version>


### PR DESCRIPTION
This PR does three things
- Updates minimum requirements of storycad to 19041 (win10 20h2) and recomended to 22621 (Win11 23h2)
- Updates all dependencies
- Fixes a possible error on loading as preferences loads too.