### PR TITLE
Add theme option

### DIFF
--- a/StoryCAD/App.xaml.cs
+++ b/StoryCAD/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿    using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -35,6 +35,8 @@ using LaunchActivatedEventArgs = Microsoft.UI.Xaml.LaunchActivatedEventArgs;
 using System.Globalization;
 using System.Reflection;
 using StoryCAD.Services.IoC;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI;
 
 namespace StoryCAD;
 
@@ -182,6 +184,7 @@ public partial class App
         mainWindow.Content = rootFrame;
         mainWindow.CenterOnScreen(); // Centers the window on the monitor
         mainWindow.Activate();
+        (mainWindow.Content as FrameworkElement).RequestedTheme = ElementTheme.Light;
         // Navigate to the first page:
         //   If we've not yet initialized Preferences, it's PreferencesInitialization.
         //   If we have initialized Preferences, it Shell.

--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -89,7 +89,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <!-- Command Bar -->
-        <CommandBar  Background="{x:Bind ShellVm.UserPreferences.PrimaryColor}" IsOpen="False">
+        <CommandBar  Background="{x:Bind Windowing.PrimaryColor, Mode=OneWay}" IsOpen="False" x:Name="ToolBar">
             <CommandBar.Content>
                 <StackPanel Orientation="Horizontal">
                     <AutoSuggestBox PlaceholderText="Enter text to search for here" QueryIcon="Find" Width="335" Margin="0,8" QuerySubmitted="Search" TextChanged="ClearNodes" Text="{x:Bind ShellVm.FilterText, Mode=TwoWay}" VerticalAlignment="Center"/>
@@ -364,7 +364,7 @@
             </SplitView.Content>
         </SplitView>
         <!-- Status Bar -->
-        <StackPanel Grid.Row="2" Orientation="Horizontal" Background="{x:Bind ShellVm.UserPreferences.PrimaryColor}">
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Background="{x:Bind Windowing.PrimaryColor, Mode=OneWay}" x:Name="StatusBar">
             <ComboBox IsEditable="False" Width="200"  Margin="10" ItemsSource="{x:Bind ShellVm.ViewList}" 
                       SelectionChanged="{x:Bind ShellVm.ViewChanged, Mode=OneWay}" 
                       SelectedItem="{x:Bind ShellVm.SelectedView, Mode=TwoWay}" />

--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -4,8 +4,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-    xmlns:viewmodels="using:StoryCAD.ViewModels"   
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls" RequestedTheme="{x:Bind Windowing.RequestedTheme, Mode=OneWay}"
+    xmlns:viewmodels="using:StoryCAD.ViewModels"
     mc:Ignorable="d">
     <Page.Resources>
         <ResourceDictionary>
@@ -359,7 +359,7 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <!-- Navigation Frame -->
-                    <Frame x:Name="SplitViewFrame" Navigated="SplitViewFrame_OnNavigated" Margin="0,0,0,5" />
+                    <Frame x:Name="SplitViewFrame" Navigated="SplitViewFrame_OnNavigated" Padding="0,0,0,0"/>
                 </Grid>
             </SplitView.Content>
         </SplitView>

--- a/StoryCAD/Views/Shell.xaml.cs
+++ b/StoryCAD/Views/Shell.xaml.cs
@@ -16,12 +16,14 @@ using Microsoft.UI.Dispatching;
 using StoryCAD.Services;
 using System.Linq;
 using Windows.ApplicationModel.DataTransfer;
+using Microsoft.UI;
 
 namespace StoryCAD.Views;
 
 public sealed partial class Shell
 {
     public ShellViewModel ShellVm => Ioc.Default.GetService<ShellViewModel>();
+    public Windowing Windowing => Ioc.Default.GetService<Windowing>();
     public UnifiedVM UnifiedVm => Ioc.Default.GetService<UnifiedVM>();
     public PreferencesModel Preferences = Ioc.Default.GetRequiredService<AppState>().Preferences;
 
@@ -53,10 +55,7 @@ public sealed partial class Shell
 
     private async void Shell_Loaded(object sender, RoutedEventArgs e)
     {
-        // The Shell_Loaded event is processed in order to obtain and save the XamlRool  
-        // and pass it on to ContentDialogs as a WinUI work-around. See
-        // https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.controls.contentdialog?view=winui-3.0-preview
-        Ioc.Default.GetRequiredService<Windowing>().XamlRoot = Content.XamlRoot;
+        Windowing.XamlRoot = Content.XamlRoot;
         Ioc.Default.GetService<AppState>().StartUpTimer.Stop();
         ShellVm.ShowHomePage();
         ShellVm.ShowConnectionStatus();
@@ -90,6 +89,12 @@ public sealed partial class Shell
     {
         NavigationTree.SelectionMode = TreeViewSelectionMode.None;
         NavigationTree.SelectionMode = TreeViewSelectionMode.Single;
+        (SplitViewFrame.Content as FrameworkElement).RequestedTheme = Windowing.RequestedTheme;
+        SplitViewFrame.Background = Windowing.RequestedTheme == ElementTheme.Light ? new SolidColorBrush(Colors.LightGray) : new SolidColorBrush(Colors.Black);
+        if (!(SplitViewFrame.Content as FrameworkElement).BaseUri.ToString().Contains("HomePage"))
+        {
+            (SplitViewFrame.Content as Page).Margin = new(0, 0, 0, 5);
+        }
     }
 
     /// <summary>

--- a/StoryCAD/Views/Shell.xaml.cs
+++ b/StoryCAD/Views/Shell.xaml.cs
@@ -17,6 +17,7 @@ using StoryCAD.Services;
 using System.Linq;
 using Windows.ApplicationModel.DataTransfer;
 using Microsoft.UI;
+using Windows.Storage.Provider;
 
 namespace StoryCAD.Views;
 

--- a/StoryCADLib/Controls/RelationshipView.xaml.cs
+++ b/StoryCADLib/Controls/RelationshipView.xaml.cs
@@ -58,11 +58,10 @@ public sealed partial class RelationshipView
             {
                 Title = "Are you sure?",
                 Content = $"Are you sure you want to delete the relationship between {CharVm.Name} and {characterToDelete.Partner.Name}?",
-                XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
                 PrimaryButtonText = "Yes",
                 SecondaryButtonText = "No"
             };
-            ContentDialogResult result = await CD.ShowAsync();
+            ContentDialogResult result = await Ioc.Default.GetService<Windowing>().ShowContentDialog(CD);
             Logger.Log(LogLevel.Info, $"Dialog Result: {result}");
 
             if (result == ContentDialogResult.Primary) //If positive, then delete.

--- a/StoryCADLib/Controls/RichEditBoxExtended.cs
+++ b/StoryCADLib/Controls/RichEditBoxExtended.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.UI;
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.UI;
 using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using StoryCAD.Models;
 
 namespace StoryCAD.Controls;
 
@@ -36,7 +38,7 @@ public class RichEditBoxExtended : RichEditBox
         TextChanged += RichEditBoxExtended_TextChanged;
         TextAlignment = TextAlignment.Left;
         CornerRadius = new(5);
-        if (Application.Current.RequestedTheme == ApplicationTheme.Dark) { Foreground = new SolidColorBrush(Colors.LightGray); } //Color fix for dark mode
+        if (Ioc.Default.GetRequiredService<Windowing>().RequestedTheme == ElementTheme.Dark) { Foreground = new SolidColorBrush(Colors.LightGray); } //Color fix for dark mode
     }
 
 

--- a/StoryCADLib/DAL/PreferencesIO.cs
+++ b/StoryCADLib/DAL/PreferencesIO.cs
@@ -169,6 +169,10 @@ public class PreferencesIo
                         BrowserType.TryParse(typeof(BrowserType), _tokens[1].ToCharArray(), true, out val);
                         _model.PreferredSearchEngine = (BrowserType)val;
                         break;
+                    case "Theme":
+                        _model.ThemePreference = (ElementTheme)(Convert.ToInt16(_tokens[1]));
+                        break;
+
                 }
             }
             _log.Log(LogLevel.Info, "PreferencesModel updated from StoryCAD.prf.");
