### PR TITLE
Remove Patreon References.

### DIFF
--- a/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
@@ -69,19 +69,13 @@
                             </Button.Content>
                         </Button>
 
-                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Twitter">
-                            <Button.Content>
-                                <Image Source="/Assets/Icons/TwitterIcon.png"/>
-                            </Button.Content>
-                        </Button>
+						<Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Twitter">
+							<Button.Content>
+								<Image Source="/Assets/Icons/TwitterIcon.png"/>
+							</Button.Content>
+						</Button>
 
-                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Patreon">
-                            <Button.Content>
-                                <Image Source="/Assets/Icons/PatreonIcon.png"/>
-                            </Button.Content>
-                        </Button>
-
-                        <Button Width="50" Height="50" Margin="5"  Click="OpenURL" Tag="Youtube">
+						<Button Width="50" Height="50" Margin="5"  Click="OpenURL" Tag="Youtube">
                             <Button.Content>
                                 <Image Source="/Assets/Icons/YoutubeIcon.png"/>
                             </Button.Content>

--- a/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml.cs
@@ -163,9 +163,6 @@ public sealed partial class PreferencesDialog
             case "FaceBook":
                 URL.FileName = "https://www.facebook.com/StoryCAD";
                 break;
-            case "Patreon":
-                URL.FileName = "https://www.patreon.com/storybuilder2";
-                break;
             case "Twitter":
                 URL.FileName = "https://twitter.com/StoryCAD";
                 break;


### PR DESCRIPTION
This PR remove a link to the StoryCAD Patreon from the about page as StoryBuilder-org no longer collects donations via patreon.
Users wishing to donate to StoryCAD can do so through the StoryBuilder websites Donation page.



![image](https://github.com/storybuilder-org/StoryCAD/assets/49795711/1b025632-9858-4e8c-a233-01234d72bc73)


