### PR TITLE
Fix light theme, fix windowing warning.

### DIFF
--- a/StoryCAD/Views/Shell.xaml.cs
+++ b/StoryCAD/Views/Shell.xaml.cs
@@ -91,7 +91,7 @@ public sealed partial class Shell
         NavigationTree.SelectionMode = TreeViewSelectionMode.None;
         NavigationTree.SelectionMode = TreeViewSelectionMode.Single;
         (SplitViewFrame.Content as FrameworkElement).RequestedTheme = Windowing.RequestedTheme;
-        SplitViewFrame.Background = Windowing.RequestedTheme == ElementTheme.Light ? new SolidColorBrush(Colors.LightGray) : new SolidColorBrush(Colors.Black);
+        SplitViewFrame.Background = Windowing.RequestedTheme == ElementTheme.Light ? new SolidColorBrush(Colors.White) : new SolidColorBrush(Colors.Black);
         if (!(SplitViewFrame.Content as FrameworkElement).BaseUri.ToString().Contains("HomePage"))
         {
             (SplitViewFrame.Content as Page).Margin = new(0, 0, 0, 5);

--- a/StoryCADLib/Models/Windowing.cs
+++ b/StoryCADLib/Models/Windowing.cs
@@ -132,7 +132,7 @@ public class Windowing : ObservableRecipient
     /// This will update the elements of the UI to 
     /// match the theme set in RequestedTheme.
     /// </summary>
-    public void UpdateUIToTheme()
+    public async void UpdateUIToTheme()
     {
         (MainWindow.Content as FrameworkElement).RequestedTheme = RequestedTheme;
 
@@ -140,7 +140,7 @@ public class Windowing : ObservableRecipient
         //Save file, close current node since it won't be the right theme.
         if (ShellVM.StoryModel != null && ShellVM.DataSource != null && ShellVM.DataSource.Count > 0)
         {
-            Ioc.Default.GetRequiredService<ShellViewModel>().SaveFile();
+            await Ioc.Default.GetRequiredService<ShellViewModel>().SaveFile();
             Ioc.Default.GetRequiredService<ShellViewModel>().ShowHomePage();
         }
         }


### PR DESCRIPTION
This PR currently does two things
1 - Fixes the background of light theme, reverting it from light grey to just white as it should have been
2 - Fixes an issue with windowing where it didn't await a save file call, this has been fixed.

This PR does not fix warnings related to window.current being null as at this time I do not have the time or resources to investigate this however this doesn't appear (from a cursory glance at least) to be causing issues within the app. Irregardless of this these warnings should be fixed at some point in the near future (ideally before the release of 2.13).