### PR TITLE
Fix typo in lists

### DIFF
--- a/StoryCADLib/Assets/Install/Lists.ini
+++ b/StoryCADLib/Assets/Install/Lists.ini
@@ -12,7 +12,7 @@ Adventurous=Shy
 Adventurous=Timid
 
 [Aggressiveness]
-Aggressiveness=Aggressive/[Sub
+Aggressiveness=Aggressive
 Aggressiveness=Assaultive
 Aggressiveness=Combative
 Aggressiveness=Cringing


### PR DESCRIPTION
This PR fixes a typo in lists that appears to have some how gone unnoticed for roughly 2 years.
replaces Aggressive/[Sub  to just Aggressive

NOTE: this PR will fail due to issues with StoryCAD Tests