@@ -179,16 +183,25 @@ public class PreferencesIo
             _log.Log(LogLevel.Info, "StoryCAD.prf not found; default created.");
         }
 
+        //Handle UI Theme stuff
+        Windowing window = Ioc.Default.GetService<Windowing>();
+        if (_model.ThemePreference == ElementTheme.Default)
+        {
+            window.RequestedTheme = Application.Current.RequestedTheme == ApplicationTheme.Dark ? ElementTheme.Dark : ElementTheme.Light;
+        }
+        else { Ioc.Default.GetService<Windowing>().RequestedTheme = _model.ThemePreference; }
+
         if (Ioc.Default.GetService<Windowing>().RequestedTheme == ElementTheme.Light)
         {
-            _model.PrimaryColor = new SolidColorBrush(Colors.LightGray);
-            _model.SecondaryColor = new SolidColorBrush(Colors.Black);
+            window.PrimaryColor = new SolidColorBrush(Colors.LightGray);
+            window.SecondaryColor = new SolidColorBrush(Colors.Black);
         }
-        else
+        else 
         {
-            _model.PrimaryColor = new SolidColorBrush(Colors.DarkSlateGray);
-            _model.SecondaryColor = new SolidColorBrush(Colors.White);
-        } 
+            window.PrimaryColor = new SolidColorBrush(Colors.DarkSlateGray);
+            window.SecondaryColor = new SolidColorBrush(Colors.White);
+        }
+
     }
 
     /// <summary>
@@ -226,6 +239,7 @@ public class PreferencesIo
             RecordPreferencesStatus={_model.RecordPreferencesStatus}
             RecordVersionStatus={_model.RecordVersionStatus}
             SearchEngine={_model.PreferredSearchEngine}
