### PR TITLE
Update file writes.

### DIFF
--- a/StoryCADLib/Services/Dialogs/NewProjectPage.xaml
+++ b/StoryCADLib/Services/Dialogs/NewProjectPage.xaml
@@ -8,7 +8,8 @@
     Background="{x:Bind UnifiedVM.AdjustmentColor, Mode=OneWay}">
     <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="0,0,70,0">
         <TextBlock Text="New Project"  HorizontalAlignment="Center" FontSize="28" Margin="15"/>
-        <ComboBox  Header="Template:" MinWidth="220" SelectedIndex="{x:Bind UnifiedVM.SelectedTemplateIndex, Mode=TwoWay}" HorizontalAlignment="Center" Margin="0,20">
+		<ComboBox Header="Template:" MinWidth="220"  HorizontalAlignment="Center" Margin="0,20" 
+		          SelectedIndex="{x:Bind UnifiedVM.SelectedTemplateIndex, Mode=TwoWay}">
             <x:String>Blank Project</x:String>
             <x:String>Overview and Story Problem</x:String>
             <x:String>Folders</x:String>
@@ -17,11 +18,17 @@
             <x:String>Problems and Characters</x:String>
         </ComboBox>
 
-        <TextBox x:Name="ProjectPathName" HorizontalContentAlignment="Center" HorizontalAlignment="Center" Header="Project path:"  Text="{x:Bind UnifiedVM.ProjectPath, Mode=TwoWay}" Margin="5,20"/>
+		<!-- Project path and name boxes -->
+		<TextBox HorizontalContentAlignment="Center" PlaceholderText="You can't put files here"
+                 HorizontalAlignment="Center" Header="Project path:" 
+                 Text="{x:Bind UnifiedVM.ProjectPath, Mode=TwoWay}" Margin="5,20"/>
         <Button Content="Browse" Click="Browse_Click" HorizontalAlignment="Center"/>
 
-        <TextBox x:Name="ProjectName" x:FieldModifier="public" MinWidth="250" HorizontalAlignment="Center" Header="Project Name: " Text="{x:Bind UnifiedVM.ProjectName, Mode=TwoWay}" Margin="0,20"/>
+        <TextBox x:Name="ProjectName" x:FieldModifier="public" MinWidth="250" 
+                 HorizontalAlignment="Center" Header="Project Name: "
+                 Text="{x:Bind UnifiedVM.ProjectName, Mode=TwoWay}" Margin="0,20"/>
 
-        <Button Content="Create project" Margin="5,20" HorizontalAlignment="Center" Click="CheckValidity"/>
+		<Button Content="Create project" Margin="5,20" HorizontalAlignment="Center" 
+		        Click="{x:Bind UnifiedVM.CheckValidity}"/>
     </StackPanel>
 </Page>

--- a/StoryCADLib/Services/Dialogs/NewProjectPage.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/NewProjectPage.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Runtime.InteropServices;
 using Windows.Storage;
 using Windows.Storage.Pickers;
@@ -7,16 +6,10 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using StoryCAD.ViewModels;
 using WinRT;
