### PR TITLE
Fix potential spacing issue in samples

### DIFF
--- a/StoryCAD/App.xaml.cs
+++ b/StoryCAD/App.xaml.cs
@@ -187,7 +187,6 @@ public partial class App
         mainWindow.Content = rootFrame;
         mainWindow.CenterOnScreen(); // Centers the window on the monitor
         mainWindow.Activate();
-        (mainWindow.Content as FrameworkElement).RequestedTheme = ElementTheme.Light;
         // Navigate to the first page:
         //   If we've not yet initialized Preferences, it's PreferencesInitialization.
         //   If we have initialized Preferences, it Shell.

--- a/StoryCADLib/Services/Dialogs/SamplePage.xaml
+++ b/StoryCADLib/Services/Dialogs/SamplePage.xaml
@@ -8,10 +8,12 @@
     Background="{x:Bind UnifiedVM.AdjustmentColor, Mode=OneWay}" Height="800">
 
     <StackPanel VerticalAlignment="Stretch" HorizontalAlignment="Center" Margin="0,0,70,0">
-        <InfoBar IsOpen="True" Severity="Warning" IsClosable="False" Width="300"
+        <InfoBar IsOpen="True" Severity="Warning" IsClosable="False" Width="350"
                  Message="Sample edits will be lost unless you use Save As to save them elsewhere."/>
         <TextBlock Text="Sample stories:" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="4" FontSize="25" />
-        <ListBox HorizontalAlignment="Center" VerticalAlignment="Center" Name="Samples" Width="200" Background="{x:Bind UnifiedVM.AdjustmentColor, Mode=OneWay}"/>
+        <ScrollViewer MaxHeight="350">
+            <ListBox HorizontalAlignment="Center" VerticalAlignment="Center" Name="Samples" Width="200" Background="{x:Bind UnifiedVM.AdjustmentColor, Mode=OneWay}"/>
+        </ScrollViewer>
         <Button HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="10" Click="LoadSample" Content="Open sample"/>
 
     </StackPanel>


### PR DESCRIPTION
This PR fixes a rare issue with the samples page cutting off the open sample button.

This fix also implements a fix that should prevent this from happening again.