+            Theme={(int)_model.ThemePreference}
             """;
 
         _newPreferences += (_model.WrapNodeNames == TextWrapping.WrapWholeWords ? Environment.NewLine + "WrapNodeNames=True" : Environment.NewLine + "WrapNodeNames=False");

--- a/StoryCADLib/DAL/PreferencesIO.cs
+++ b/StoryCADLib/DAL/PreferencesIO.cs
@@ -162,7 +162,7 @@ public class PreferencesIo
             _log.Log(LogLevel.Info, "StoryCAD.prf not found; default created.");
         }
 
-        if (Application.Current.RequestedTheme == ApplicationTheme.Light)
+        if (Ioc.Default.GetService<Windowing>().RequestedTheme == ElementTheme.Light)
         {
             _model.PrimaryColor = new SolidColorBrush(Colors.LightGray);
             _model.SecondaryColor = new SolidColorBrush(Colors.Black);
@@ -171,9 +171,7 @@ public class PreferencesIo
         {
             _model.PrimaryColor = new SolidColorBrush(Colors.DarkSlateGray);
             _model.SecondaryColor = new SolidColorBrush(Colors.White);
-        }
-
-        _model.AccentColor = new UISettings().GetColorValue(UIColorType.Accent);
+        } 
     }
 
     /// <summary>

--- a/StoryCADLib/Models/AppState.cs
+++ b/StoryCADLib/Models/AppState.cs
@@ -152,7 +152,7 @@ public class AppState
                      Email - {Preferences.Email}
                      Elmah Consent - {Preferences.ErrorCollectionConsent}
                      Theme - {Preferences.PrimaryColor.Color.ToHex()}
-                     Accent Color - {Preferences.AccentColor} 
+                     Accent Color - {Ioc.Default.GetRequiredService<Windowing>().AccentColor} 
                      Last Version Prefs logged - {Preferences.Version}
                      Search Engine - {Preferences.PreferredSearchEngine} 
                      AutoSave - {Preferences.AutoSave}

--- a/StoryCADLib/Models/AppState.cs
+++ b/StoryCADLib/Models/AppState.cs
@@ -151,7 +151,7 @@ public class AppState
                      Name - {Preferences.FirstName}  {Preferences.LastName}
                      Email - {Preferences.Email}
                      Elmah Consent - {Preferences.ErrorCollectionConsent}
-                     Theme - {Preferences.PrimaryColor.Color.ToHex()}
+                     Theme - {Ioc.Default.GetRequiredService<Windowing>().PrimaryColor.Color.ToHex()}
                      Accent Color - {Ioc.Default.GetRequiredService<Windowing>().AccentColor} 
                      Last Version Prefs logged - {Preferences.Version}
                      Search Engine - {Preferences.PreferredSearchEngine} 

--- a/StoryCADLib/Models/MissingManifestResourceException.cs
+++ b/StoryCADLib/Models/MissingManifestResourceException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace StoryCAD.Models
+{
+    [Serializable]
+    internal class MissingManifestResourceException : Exception
+    {
+        public MissingManifestResourceException()
+        {
+        }
+
+        public MissingManifestResourceException(string message) : base(message)
+        {
+        }
+
+        public MissingManifestResourceException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected MissingManifestResourceException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/StoryCADLib/Models/Tools/PreferencesModel.cs
+++ b/StoryCADLib/Models/Tools/PreferencesModel.cs
@@ -2,6 +2,7 @@
 using Microsoft.UI.Xaml.Media;
 using Windows.UI.ViewManagement;
 using CommunityToolkit.Mvvm.ComponentModel;
+using static Org.BouncyCastle.Crypto.Engines.SM2Engine;
 
 namespace StoryCAD.Models.Tools;
 
@@ -39,14 +40,10 @@ public class PreferencesModel : ObservableObject
 
     /// <summary>
     /// This is the users theme preference
-    /// It can be light, dark or default
+    /// It can be light, dark or default (System theme)
     /// </summary>
     public ElementTheme ThemePreference;
 
-
-    // Visual changes
-    public SolidColorBrush PrimaryColor { get; set; } //Sets UI Color
-    public SolidColorBrush SecondaryColor { get; set; } //Sets node color.
 
     public TextWrapping WrapNodeNames { get; set; }
 
@@ -93,9 +90,6 @@ public class PreferencesModel : ObservableObject
         Newsletter = false;
         PreferencesInitialized = false;
         LastSelectedTemplate = 0;
-
-        PrimaryColor = new SolidColorBrush(new UISettings().GetColorValue(UIColorType.Accent));
-        SecondaryColor = new SolidColorBrush(new UISettings().GetColorValue(UIColorType.Accent));
         WrapNodeNames = TextWrapping.WrapWholeWords; 
 
         LastFile1 = string.Empty;
@@ -113,8 +107,9 @@ public class PreferencesModel : ObservableObject
 
         Version = string.Empty;
         RecordPreferencesStatus = false;
-        RecordVersionStatus = false;      // Last version change was logged successfully or notx
+        RecordVersionStatus = false;      // Last version change was logged successfully or not
         PreferredSearchEngine = BrowserType.DuckDuckGo;
+        ThemePreference = ElementTheme.Default; // Use system theme
     }
     #endregion
 }

--- a/StoryCADLib/Models/Tools/PreferencesModel.cs
+++ b/StoryCADLib/Models/Tools/PreferencesModel.cs
@@ -1,10 +1,7 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using Windows.UI.ViewManagement;
-using ABI.Windows.Media.Protection.PlayReady;
 using CommunityToolkit.Mvvm.ComponentModel;
-using System;
-using Windows.UI;
 
 namespace StoryCAD.Models.Tools;
 
@@ -38,21 +35,18 @@ public class PreferencesModel : ObservableObject
     public bool PreferencesInitialized { get; set; }
     public int LastSelectedTemplate { get; set; } //This is the Last Template Selected by the user.
 
+
+    /// <summary>
+    /// This is the users theme preference
+    /// It can be light, dark or default
+    /// </summary>
+    public ElementTheme ThemePreference;
+
+
     // Visual changes
     public SolidColorBrush PrimaryColor { get; set; } //Sets UI Color
     public SolidColorBrush SecondaryColor { get; set; } //Sets node color.
-    public SolidColorBrush ContrastColor // A color that contrasts nicely with the users accent color
-    {
-        get
-        {
-            Color Contrast = AccentColor;
-            Contrast.R = (byte)(Contrast.R * 1.4);
-            Contrast.B = (byte)(Contrast.B * 1.4);
-            Contrast.G = (byte)(Contrast.G * 1.4);
-            return new SolidColorBrush(Contrast);
-        }
-    }
-    public Color AccentColor { get; set; } //Sets Text Color
+
     public TextWrapping WrapNodeNames { get; set; }
 
     // Backup Information

--- a/StoryCADLib/Models/Windowing.cs
+++ b/StoryCADLib/Models/Windowing.cs
@@ -135,6 +135,11 @@ public class Windowing : ObservableRecipient
     public void UpdateUIToTheme()
     {
         (MainWindow.Content as FrameworkElement).RequestedTheme = RequestedTheme;
+
+        //Save file, close current node since it won't be the right theme.
+        Ioc.Default.GetRequiredService<ShellViewModel>().SaveFile();
+        Ioc.Default.GetRequiredService<ShellViewModel>().ShowHomePage();
+
     }
 
     /// <summary>

--- a/StoryCADLib/Models/Windowing.cs
+++ b/StoryCADLib/Models/Windowing.cs
@@ -136,11 +136,14 @@ public class Windowing : ObservableRecipient
     {
         (MainWindow.Content as FrameworkElement).RequestedTheme = RequestedTheme;
 
+        ShellViewModel ShellVM = Ioc.Default.GetRequiredService<ShellViewModel>();
         //Save file, close current node since it won't be the right theme.
-        Ioc.Default.GetRequiredService<ShellViewModel>().SaveFile();
-        Ioc.Default.GetRequiredService<ShellViewModel>().ShowHomePage();
-
-    }
+        if (ShellVM.StoryModel != null && ShellVM.DataSource != null && ShellVM.DataSource.Count > 0)
+        {
+            Ioc.Default.GetRequiredService<ShellViewModel>().SaveFile();
+            Ioc.Default.GetRequiredService<ShellViewModel>().ShowHomePage();
+        }
+        }
 
     /// <summary>
     /// This takes a ContentDialog and shows it to the user

--- a/StoryCADLib/Models/Windowing.cs
+++ b/StoryCADLib/Models/Windowing.cs
@@ -52,7 +52,7 @@ public class Windowing : ObservableRecipient
     /// </summary>
     public DispatcherQueue GlobalDispatcher = null;
 
-    private ElementTheme _requestedTheme = ElementTheme.Light;
+    private ElementTheme _requestedTheme = ElementTheme.Default;
     public ElementTheme RequestedTheme
     {
         get => _requestedTheme;
@@ -64,6 +64,28 @@ public class Windowing : ObservableRecipient
     /// (Set in Windows Settings)
     /// </summary>
     public Color AccentColor => new UISettings().GetColorValue(UIColorType.Accent);
+
+
+    // Visual changes
+    private SolidColorBrush _primaryBrush;
+    /// <summary>
+    /// Sets the shell color
+    /// </summary>
+    public SolidColorBrush PrimaryColor
+    {
+        get => _primaryBrush;
+        set => SetProperty(ref _primaryBrush, value);
+    }
+
+    private SolidColorBrush _secondaryBrush;
+    /// <summary>
+    /// Handles various other colorations
+    /// </summary>
+    public SolidColorBrush SecondaryColor
+    {
+        get => _secondaryBrush;
+        set => SetProperty(ref _secondaryBrush, value);
+    }
 
     /// <summary>
     /// This is a color that should in most cases
@@ -112,7 +134,7 @@ public class Windowing : ObservableRecipient
     /// </summary>
     public void UpdateUIToTheme()
     {
-
+        (MainWindow.Content as FrameworkElement).RequestedTheme = RequestedTheme;
     }
 
     /// <summary>

--- a/StoryCADLib/Services/Dialogs/Changelog.cs
+++ b/StoryCADLib/Services/Dialogs/Changelog.cs
@@ -7,6 +7,7 @@ using StoryCAD.Models;
 using System;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using StoryCAD.Services.Logging;
+using MySqlX.XDevAPI.Common;
 
 namespace StoryCAD.Services.Dialogs
 {
@@ -74,9 +75,9 @@ namespace StoryCAD.Services.Dialogs
                     },
                     Title = "What's new in StoryCAD " + AppDat.Version,
                     PrimaryButtonText = "Okay",
-                    XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
                 };
-                await _changelogUI.ShowAsync();
+                await Ioc.Default.GetService<Windowing>().ShowContentDialog(_changelogUI);
+
             }
             catch (Exception _e)
             {

--- a/StoryCADLib/Services/Dialogs/SamplePage.xaml
+++ b/StoryCADLib/Services/Dialogs/SamplePage.xaml
@@ -9,7 +9,7 @@
 
     <StackPanel VerticalAlignment="Stretch" HorizontalAlignment="Center" Margin="0,0,70,0">
         <InfoBar IsOpen="True" Severity="Warning" IsClosable="False" Width="300"
-                 Message="Sample edits will be lost unless you use Save As save them elsewhere."/>
+                 Message="Sample edits will be lost unless you use Save As to save them elsewhere."/>
         <TextBlock Text="Sample stories:" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="4" FontSize="25" />
         <ListBox HorizontalAlignment="Center" VerticalAlignment="Center" Name="Samples" Width="200" Background="{x:Bind UnifiedVM.AdjustmentColor, Mode=OneWay}"/>
         <Button HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="10" Click="LoadSample" Content="Open sample"/>

--- a/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
@@ -3,8 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <StackPanel Width="500" Height="400">
-        <Pivot Name="PivotView" Height="355" Width="500" VerticalAlignment="Stretch">
+    <StackPanel Width="500" Height="410">
+        <Pivot Name="PivotView" Height="381" Width="500" VerticalAlignment="Stretch">
             <PivotItem Header="General" VerticalContentAlignment="Stretch" VerticalAlignment="Center">
                 <StackPanel>
                     <TextBox Header="Your first name:" PlaceholderText="Put the first name want to publish under here" HorizontalAlignment="Center" Margin="8" Width="300" Text="{x:Bind PreferencesVm.FirstName, Mode=TwoWay}"/>
@@ -37,7 +37,12 @@
                         <NumberBox Minimum="15" Maximum="60" IsEnabled="{x:Bind PreferencesVm.AutoSave, Mode=TwoWay}" PlaceholderText="Enter a value (Seconds)" Value="{x:Bind PreferencesVm.AutoSaveInterval, Mode=TwoWay}" HorizontalAlignment="Left" Margin="8"/>
                         <TextBlock Text="Seconds" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                     </StackPanel>
-                    <ComboBox Header="Preferred Search Engine" HorizontalAlignment="Stretch" Name="SearchEngine" SelectedIndex="{x:Bind PreferencesVm.SearchEngineIndex, Mode=TwoWay}">
+                    <ComboBox Header="Preferred Theme" HorizontalAlignment="Stretch" SelectedIndex="{x:Bind PreferencesVm.PreferredThemeIndex, Mode=TwoWay}" Margin="8">
+                        <ComboBoxItem Content="Use system theme"/>
+                        <ComboBoxItem Content="Light Theme"/>
+                        <ComboBoxItem Content="Dark Theme"/>
+                    </ComboBox>
+                    <ComboBox Header="Preferred Search Engine" HorizontalAlignment="Stretch" Name="SearchEngine" SelectedIndex="{x:Bind PreferencesVm.SearchEngineIndex, Mode=TwoWay}" Margin="0,4,0,0">
                         <ComboBoxItem Content="DuckDuckGo"/>
                         <ComboBoxItem Content="Google"/>
                         <ComboBoxItem Content="Bing"/>
@@ -126,16 +131,16 @@
 
             </PivotItem>
         </Pivot>
-      <SymbolIcon Symbol="ReportHacked"
-                    Foreground="Red"
-                    Visibility="{x:Bind PreferencesVm.HasErrors, Mode=OneWay}"
-                    HorizontalAlignment="Left"
-                    Margin="0 4">
-            <ToolTipService.ToolTip>
-                <TextBlock Text="{x:Bind PreferencesVm.Errors, Mode=OneWay}" MaxWidth="350"
-                           Foreground="Red" />
-            </ToolTipService.ToolTip>
-        </SymbolIcon>
-        <TextBlock Text="Changing some preferences may require a restart to take effect." HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,15,0,0"/>
+          <SymbolIcon Symbol="ReportHacked"
+                        Foreground="Red"
+                        Visibility="{x:Bind PreferencesVm.HasErrors, Mode=OneWay}"
+                        HorizontalAlignment="Left" VerticalAlignment="Bottom"
+                        Margin="0">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="{x:Bind PreferencesVm.Errors, Mode=OneWay}" MaxWidth="350"
+                               Foreground="Red" />
+                </ToolTipService.ToolTip>
+          </SymbolIcon>
+        <TextBlock Text="Changing some preferences may require a restart to take effect." HorizontalAlignment="Center" Margin="0,10,0,0"/>
     </StackPanel>
 </Page>

--- a/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml.cs
@@ -134,15 +134,17 @@ public sealed partial class PrintReportsDialog
                 Window.GlobalDispatcher.TryEnqueue(async () =>
                 {
                     PrintVM.CloseDialog();
-                    await new ContentDialog
+                    ContentDialog Dialog = new()
                     {
-                        XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
                         Title = "Printing error",
                         Content = "The following error occurred when trying to print:\n\n" + ex.Message,
                         PrimaryButtonText = "Ok"
-                    }.ShowAsync();
+                    };
+
+                    await Ioc.Default.GetService<Windowing>().ShowContentDialog(Dialog);
                 });
-;
+
+                ;
             }
         }
         else //Print Manager isn't supported so we fall back to the old version of printing directly.

--- a/StoryCADLib/Services/Dialogs/UnifiedMenu.xaml
+++ b/StoryCADLib/Services/Dialogs/UnifiedMenu.xaml
@@ -4,7 +4,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d" Background="{x:Bind UnifiedMenuVM.AdjustmentColor}">
+    mc:Ignorable="d" Background="{x:Bind UnifiedMenuVM.AdjustmentColor}"
+    RequestedTheme="{x:Bind Windowing.RequestedTheme, Mode=OneWay}">
 
     <Grid Width="auto" Height="500" MinWidth="600" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
         <Grid.ColumnDefinitions>

--- a/StoryCADLib/Services/Dialogs/UnifiedMenu.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/UnifiedMenu.xaml.cs
@@ -41,6 +41,6 @@ public sealed partial class UnifiedMenuPage
         UnifiedMenuVM.UpdateContent = UpdateContent;  // Connect the VM's delegate to HideDialog
         UnifiedMenuVM.CurrentTab = new ListBoxItem { Name = "Recent" }; //Makes unified VM load recents by default
         UnifiedMenuVM.SidebarChange(null, null);
-        if (ActualTheme == ElementTheme.Light) {UnifiedMenuVM.AdjustmentColor = new SolidColorBrush(Colors.White);}
+        if (Windowing.RequestedTheme == ElementTheme.Light) {UnifiedMenuVM.AdjustmentColor = new SolidColorBrush(Colors.White);}
     }
 }

--- a/StoryCADLib/Services/Dialogs/UnifiedMenu.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/UnifiedMenu.xaml.cs
@@ -10,6 +10,7 @@ namespace StoryCAD.Services.Dialogs;
 
 public sealed partial class UnifiedMenuPage
 {
+    Windowing Windowing = Ioc.Default.GetRequiredService<Windowing>();
     public delegate void UpdateContentDelegate();
 
     public void UpdateContent()

--- a/StoryCADLib/ViewModels/CharacterViewModel.cs
+++ b/StoryCADLib/ViewModels/CharacterViewModel.cs
@@ -28,7 +28,7 @@ public class CharacterViewModel : ObservableRecipient, INavigable
     public RelationshipModel CurrentRelationship;
     private bool _changeable; // process property changes for this story element
     private bool _changed;    // this story element has changed
-
+    Windowing Windowing = Ioc.Default.GetService<Windowing>();
     #endregion
 
     #region Properties
@@ -759,16 +759,15 @@ public class CharacterViewModel : ObservableRecipient, INavigable
         }
 
         //Creates dialog and shows dialog
-        ContentDialog _newRelationship = new()
+        ContentDialog _NewRelDialog = new()
         {
             Title = "New relationship",
             PrimaryButtonText = "Add relationship",
             SecondaryButtonText = "Cancel",
-            XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
             Content = new NewRelationshipPage(_vm),
             MinWidth = 200
         };
-        ContentDialogResult _result = await _newRelationship.ShowAsync();
+        ContentDialogResult _result = await Windowing.ShowContentDialog(_NewRelDialog);
 
         if (_result == ContentDialogResult.Primary) //User clicks add relationship
         {
@@ -837,13 +836,12 @@ public class CharacterViewModel : ObservableRecipient, INavigable
         //Creates and shows dialog
         ContentDialog _flawDialog = new()
         {
-            XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
             Content = new Flaw(),
             Title = "Flaw Builder",
             PrimaryButtonText = "Copy flaw example",
             CloseButtonText = "Cancel"
         };
-        ContentDialogResult _result = await _flawDialog.ShowAsync();
+        ContentDialogResult _result = await Windowing.ShowContentDialog(_flawDialog);
 
         if (_result == ContentDialogResult.Primary)   // Copy to Character Flaw  
         {
@@ -866,10 +864,9 @@ public class CharacterViewModel : ObservableRecipient, INavigable
             Title = "Trait builder",
             PrimaryButtonText = "Copy trait",
             CloseButtonText = "Cancel",
-            XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
             Content = new Traits()
         };
-        ContentDialogResult _result = await _traitDialog.ShowAsync();
+        ContentDialogResult _result = await Windowing.ShowContentDialog(_traitDialog);
 
         if (_result == ContentDialogResult.Primary)   // Copy to Character Trait 
         {
@@ -965,7 +962,7 @@ public class CharacterViewModel : ObservableRecipient, INavigable
         catch (Exception e)
         {
             _logger.LogException(LogLevel.Fatal, e, "Error loading lists in Problem view model");
-            ShowError();
+            Windowing.ShowResourceErrorMessage();
         }
 
         CharacterTraits = new ObservableCollection<string>();
@@ -1022,20 +1019,6 @@ public class CharacterViewModel : ObservableRecipient, INavigable
 
         PropertyChanged += OnPropertyChanged;
     }
-
-    async void ShowError()
-    {
-        await new ContentDialog()
-        {
-            XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
-            Title = "Error loading resources",
-            Content = "An error has occurred, please reinstall or update StoryCAD to continue.",
-            CloseButtonText = "Close"
-        }.ShowAsync();
-        throw new MissingManifestResourceException();
-
-    }
-
 }
 
 #endregion

--- a/StoryCADLib/ViewModels/OverviewViewModel.cs
+++ b/StoryCADLib/ViewModels/OverviewViewModel.cs
@@ -363,7 +363,7 @@ public class OverviewViewModel : ObservableRecipient, INavigable
         catch (Exception e)
         {
             _logger!.LogException(LogLevel.Fatal, e, "Error loading lists in Problem view model");
-            ShowError();
+            Ioc.Default.GetService<Windowing>().ShowResourceErrorMessage();
         }
 
         DateCreated = string.Empty;
@@ -384,19 +384,6 @@ public class OverviewViewModel : ObservableRecipient, INavigable
         Notes = string.Empty;
 
         PropertyChanged += OnPropertyChanged;
-    }
-
-    async void ShowError()
-    {
-        await new ContentDialog()
-        {
-            XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
-            Title = "Error loading resources",
-            Content = "An error has occurred, please reinstall or update StoryCAD to continue.",
-            CloseButtonText = "Close"
-        }.ShowAsync();
-        throw new MissingManifestResourceException();
-
     }
     #endregion
 }

--- a/StoryCADLib/ViewModels/ProblemViewModel.cs
+++ b/StoryCADLib/ViewModels/ProblemViewModel.cs
@@ -337,14 +337,13 @@ public class ProblemViewModel : ObservableRecipient, INavigable
         ContentDialog _conflictDialog = new()
         {
             Title = "Conflict builder",
-            XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
             PrimaryButtonText = "Copy to Protagonist",
             SecondaryButtonText = "Copy to Antagonist",
-            CloseButtonText = "Close"
+            CloseButtonText = "Close",
         };
         Conflict _selectedConflict = new();
         _conflictDialog.Content = _selectedConflict;
-        ContentDialogResult _result = await _conflictDialog.ShowAsync();
+        ContentDialogResult _result = await Ioc.Default.GetService<Windowing>().ShowContentDialog(_conflictDialog);
 
         if (_selectedConflict.ExampleText == null) {_selectedConflict.ExampleText = "";}
         switch (_result)
@@ -427,7 +426,7 @@ public class ProblemViewModel : ObservableRecipient, INavigable
         catch (Exception e)
         {
             _logger!.LogException(LogLevel.Fatal, e, "Error loading lists in Problem view model");
-            ShowError();
+            Ioc.Default.GetRequiredService<Windowing>().ShowResourceErrorMessage();
         }
 
         ConflictCommand = new RelayCommand(ConflictTool, () => true);
@@ -435,16 +434,4 @@ public class ProblemViewModel : ObservableRecipient, INavigable
         PropertyChanged += OnPropertyChanged;
     }
     #endregion
-
-    async void ShowError()
-    {
-        await new ContentDialog()
-        {
-            XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
-            Title = "Error loading resources",
-            Content = "An error has occurred, please reinstall or update StoryCAD to continue.",
-            CloseButtonText = "Close"
-        }.ShowAsync();
-        throw new MissingManifestResourceException();
-    }
 }

--- a/StoryCADLib/ViewModels/SceneViewModel.cs
+++ b/StoryCADLib/ViewModels/SceneViewModel.cs
@@ -686,7 +686,7 @@ public class SceneViewModel : ObservableRecipient, INavigable
         catch (Exception e)
         {
             _logger.LogException(LogLevel.Fatal, e, "Error loading lists in Problem view model");
-            ShowError();
+            Ioc.Default.GetRequiredService<Windowing>().ShowResourceErrorMessage();
         }
 
 
@@ -700,20 +700,4 @@ public class SceneViewModel : ObservableRecipient, INavigable
     }
 
     #endregion
-    async void ShowError()
-    {
-        await new ContentDialog()
-        {
-            XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
-            Title = "Error loading resources",
-            Content = "An error has occurred, please reinstall or update StoryCAD to continue.",
-            CloseButtonText = "Close"
-        }.ShowAsync();
-        throw new MissingManifestResourceException();
-
-    }
-}
-
-internal class CastSelectionType
-{
 }

--- a/StoryCADLib/ViewModels/SettingViewModel.cs
+++ b/StoryCADLib/ViewModels/SettingViewModel.cs
@@ -284,24 +284,11 @@ public class SettingViewModel : ObservableRecipient, INavigable
         catch (Exception e)
         {
             _logger.LogException(LogLevel.Fatal, e, "Error loading lists in Problem view model");
-            ShowError();
+            Ioc.Default.GetRequiredService<Windowing>().ShowResourceErrorMessage();
         }
 
 
         PropertyChanged += OnPropertyChanged;
-    }
-
-    async void ShowError()
-    {
-        await new ContentDialog()
-        {
-            XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
-            Title = "Error loading resources",
-            Content = "An error has occurred, please reinstall or update StoryCAD to continue.",
-            CloseButtonText = "Close"
-        }.ShowAsync();
-        throw new MissingManifestResourceException();
-
     }
     #endregion
 }

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -2184,7 +2184,7 @@ public class ShellViewModel : ObservableRecipient
         switch (statusMessage.Value.Level)
         {
             case LogLevel.Info:
-                StatusColor = State.Preferences.SecondaryColor;
+                StatusColor = Window.SecondaryColor;
                 _statusTimer.Interval = new TimeSpan(0, 0, 15);  // Timer will tick in 15 seconds
                 _statusTimer.Start();
                 break;

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -59,9 +59,7 @@ public class ShellViewModel : ObservableRecipient
     public List<StoryNodeItem> NewNodeHighlightCache = new();
 
     public StoryViewType CurrentViewType;
-
     private ContentDialog _contentDialog;
-
     private int _sourceIndex;
     private ObservableCollection<StoryNodeItem> _sourceChildren;
     private int _targetIndex;
@@ -366,9 +364,13 @@ public class ShellViewModel : ObservableRecipient
         {
             _canExecuteCommands = false;
             // Needs logging
-            _contentDialog = new() { XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot, Content = new UnifiedMenuPage() };
-            if (Application.Current.RequestedTheme == ApplicationTheme.Light) { _contentDialog.Background = new SolidColorBrush(Colors.LightGray); }
-            await _contentDialog.ShowAsync();
+            _contentDialog = new() { Content = new UnifiedMenuPage() };
+            if (Window.RequestedTheme == ElementTheme.Light) 
+            {
+                _contentDialog.RequestedTheme = Window.RequestedTheme;
+                _contentDialog.Background = new SolidColorBrush(Colors.LightGray);
+            }
+            await Window.ShowContentDialog(_contentDialog);
             _canExecuteCommands = true;
         }   
     }
@@ -632,15 +634,15 @@ public class ShellViewModel : ObservableRecipient
     /// </summary>
     public async Task ShowDotEnvWarningAsync()
     {
-        await new ContentDialog
+        ContentDialog Dialog = new()
         {
             Title = "File missing.",
             Content = "This copy is missing a key file, if you are working on a branch or fork this is expected and you do not need to do anything about this." +
-                      "\nHowever if you are not a developer then report this as it should not happen.\nThe following may have issues or possible errors\n" +
-                      "Syncfusion related items and error logging.",
-            XamlRoot = Window.XamlRoot,
+                       "\nHowever if you are not a developer then report this as it should not happen.\nThe following may have issues or possible errors\n" +
+                       "Syncfusion related items and error logging.",
             PrimaryButtonText = "Okay"
-        }.ShowAsync();
+        };
+        await Window.ShowContentDialog(Dialog);
         Ioc.Default.GetRequiredService<LogService>().Log(LogLevel.Error, "Env missing.");
     }
 
@@ -933,7 +935,6 @@ public class ShellViewModel : ObservableRecipient
                 ContentDialog _saveAsDialog = new()
                 {
                     Title = "Save as",
-                    XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
                     PrimaryButtonText = "Save",
                     SecondaryButtonText = "Cancel",
                     Content = new SaveAsDialog()
@@ -946,7 +947,7 @@ public class ShellViewModel : ObservableRecipient
                 _saveAsVM.ParentFolder = StoryModel.ProjectFolder;
                 _saveAsVM.ProjectPathName = StoryModel.ProjectPath;
 
-                ContentDialogResult _result = await _saveAsDialog.ShowAsync();
+                ContentDialogResult _result = await Window.ShowContentDialog(_saveAsDialog);
 
                 if (_result == ContentDialogResult.Primary) //If save is clicked
                 {
@@ -1009,9 +1010,8 @@ public class ShellViewModel : ObservableRecipient
                 SecondaryButtonText = "No",
                 Title = "Replace file?",
                 Content = $"File {Path.Combine(_saveAsVM.ProjectPathName, _saveAsVM.ProjectName)} already exists. \n\nDo you want to replace it?",
-                XamlRoot = Window.XamlRoot
             };
-            return await _replaceDialog.ShowAsync() == ContentDialogResult.Primary;
+            return await Window.ShowContentDialog(_replaceDialog) == ContentDialogResult.Primary;
         }
         return true;
     }
@@ -1028,9 +1028,8 @@ public class ShellViewModel : ObservableRecipient
                 Title = "Save changes?",
                 PrimaryButtonText = "Yes",
                 SecondaryButtonText = "No",
-                XamlRoot = Window.XamlRoot
             };
-            if (await _warning.ShowAsync() == ContentDialogResult.Primary)
+            if (await Window.ShowContentDialog(_warning) == ContentDialogResult.Primary)
             {
                 SaveModel();
                 await WriteModel();
@@ -1066,9 +1065,8 @@ public class ShellViewModel : ObservableRecipient
                 Title = "Save changes?",
                 PrimaryButtonText = "Yes",
                 SecondaryButtonText = "No",
-                XamlRoot = Window.XamlRoot
             };
-            if (await _warning.ShowAsync() == ContentDialogResult.Primary)
+            if (await Window.ShowContentDialog(_warning) == ContentDialogResult.Primary)
             {
                 SaveModel();
                 await WriteModel();
@@ -1098,14 +1096,13 @@ public class ShellViewModel : ObservableRecipient
         Ioc.Default.GetRequiredService<PreferencesViewModel>().LoadModel();
         ContentDialog _preferencesDialog = new()
         {
-            XamlRoot = Window.XamlRoot,
             Content = new PreferencesDialog(),
             Title = "Preferences",
             PrimaryButtonText = "Save",
             CloseButtonText = "Cancel"
         };
 
-        ContentDialogResult _result = await _preferencesDialog.ShowAsync();
+        ContentDialogResult _result = await Window.ShowContentDialog(_preferencesDialog);
         switch (_result)
         {
             // Save changes
@@ -1136,10 +1133,9 @@ public class ShellViewModel : ObservableRecipient
             {
                 Title = "Key questions",
                 CloseButtonText = "Close",
-                XamlRoot = Window.XamlRoot,
                 Content = new KeyQuestionsDialog()
             };
-            await _keyQuestionsDialog.ShowAsync();
+            await Ioc.Default.GetService<Windowing>().ShowContentDialog(_keyQuestionsDialog);
 
             Ioc.Default.GetRequiredService<KeyQuestionsViewModel>().NextQuestion();
             Logger.Log(LogLevel.Info, "KeyQuestions finished");
@@ -1158,12 +1154,11 @@ public class ShellViewModel : ObservableRecipient
 
             ContentDialog _dialog = new()
             {
-                XamlRoot = Window.XamlRoot,
                 Title = "Topic Information",
                 CloseButtonText = "Done",
                 Content = new TopicsDialog()
             };
-            await _dialog.ShowAsync();
+            await Window.ShowContentDialog(_dialog);
 
             _canExecuteCommands = true;
         }
@@ -1185,13 +1180,12 @@ public class ShellViewModel : ObservableRecipient
                 //Creates and shows content dialog
                 ContentDialog _dialog = new()
                 {
-                    XamlRoot = Window.XamlRoot,
                     Title = "Master plots",
                     PrimaryButtonText = "Copy",
                     SecondaryButtonText = "Cancel",
                     Content = new MasterPlotsDialog()
                 };
-                ContentDialogResult _result = await _dialog.ShowAsync();
+                ContentDialogResult _result = await Window.ShowContentDialog(_dialog);
 
                 if (_result == ContentDialogResult.Primary) // Copy command
                 {
@@ -1239,14 +1233,13 @@ public class ShellViewModel : ObservableRecipient
                 //Creates and shows dialog
                 ContentDialog _dialog = new()
                 {
-                    XamlRoot = Window.XamlRoot,
                     Title = "Dramatic situations",
                     PrimaryButtonText = "Copy as problem",
                     SecondaryButtonText = "Copy as scene",
                     CloseButtonText = "Cancel",
                     Content = new DramaticSituationsDialog()
                 };
-                ContentDialogResult _result = await _dialog.ShowAsync();
+                ContentDialogResult _result = await Window.ShowContentDialog(_dialog);
 
                 DramaticSituationModel _situationModel = Ioc.Default.GetRequiredService<DramaticSituationsViewModel>().Situation;
                 string _msg;
@@ -1297,9 +1290,8 @@ public class ShellViewModel : ObservableRecipient
                     Content = new StockScenesDialog(),
                     PrimaryButtonText = "Add Scene",
                     CloseButtonText = "Cancel",
-                    XamlRoot = Window.XamlRoot
                 };
-                ContentDialogResult _result = await _dialog.ShowAsync();
+                ContentDialogResult _result = await Window.ShowContentDialog(_dialog);
 
                 if (_result == ContentDialogResult.Primary) // Copy command
                 {
@@ -1839,7 +1831,7 @@ public class ShellViewModel : ObservableRecipient
             _newNode.Parent.IsExpanded = true;
             _newNode.IsRoot = false; //Only an overview node can be a root, which cant be created normally
             _newNode.IsSelected = false;
-            _newNode.Background = State.Preferences.ContrastColor;
+            _newNode.Background = Window.ContrastColor;
             NewNodeHighlightCache.Add(_newNode);
         }
         else { return null; }   
@@ -1889,16 +1881,15 @@ public class ShellViewModel : ObservableRecipient
             _content.Children.Add(new ListView { ItemsSource = _foundNodes, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center, Height = 300, Width = 480 });
 
             //Creates dialog and then shows it
-            _contentDialog = new()
+            ContentDialog _Dialog = new()
             {
-                XamlRoot = Window.XamlRoot,
                 Content = _content,
                 Title = "Are you sure you want to delete this node?",
                 Width = 500,
                 PrimaryButtonText = "Confirm",
                 SecondaryButtonText = "Cancel"
             };
-            if (await _contentDialog.ShowAsync() == ContentDialogResult.Secondary) { _delete = false; }
+            if (await Ioc.Default.GetRequiredService<Windowing>().ShowContentDialog(_Dialog)== ContentDialogResult.Secondary) { _delete = false; }
         }
 
 
@@ -2361,7 +2352,7 @@ public class ShellViewModel : ObservableRecipient
             if (Search.SearchStoryElement(_node, FilterText, StoryModel)) //checks if node name contains the thing we are looking for
             {
                 _searchTotal++;
-                if (Application.Current.RequestedTheme == ApplicationTheme.Light)
+                if (Window.RequestedTheme == ElementTheme.Light)
                 {
                     _node.Background = new SolidColorBrush(Colors.LightGoldenrodYellow);
                 }

--- a/StoryCADLib/ViewModels/Tools/NarrativeToolVM.cs
+++ b/StoryCADLib/ViewModels/Tools/NarrativeToolVM.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using StoryCAD.Models;
 using StoryCAD.Services.Dialogs.Tools;
@@ -81,12 +82,11 @@ public class NarrativeToolVM: ObservableRecipient
             {
                 ContentDialog _dialog = new()
                 {
-                    XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
                     Title = "Narrative Editor",
                     PrimaryButtonText = "Done",
                     Content = new NarrativeTool()
                 };
-                await _dialog.ShowAsync();
+                await Ioc.Default.GetService<Windowing>().ShowContentDialog(_dialog);
             }
             catch (Exception ex)
             {

--- a/StoryCADLib/ViewModels/Tools/PreferencesViewModel.cs
+++ b/StoryCADLib/ViewModels/Tools/PreferencesViewModel.cs
@@ -99,13 +99,6 @@ public class PreferencesViewModel : ObservableValidator
         set => SetProperty(ref _lastSelectedTemplate, value);
     }
 
-
-    // Visual changes
-
-    public SolidColorBrush PrimaryColor { get; set; } //Sets UI Color
-   
-    public SolidColorBrush SecondaryColor = new(new UISettings().GetColorValue(UIColorType.Accent)); //Sets Text Color
-    
     public TextWrapping WrapNodeNames { get; set; }
 
     // Backup Information
@@ -183,6 +176,12 @@ public class PreferencesViewModel : ObservableValidator
         set => PreferredSearchEngine = (BrowserType)value;
     } // Last version change was logged successfully or not
 
+    private ElementTheme PreferedTheme;
+    public int PreferredThemeIndex
+    {
+        get => (int)PreferedTheme;
+        set => PreferedTheme = (ElementTheme)value;
+    }
 
     #endregion
 
@@ -197,9 +196,6 @@ public class PreferencesViewModel : ObservableValidator
         Newsletter = CurrentModel.Newsletter;
         PreferencesInitialized = CurrentModel.PreferencesInitialized;
         LastSelectedTemplate = CurrentModel.LastSelectedTemplate;
-
-        PrimaryColor = CurrentModel.PrimaryColor;
-        SecondaryColor = CurrentModel.SecondaryColor;
         WrapNodeNames = CurrentModel.WrapNodeNames;
 
         LastFile1 = CurrentModel.LastFile1;
@@ -220,6 +216,7 @@ public class PreferencesViewModel : ObservableValidator
         RecordPreferencesStatus = CurrentModel.RecordPreferencesStatus;
         RecordVersionStatus = CurrentModel.RecordVersionStatus;
         PreferredSearchEngine = CurrentModel.PreferredSearchEngine;
+        PreferedTheme = CurrentModel.ThemePreference;
     }
 
     internal void SaveModel()
@@ -231,8 +228,6 @@ public class PreferencesViewModel : ObservableValidator
         CurrentModel.Newsletter = Newsletter;
         CurrentModel.PreferencesInitialized = PreferencesInitialized;
         CurrentModel.LastSelectedTemplate = LastSelectedTemplate;
-        CurrentModel.PrimaryColor = PrimaryColor;
-        CurrentModel.SecondaryColor = SecondaryColor;
         CurrentModel.WrapNodeNames = WrapNodeNames;
 
         CurrentModel.LastFile1 = LastFile1;
@@ -252,6 +247,13 @@ public class PreferencesViewModel : ObservableValidator
         CurrentModel.RecordPreferencesStatus = RecordPreferencesStatus;
         CurrentModel.RecordVersionStatus = RecordVersionStatus;
         CurrentModel.PreferredSearchEngine = PreferredSearchEngine;
+
+        if (CurrentModel.ThemePreference != PreferedTheme)
+        {
+            Ioc.Default.GetService<Windowing>().RequestedTheme = CurrentModel.ThemePreference;
+            Ioc.Default.GetService<Windowing>().UpdateUIToTheme();
+        }
+        CurrentModel.ThemePreference = PreferedTheme;
     }
 
     /// <summary>

--- a/StoryCADLib/ViewModels/Tools/PrintReportDialogVM.cs
+++ b/StoryCADLib/ViewModels/Tools/PrintReportDialogVM.cs
@@ -182,10 +182,9 @@ public class PrintReportDialogVM : ObservableRecipient
             Dialog = new()
             {
                 Title = "Generate Reports",
-                XamlRoot = Window.XamlRoot,
                 Content = new PrintReportsDialog()
             };
-            await Dialog.ShowAsync();
+            await Ioc.Default.GetService<Windowing>().ShowContentDialog(Dialog);
             ShellVM._canExecuteCommands = true;
 
         }
@@ -381,14 +380,13 @@ public class PrintReportDialogVM : ObservableRecipient
         if (args.Completion == PrintTaskCompletion.Failed) //Show message if print fails
         {
             //Use an enqueue here because the sample version doesn't use it properly (i think or it doesn't work here.)
-             ContentDialog cd = new()
+             ContentDialog Dialog = new()
              {
-                XamlRoot = Ioc.Default.GetRequiredService<Windowing>().XamlRoot,
                 Title = "Printing error",
                 Content = "An error occurred trying to print your document.",
                 PrimaryButtonText = "OK"
              };
-             await cd.ShowAsync();
+            await Window.ShowContentDialog(Dialog);
         }
 
         Window.GlobalDispatcher.TryEnqueue(() =>

--- a/StoryCADLib/ViewModels/WebViewModel.cs
+++ b/StoryCADLib/ViewModels/WebViewModel.cs
@@ -137,12 +137,11 @@ public class WebViewModel : ObservableRecipient, INavigable
         {
             Title = "Webview is missing.",
             Content = "This computer is missing the WebView2 Runtime, without it some features may not work.\nWould you like to install this now?",
-            XamlRoot = Window.XamlRoot,
             PrimaryButtonText = "Yes",
             SecondaryButtonText = "No"
         };
 
-        ContentDialogResult _result = await _dialog.ShowAsync();
+        ContentDialogResult _result = await Ioc.Default.GetService<Windowing>().ShowContentDialog(_dialog);
         _logger.Log(LogLevel.Error, $"User clicked {_result}");
 
         //Ok clicked
@@ -174,7 +173,7 @@ public class WebViewModel : ObservableRecipient, INavigable
                 .WaitForExitAsync();
 
             //Show success/fail dialog
-            ContentDialog _dialog = new() { PrimaryButtonText = "Ok", XamlRoot = Window.XamlRoot };
+            ContentDialog _dialog = new() { PrimaryButtonText = "Ok" };
             try
             {
                 _dialog.Title = "Webview installed!";
@@ -190,7 +189,7 @@ public class WebViewModel : ObservableRecipient, INavigable
                     $"An error occurred installing the Evergreen Webview Runtime ({_ex.Message})");
             }
 
-            await _dialog.ShowAsync();
+            await Ioc.Default.GetService<Windowing>().ShowContentDialog(_dialog);
             _logger.Log(LogLevel.Warn, "Finished installing webview runtime.");
         }
         catch (Exception _ex)


### PR DESCRIPTION
This PR fixes #624 and as such adds a theme option to StoryCAD to change the theme between three options
Light Theme, Dark Theme and Use System Theme.

The colors of these theme's haven't changed however how StoryCAD handles these colors has been massively reworked to support changing themes such as 
-Adding a helper function to automatically theme a given content dialog.
-Moving most if not all color related code from prefs to Windowing (excludes theme preference)

This should theoretically allow preference to set the shell color (primary color) in the future however this is not implemented, supported or planned currently.