-using System.Text.RegularExpressions;
-using CommunityToolkit.Mvvm.DependencyInjection;
-using StoryCAD.Services.Logging;
-
 namespace StoryCAD.Services.Dialogs;
 
 public sealed partial class NewProjectPage : Page
 {
-	LogService Logger = Ioc.Default.GetRequiredService<LogService>();
-
     public NewProjectPage(UnifiedVM vm)
     {
         InitializeComponent();
@@ -71,58 +64,4 @@ public sealed partial class NewProjectPage : Page
 
     [DllImport("user32.dll", ExactSpelling = true, CharSet = CharSet.Auto, PreserveSig = true, SetLastError = false)]
     public static extern IntPtr GetActiveWindow();
-
-    private void CheckValidity(object sender, RoutedEventArgs e)
-    {
-	    Logger.Log(LogLevel.Info, $"Testing filename validity for {ProjectFolderPath}\\{ProjectName}");
-
-		//Checks file path validity
-		try { Directory.CreateDirectory(ProjectPathName.Text); }
-        catch
-        {
-            ProjectPathName.Text = "";
-            ProjectPathName.PlaceholderText = "You can't put files here!";
-            return;
-        }
-
-        //Checks file name validity
-        //NOTE: File.Create() Strips out anything past an illegal character
-        //(or throws an exception if it's just an illegal character)
-        try
-        {
-            string testfile = Path.Combine(ProjectPathName.Text, ProjectName.Text);
-            var x = Path.GetInvalidPathChars();
-            //Check validity
-            Regex BadChars = new("[" + Regex.Escape(Path.GetInvalidPathChars().ToString()) + "]");
-            if (BadChars.IsMatch(testfile))
-            {
-                throw new FileNotFoundException("the filename is invalid.");
-            }
-
-            //Try creating file and then checking it exists.
-            using (FileStream fs = File.Create(testfile)) { }
-
-            if (!File.Exists(testfile))
-                throw new FileNotFoundException("the filename was not found.");
-	        File.Delete(testfile);
-
-        }
-        catch (UnauthorizedAccessException)
-        {
-	        Logger.Log(LogLevel.Warn, $"User lacks access to {ProjectFolderPath}");
-			//Set path to users documents if they try to save to an invalid location
-			UnifiedVM.ProjectPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-			ProjectFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-			ProjectPathName.Text = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-	        return;
-        }
-		catch
-        {
-			ProjectName.Text = "";
-            ProjectName.PlaceholderText = "You can't call your file that!";
-            return;
-        }
-
-        UnifiedVM.MakeProject();
-    }
 }

--- a/StoryCADLib/Services/Dialogs/NewProjectPage.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/NewProjectPage.xaml.cs
@@ -111,12 +111,14 @@ public sealed partial class NewProjectPage : Page
         {
 	        Logger.Log(LogLevel.Warn, $"User lacks access to {ProjectFolderPath}");
 			//Set path to users documents if they try to save to an invalid location
+			UnifiedVM.ProjectPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 			ProjectFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+			ProjectPathName.Text = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 	        return;
         }
 		catch
         {
-            ProjectName.Text = "";
+			ProjectName.Text = "";
             ProjectName.PlaceholderText = "You can't call your file that!";
             return;
         }

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -912,7 +912,7 @@ public class ShellViewModel : ObservableRecipient
     /// </summary>|
     public async Task WriteModel()
     {
-        Logger.Log(LogLevel.Info, $"In WriteModel, file={StoryModel.ProjectFilename}");
+        Logger.Log(LogLevel.Info, $"In WriteModel, file={StoryModel.ProjectFilename} path={StoryModel.ProjectPath}");
         try
         {
             try //Updating the lost modified time
@@ -936,7 +936,8 @@ public class ShellViewModel : ObservableRecipient
         }
         catch (Exception _ex)
         {
-            Logger.LogException(LogLevel.Error, _ex, "Error writing file");
+            Logger.LogException(LogLevel.Error, _ex, 
+	            $"Error writing file {_ex.Message} {_ex.Source}");
             Messenger.Send(new StatusChangedMessage(new("Error writing file - see log", LogLevel.Error)));
             return;
         }

--- a/StoryCADLib/ViewModels/UnifiedVM.cs
+++ b/StoryCADLib/ViewModels/UnifiedVM.cs
@@ -84,6 +84,12 @@ public class UnifiedVM : ObservableRecipient
         SelectedRecentIndex = -1;
         ProjectName = string.Empty;
         ProjectPath = Ioc.Default.GetRequiredService<PreferenceService>().Model.ProjectDirectory;
+
+        if (!Ioc.Default.GetRequiredService<AppState>().StoryCADTestsMode)
+        {
+	        ContentView = new();
+
+        }
     }
 
     public UnifiedMenuPage.UpdateContentDelegate UpdateContent;
@@ -100,7 +106,7 @@ public class UnifiedVM : ObservableRecipient
     /// This controls the frame and sets it content.
     /// </summary>
     /// <returns></returns>
-    private StackPanel _contentView = new();
+    private StackPanel _contentView;
     public StackPanel ContentView
     {
         get => _contentView;

--- a/StoryCADTests/App.xaml.cs
+++ b/StoryCADTests/App.xaml.cs
@@ -41,20 +41,20 @@ public partial class App : Application
     {
         _log.Log(LogLevel.Info, "StoryCADTests.App launched");
         AppState State = Ioc.Default.GetRequiredService<AppState>();
-        await Ioc.Default.GetRequiredService<StoryCAD.Services.PreferenceService>().LoadPreferences();
+        await Ioc.Default.GetRequiredService<PreferenceService>().LoadPreferences();
 
         string pathMsg = string.Format("Configuration data location = " + State.RootDirectory);
         _log.Log(LogLevel.Info, pathMsg);
 
-        Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.CreateDefaultUI();
-        Window = new MainWindow();
-        // Ensure the current window is active
-        Window.Activate();
-        UITestMethodAttribute.DispatcherQueue = Window.DispatcherQueue;
+		Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.CreateDefaultUI();
+		Window = new MainWindow();
+		// Ensure the current window is active
+		Window.Activate();
+		UITestMethodAttribute.DispatcherQueue = Window.DispatcherQueue;
 
 
-        // Replace back with e.Arguments when https://github.com/microsoft/microsoft-ui-xaml/issues/3368 is fixed
-        Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.Run(Environment.CommandLine);
+		// Replace back with e.Arguments when https://github.com/microsoft/microsoft-ui-xaml/issues/3368 is fixed
+		Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.Run(Environment.CommandLine);
     }
 
     private void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)

--- a/StoryCADTests/FileTests.cs
+++ b/StoryCADTests/FileTests.cs
@@ -4,11 +4,11 @@ using StoryCAD.DAL;
 using StoryCAD.Models;
 using StoryCAD.ViewModels;
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Storage;
-using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
 
 namespace StoryCADTests;
 
@@ -95,7 +95,7 @@ public class FileTests
     }
 
 
-    [UITestMethod]
+    [TestMethod]
     public Task InvalidFileAccessTest()
     {
 	    string Dir = AppDomain.CurrentDomain.BaseDirectory;

--- a/StoryCADTests/FileTests.cs
+++ b/StoryCADTests/FileTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Storage;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
 
 namespace StoryCADTests;
 
@@ -93,4 +94,22 @@ public class FileTests
         Assert.AreEqual(5, storyModel.ExplorerView.Count, "Overview Children count mismatch"); 
     }
 
+
+    [UITestMethod]
+    public Task InvalidFileAccessTest()
+    {
+	    string Dir = AppDomain.CurrentDomain.BaseDirectory;
+	    UnifiedVM UVM = new()
+	    {
+		    ProjectName = "TestProject",
+		    ProjectPath = Path.Combine(Dir, "TestProject")
+	    };
+
+		//Check file path validity
+		UVM.CheckValidity(null,null);
+
+	    //Check Project Path was reset to default.
+		Assert.IsTrue(UVM.ProjectPath == Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
+		return null;
+    }
 }


### PR DESCRIPTION
This PR changes 2 things 
 - Updates code in WriteModel() to increase logging about the path the file is written to
 - Adds code within FileCreation to block creating a file if the user doesn't have access rights to it; if a user tries to create a outline with an invalid file path then it is blocked and the parent folder is set to the users documents from this they can then either change the parent folder again or press the create file button again to create the outline in docs folder.
fixes #725, 
fixes #726