### PR TITLE
Remove SyncFusion

### DIFF
--- a/ACKNOWLEDGE.md
+++ b/ACKNOWLEDGE.md
@@ -16,6 +16,7 @@ and we'll rectify that.
 * Mylo
 * Tina
 * Tim        
+* Syncfusion
 
 ## Software
 
@@ -27,10 +28,12 @@ StoryCAD uses or links to the following software:
 * [Elmah.io][4]
 * [NRtfTree][5]
 * [Scrivener][6]
-* [SyncFusion][7]
 
-We are especially grateful to elmah.io and Syncfusion, commercial products who make their
+We are especially grateful to elmah.io commercial products who make their
 livelihood freely available to public open source projects like ours.
+
+(StoryCAD Versions before 2.14.2 relied on SyncFusion Controls and we are 
+eternally greatful for their support.)
 
 ## Origins
 

--- a/StoryCAD/App.xaml.cs
+++ b/StoryCAD/App.xaml.cs
@@ -17,25 +17,17 @@ using StoryCAD.Services.Logging;
 using StoryCAD.Services.Navigation;
 using StoryCAD.ViewModels;
 using StoryCAD.Views;
-using Syncfusion.Licensing;
 using WinUIEx;
 using AppInstance = Microsoft.Windows.AppLifecycle.AppInstance;
 using UnhandledExceptionEventArgs = Microsoft.UI.Xaml.UnhandledExceptionEventArgs;
 using Windows.ApplicationModel.Activation;
-using K4os.Hash.xxHash;
 using Microsoft.UI.Xaml;
 using StoryCAD.DAL;
 using LaunchActivatedEventArgs = Microsoft.UI.Xaml.LaunchActivatedEventArgs;
-using System.Globalization;
-using System.Reflection;
-    using System.Runtime.Loader;
-    using StoryCAD.Services.IoC;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI;
+using StoryCAD.Services.IoC;
 using StoryCAD.Services;
-using StoryCAD.Services.Collaborator;
 
-    namespace StoryCAD;
+namespace StoryCAD;
 
 public partial class App
 {
@@ -81,10 +73,6 @@ public partial class App
         try
         {
             DotEnv.Load(options);
-
-            //Register Syncfusion license
-            string token = EnvReader.GetStringValue("SYNCFUSION_TOKEN");
-            SyncfusionLicenseProvider.RegisterLicense(token);
             Ioc.Default.GetRequiredService<AppState>().EnvPresent = true;
         }
         catch { }

--- a/StoryCAD/StoryCAD.csproj
+++ b/StoryCAD/StoryCAD.csproj
@@ -47,7 +47,6 @@
 		<PackageReference Include="NLog" Version="5.3.2" />
 		<PackageReference Include="NLog.Extensions.Logging" Version="5.3.11" />
 		<PackageReference Include="PInvoke.User32" Version="0.7.124" />
-		<PackageReference Include="Syncfusion.Editors.WinUI" Version="26.1.35" />
 		<PackageReference Include="WinUIEx" Version="2.3.4" />
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>

--- a/StoryCAD/Views/CharacterPage.xaml
+++ b/StoryCAD/Views/CharacterPage.xaml
@@ -2,7 +2,6 @@
     x:Class="StoryCAD.Views.CharacterPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:editors="using:Syncfusion.UI.Xaml.Editors"
     xmlns:local="using:StoryCAD.Views"
     xmlns:usercontrols="using:StoryCAD.Controls"
     xmlns:viewModels="using:StoryCAD.ViewModels">
@@ -24,9 +23,9 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    <editors:SfComboBox IsEditable="True" Header="Role" Grid.Row="0"  MinWidth="200" ItemsSource="{x:Bind CharVm.RoleList}" Text="{x:Bind CharVm.Role, Mode=TwoWay}" />
-                    <editors:SfComboBox Header="Story Role" Grid.Row="1" IsEditable="False" MinWidth="200" ItemsSource="{x:Bind CharVm.StoryRoleList}" SelectedItem="{x:Bind CharVm.StoryRole, Mode=TwoWay}" />
-                    <editors:SfComboBox Header="Archetype" Grid.Row="2" IsEditable="False" MinWidth="200" ItemsSource="{x:Bind CharVm.ArchetypeList}" SelectedItem="{x:Bind CharVm.Archetype, Mode=TwoWay}" />
+                    <ComboBox IsEditable="True" Header="Role" Grid.Row="0"  MinWidth="200" ItemsSource="{x:Bind CharVm.RoleList}" Text="{x:Bind CharVm.Role, Mode=TwoWay}" />
+                    <ComboBox Header="Story Role" Grid.Row="1" IsEditable="False" MinWidth="200" ItemsSource="{x:Bind CharVm.StoryRoleList}" SelectedItem="{x:Bind CharVm.StoryRole, Mode=TwoWay}" />
+                    <ComboBox Header="Archetype" Grid.Row="2" IsEditable="False" MinWidth="200" ItemsSource="{x:Bind CharVm.ArchetypeList}" SelectedItem="{x:Bind CharVm.Archetype, Mode=TwoWay}" />
                     <usercontrols:RichEditBoxExtended Header="Character Sketch" Grid.Row="3" RtfText="{x:Bind CharVm.CharacterSketch, Mode=TwoWay}" AcceptsReturn="True" IsSpellCheckEnabled="True" TextWrapping="Wrap" ScrollViewer.VerticalScrollBarVisibility="Visible" />
                 </Grid>
             </PivotItem>
@@ -71,11 +70,11 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <editors:SfComboBox IsEditable="True" Header="Eye Color" Grid.Column="0" MinWidth="200"
+                        <ComboBox IsEditable="True" Header="Eye Color" Grid.Column="0" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.EyesList}"
                                   Text="{x:Bind CharVm.Eyes, Mode=TwoWay}" />
                         <TextBlock Grid.Column="1" MinWidth="100"/>
-                        <editors:SfComboBox IsEditable="True" Header="Hair Color" Grid.Column="2"  MinWidth="200"
+                        <ComboBox IsEditable="True" Header="Hair Color" Grid.Column="2"  MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.HairList}"
                                   Text="{x:Bind CharVm.Hair, Mode=TwoWay}" />
                     </Grid>
@@ -85,11 +84,11 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <editors:SfComboBox IsEditable="True" Header="Build" Grid.Column="0" MinWidth="200"
+                        <ComboBox IsEditable="True" Header="Build" Grid.Column="0" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.BuildList}"
                                   Text="{x:Bind CharVm.Build, Mode=TwoWay}" />
                         <TextBlock Grid.Column="1" MinWidth="100"/>
-                        <editors:SfComboBox IsEditable="True" Header="Complexion" Grid.Column="2" MinWidth="200"
+                        <ComboBox IsEditable="True" Header="Complexion" Grid.Column="2" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.SkinList}"
                                   Text="{x:Bind CharVm.Complexion, Mode=TwoWay}" />
                     </Grid>
@@ -99,11 +98,11 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <editors:SfComboBox IsEditable="True" Header="Race" Grid.Column="0"  MinWidth="200"
+                        <ComboBox IsEditable="True" Header="Race" Grid.Column="0"  MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.RaceList}"
                                   Text="{x:Bind CharVm.Race, Mode=TwoWay}" />
                         <TextBlock Grid.Column="1" MinWidth="100"/>
-                        <editors:SfComboBox IsEditable="True" Header="Nationality" Grid.Column="2" MinWidth="200"
+                        <ComboBox IsEditable="True" Header="Nationality" Grid.Column="2" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.NationalityList}"
                                   Text="{x:Bind CharVm.Nationality, Mode=TwoWay}"/>
                     </Grid>
@@ -185,7 +184,7 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <Grid Grid.Row="0" HorizontalAlignment="Left">
-                        <editors:SfComboBox Header="Personality Type" IsEditable="False" Width="200" ItemsSource="{x:Bind CharVm.EnneagramList}"
+                        <ComboBox Header="Personality Type" IsEditable="False" Width="200" ItemsSource="{x:Bind CharVm.EnneagramList}"
                               SelectedValue="{x:Bind CharVm.Enneagram, Mode=TwoWay}" />
                     </Grid>
                     <Grid Grid.Row="1" HorizontalAlignment="Left">
@@ -194,11 +193,11 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <editors:SfComboBox IsEditable="True" Header="Intelligence"  Grid.Column="0" Width="200"
+                        <ComboBox IsEditable="True" Header="Intelligence"  Grid.Column="0" Width="200"
                                   ItemsSource="{x:Bind CharVm.IntelligenceList}"
                                   Text="{x:Bind CharVm.Intelligence, Mode=TwoWay}" />
                         <TextBlock Width="100"  Grid.Column="1" />
-                        <editors:SfComboBox IsEditable="True" Header="Values"  Grid.Column="2"  Width="200"
+                        <ComboBox IsEditable="True" Header="Values"  Grid.Column="2"  Width="200"
                                   ItemsSource="{x:Bind CharVm.ValuesList}"
                                   Text="{x:Bind CharVm.Values, Mode=TwoWay}" />
                     </Grid>
@@ -208,11 +207,11 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <editors:SfComboBox IsEditable="True" Header="Focus"  Grid.Column="0" Width="200"
+                        <ComboBox IsEditable="True" Header="Focus"  Grid.Column="0" Width="200"
                                   ItemsSource="{x:Bind CharVm.FocusList}"
                                   Text="{x:Bind CharVm.Focus, Mode=TwoWay}" />
                         <TextBlock Width="100"  Grid.Column="1" />
-                        <editors:SfComboBox IsEditable="True" Header="Abnormality"  Grid.Column="2"  Width="200"
+                        <ComboBox IsEditable="True" Header="Abnormality"  Grid.Column="2"  Width="200"
                                   ItemsSource="{x:Bind CharVm.AbnormalityList}"
                                   Text="{x:Bind CharVm.Abnormality, Mode=TwoWay}" />
                     </Grid>
@@ -237,41 +236,41 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
-                    <editors:SfComboBox IsEditable="True" Header="Adventureousness" Grid.Column="0" Grid.Row="0"  MinWidth="200"
+                    <ComboBox IsEditable="True" Header="Adventureousness" Grid.Column="0" Grid.Row="0"  MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.AdventurousnessList}"
                                   Text="{x:Bind CharVm.Adventurousness, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Confidence" Grid.Column="0" Grid.Row="1" MinWidth="200"
+                    <ComboBox IsEditable="True" Header="Confidence" Grid.Column="0" Grid.Row="1" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.ConfidenceList}"
                                   Text="{x:Bind CharVm.Confidence, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Creativity" Grid.Column="0" Grid.Row="2" MinWidth="200" 
+                    <ComboBox IsEditable="True" Header="Creativity" Grid.Column="0" Grid.Row="2" MinWidth="200" 
                                   ItemsSource="{x:Bind CharVm.CreativityList}"
                                   Text="{x:Bind CharVm.Creativity, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Enthusiasm" Grid.Column="0" Grid.Row="3"  MinWidth="200"
+                    <ComboBox IsEditable="True" Header="Enthusiasm" Grid.Column="0" Grid.Row="3"  MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.EnthusiasmList}"
                                   Text="{x:Bind CharVm.Enthusiasm, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Sensitivity" Grid.Column="0" Grid.Row="4" MinWidth="200"
+                    <ComboBox IsEditable="True" Header="Sensitivity" Grid.Column="0" Grid.Row="4" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.SensitivityList}"
                                   Text="{x:Bind CharVm.Sensitivity, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Sociability" Grid.Column="0" Grid.Row="5" MinWidth="200"
+                    <ComboBox IsEditable="True" Header="Sociability" Grid.Column="0" Grid.Row="5" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.SociabilityList}"
                                   Text="{x:Bind CharVm.Sociability, Mode=TwoWay}" />
                     <TextBlock Grid.Column="1" Grid.Row="0" MinWidth="100"/>
-                    <editors:SfComboBox IsEditable="True" Header="Aggression" Grid.Column="2" Grid.Row="0" MinWidth="200"
+                    <ComboBox IsEditable="True" Header="Aggression" Grid.Column="2" Grid.Row="0" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.AggressionList}"
                                   Text="{x:Bind CharVm.Aggression, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Conscientiousness" Grid.Column="2" Grid.Row="1" MinWidth="200"
+                    <ComboBox IsEditable="True" Header="Conscientiousness" Grid.Column="2" Grid.Row="1" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.ConscientiousnessList}"
                                   Text="{x:Bind CharVm.Conscientiousness, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Dominance" Grid.Column="2" Grid.Row="2" MinWidth="200" 
+                    <ComboBox IsEditable="True" Header="Dominance" Grid.Column="2" Grid.Row="2" MinWidth="200" 
                                   ItemsSource="{x:Bind CharVm.DominanceList}"
                                   Text="{x:Bind CharVm.Dominance, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Self Assurance" Grid.Column="2" Grid.Row="3" MinWidth="200"
+                    <ComboBox IsEditable="True" Header="Self Assurance" Grid.Column="2" Grid.Row="3" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.AssuranceList}"
                                   Text="{x:Bind CharVm.Assurance, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Shrewdness" Grid.Column="2" Grid.Row="4" MinWidth="200"
+                    <ComboBox IsEditable="True" Header="Shrewdness" Grid.Column="2" Grid.Row="4" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.ShrewdnessList}"
                                   Text="{x:Bind CharVm.Shrewdness, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Stability" Grid.Column="2" Grid.Row="5" MinWidth="200"
+                    <ComboBox IsEditable="True" Header="Stability" Grid.Column="2" Grid.Row="5" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.StabilityList}"
                                   Text="{x:Bind CharVm.Stability, Mode=TwoWay}" />
                 </Grid>

--- a/StoryCAD/Views/OverviewPage.xaml
+++ b/StoryCAD/Views/OverviewPage.xaml
@@ -1,8 +1,7 @@
 <usercontrols:BindablePage NavigationCacheMode="Required"
     x:Class="StoryCAD.Views.OverviewPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:editors="using:Syncfusion.UI.Xaml.Editors"                    
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"                  
     xmlns:local="using:StoryCAD.Views"
     xmlns:usercontrols="using:StoryCAD.Controls" >
 
@@ -81,11 +80,11 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <editors:SfComboBox Header="Type" Grid.Column="0" IsEditable="False" MinWidth="200"
+                        <ComboBox Header="Type" Grid.Column="0" IsEditable="False" MinWidth="200"
                                   ItemsSource="{x:Bind OverviewVm.StoryTypeList}"
                                   SelectedItem="{x:Bind OverviewVm.StoryType, Mode=TwoWay}" />
                         <TextBlock Grid.Column="1" MinWidth="100"/>
-                        <editors:SfComboBox Header="Genre" Grid.Column="2" IsEditable="False" MinWidth="200"
+                        <ComboBox Header="Genre" Grid.Column="2" IsEditable="False" MinWidth="200"
                                   ItemsSource="{x:Bind OverviewVm.GenreList}"
                                   SelectedItem="{x:Bind OverviewVm.StoryGenre, Mode=TwoWay}" />
                     </Grid>
@@ -95,11 +94,11 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <editors:SfComboBox Header="Viewpoint" Grid.Column="0" IsEditable="False" MinWidth="200" 
+                        <ComboBox Header="Viewpoint" Grid.Column="0" IsEditable="False" MinWidth="200" 
                                   ItemsSource="{x:Bind OverviewVm.ViewpointList}"
                                   SelectedItem="{x:Bind OverviewVm.Viewpoint, Mode=TwoWay}" BorderThickness="1" />
                         <TextBlock Grid.Column="1" MinWidth="100"/>
-                        <editors:SfComboBox Header="Literary Technique" IsEditable="False" Grid.Column="2" MinWidth="200" 
+                        <ComboBox Header="Literary Technique" IsEditable="False" Grid.Column="2" MinWidth="200" 
                                   ItemsSource="{x:Bind OverviewVm.LiteraryTechniqueList}"
                                   SelectedItem="{x:Bind OverviewVm.LiteraryTechnique, Mode=TwoWay}" />
                     </Grid>
@@ -112,11 +111,11 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <editors:SfComboBox Header="Voice" Grid.Column="0" IsEditable="False" MinWidth="200" 
+                        <ComboBox Header="Voice" Grid.Column="0" IsEditable="False" MinWidth="200" 
                                   ItemsSource="{x:Bind OverviewVm.VoiceList}"
                                   SelectedItem="{x:Bind OverviewVm.Voice, Mode=TwoWay}" />
                         <TextBlock Grid.Column="1" MinWidth="100"/>
-                        <editors:SfComboBox Header="Tense" Grid.Column="2" IsEditable="False" MinWidth="200" 
+                        <ComboBox Header="Tense" Grid.Column="2" IsEditable="False" MinWidth="200" 
                                   ItemsSource="{x:Bind OverviewVm.TenseList}"
                                   SelectedItem="{x:Bind OverviewVm.Tense, Mode=TwoWay}" />
                     </Grid>
@@ -126,11 +125,11 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="2*"/>
                     </Grid.ColumnDefinitions>
-                        <editors:SfComboBox Header="Style" Grid.Column="0" IsEditable="False" MinWidth="200" 
+                        <ComboBox Header="Style" Grid.Column="0" IsEditable="False" MinWidth="200" 
                                   ItemsSource="{x:Bind OverviewVm.StyleList}"
                                   SelectedItem="{x:Bind OverviewVm.Style, Mode=TwoWay}" />
                         <TextBlock Grid.Column="1" MinWidth="100"/>
-                        <editors:SfComboBox Header="Tone" Grid.Column="2" IsEditable="False" MinWidth="200"  
+                        <ComboBox Header="Tone" Grid.Column="2" IsEditable="False" MinWidth="200"  
                                   ItemsSource="{x:Bind OverviewVm.ToneList}"
                                   SelectedItem="{x:Bind OverviewVm.Tone, Mode=TwoWay}" />
                     </Grid>

--- a/StoryCAD/Views/OverviewPage.xaml.cs
+++ b/StoryCAD/Views/OverviewPage.xaml.cs
@@ -8,6 +8,7 @@ public sealed partial class OverviewPage : BindablePage
 {
 
     public OverviewViewModel OverviewVm => Ioc.Default.GetService<OverviewViewModel>();
+    public ShellViewModel ShellVM => Ioc.Default.GetService<ShellViewModel>();
 
     public OverviewPage()
     {

--- a/StoryCAD/Views/ProblemPage.xaml
+++ b/StoryCAD/Views/ProblemPage.xaml
@@ -1,8 +1,7 @@
 ﻿<usercontrols:BindablePage NavigationCacheMode="Required"
     x:Class="StoryCAD.Views.ProblemPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:editors="using:Syncfusion.UI.Xaml.Editors"                    
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"               
     xmlns:local="using:StoryCAD.Views"
     xmlns:usercontrols="using:StoryCAD.Controls"
     xmlns:viewModels="using:StoryCAD.ViewModels">
@@ -31,25 +30,25 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <editors:SfComboBox Grid.Column="0" IsEditable="True" Header="Problem Type" Grid.Row="0"  MinWidth="200"
+                        <ComboBox Grid.Column="0" IsEditable="True" Header="Problem Type" Grid.Row="0"  MinWidth="200"
                               ItemsSource="{x:Bind ProblemVm.ProblemTypeList}"
                               Text="{x:Bind ProblemVm.ProblemType, Mode=TwoWay}" />
                         <TextBlock Grid.Column="1" Grid.Row="0" MinWidth="300"/>
-                        <editors:SfComboBox Grid.Column="2" IsEditable="True" Header="Conflict Type" Grid.Row="0"  MinWidth="200"
+                        <ComboBox Grid.Column="2" IsEditable="True" Header="Conflict Type" Grid.Row="0"  MinWidth="200"
                                     ItemsSource="{x:Bind ProblemVm.ConflictTypeList}"
                                     Text="{x:Bind ProblemVm.ConflictType, Mode=TwoWay}" />
                     </Grid>
-                    <editors:SfComboBox IsEditable="True" Header="Problem Category" Grid.Row="1" MinWidth="300"
+                    <ComboBox IsEditable="True" Header="Problem Category" Grid.Row="1" MinWidth="300"
                                         ItemsSource="{x:Bind ProblemVm.ProblemCategoryList}"
                                         Text="{x:Bind ProblemVm.ProblemCategory, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Subject" Grid.Row="2" MinWidth="300"
+                    <ComboBox IsEditable="True" Header="Subject" Grid.Row="2" MinWidth="300"
                                     ItemsSource="{x:Bind ProblemVm.SubjectList}"
                                     Text="{x:Bind ProblemVm.Subject, Mode=TwoWay}" />
                     <usercontrols:RichEditBoxExtended Header="Story Question" Grid.Row="3"
                                                           RtfText="{x:Bind ProblemVm.StoryQuestion, Mode=TwoWay}" AcceptsReturn="True"
                                                           IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                           ScrollViewer.VerticalScrollBarVisibility="Visible" />
-                    <editors:SfComboBox IsEditable="True" Header="Problem Source" Grid.Row="4" MinWidth="300"
+                    <ComboBox IsEditable="True" Header="Problem Source" Grid.Row="4" MinWidth="300"
                                     ItemsSource="{x:Bind ProblemVm.ProblemSourceList}"
                                     Text="{x:Bind ProblemVm.ProblemSource, Mode=TwoWay}" />
                 </Grid>
@@ -66,10 +65,10 @@
                     <usercontrols:CharacterName Header="Protagonist" Grid.Row="0" IsEditable="False" MinWidth="300"
                               DisplayMemberPath="Name"
                               SelectedItem="{x:Bind ProblemVm.Protagonist, Mode=TwoWay, Converter={StaticResource ToStoryElement}}" />
-                    <editors:SfComboBox IsEditable="True" Header="Goal" Grid.Row="1" 
+                    <ComboBox IsEditable="True" Header="Goal" Grid.Row="1" 
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.GoalList}"
                               Text="{x:Bind ProblemVm.ProtGoal, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Motivation" Grid.Row="2" 
+                    <ComboBox IsEditable="True" Header="Motivation" Grid.Row="2" 
                                     MinWidth="300" ItemsSource="{x:Bind ProblemVm.MotiveList}"
                                     Text="{x:Bind ProblemVm.ProtMotive, Mode=TwoWay}" />
                     <Button  Content="Conflict Builder" Grid.Row="3" HorizontalAlignment="Left" Margin="0,10,10,10" 
@@ -92,10 +91,10 @@
                     <usercontrols:CharacterName Header="Antagonist" Grid.Row="0" IsEditable="False" MinWidth="300"
                               DisplayMemberPath="Name"
                               SelectedItem="{x:Bind ProblemVm.Antagonist, Mode=TwoWay, Converter={StaticResource ToStoryElement}}" />
-                    <editors:SfComboBox IsEditable="True" Header="Goal" Grid.Row="1" 
+                    <ComboBox IsEditable="True" Header="Goal" Grid.Row="1" 
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.GoalList}"
                               Text="{x:Bind ProblemVm.AntagGoal, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Motivation" Grid.Row="2" 
+                    <ComboBox IsEditable="True" Header="Motivation" Grid.Row="2" 
                               MinWidth="300" ItemsSource="{x:Bind ProblemVm.MotiveList}"
                               Text="{x:Bind ProblemVm.AntagMotive, Mode=TwoWay}" />
                     <Button  Content="Conflict Builder" Grid.Row="3" HorizontalAlignment="Left" Margin="0,10,10,10" 
@@ -114,13 +113,13 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    <editors:SfComboBox IsEditable="True" Header="Outcome" Grid.Row="0" 
+                    <ComboBox IsEditable="True" Header="Outcome" Grid.Row="0" 
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.OutcomeList}"
                               Text="{x:Bind ProblemVm.Outcome, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Method" Grid.Row="1" 
+                    <ComboBox IsEditable="True" Header="Method" Grid.Row="1" 
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.MethodList}"
                               Text="{x:Bind ProblemVm.Method, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Theme" Grid.Row="2" 
+                    <ComboBox IsEditable="True" Header="Theme" Grid.Row="2" 
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.ThemeList}"
                               Text="{x:Bind ProblemVm.Theme, Mode=TwoWay}" />
                     <usercontrols:RichEditBoxExtended Header="Premise" Grid.Row="3"

--- a/StoryCAD/Views/ScenePage.xaml
+++ b/StoryCAD/Views/ScenePage.xaml
@@ -5,8 +5,7 @@
     xmlns:local="using:StoryCAD.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:models="using:StoryCAD.Models"
-    xmlns:editors="using:Syncfusion.UI.Xaml.Editors"                    
+    xmlns:models="using:StoryCAD.Models"            
     xmlns:usercontrols="using:StoryCAD.Controls"
     xmlns:system="using:System"
     xmlns:viewModels="using:StoryCAD.ViewModels"
@@ -68,7 +67,7 @@
                              DisplayMemberPath="Name"
                              SelectedItem="{x:Bind SceneVm.Setting, Mode=TwoWay, Converter={StaticResource ToStoryElement}}"/>
                         <TextBlock Grid.Column="1" MinWidth="50"/>
-                        <editors:SfComboBox IsEditable="True" Header="SceneType" Grid.Column="2" MinWidth="200"
+                        <ComboBox IsEditable="True" Header="SceneType" Grid.Column="2" MinWidth="200"
                                             ItemsSource="{x:Bind SceneVm.SceneTypeList}"
                                             Text="{x:Bind SceneVm.SceneType, Mode=TwoWay}" />
                     </Grid>
@@ -143,7 +142,7 @@
                             </ListView.ItemTemplate>
                         </ListView>
                         <TextBlock Grid.Column="1" MinWidth="50"/>
-                        <editors:SfComboBox Header="Value Exchange" Grid.Column="2" IsEditable="False" MinWidth="250"
+                        <ComboBox Header="Value Exchange" Grid.Column="2" IsEditable="False" MinWidth="250"
                                             ItemsSource="{x:Bind SceneVm.ValueExchangeList}"
                                             SelectedValue="{x:Bind SceneVm.ValueExchange, Mode=TwoWay}"
                                             PlaceholderText="What changes for your scene's protagonist?."/>
@@ -190,14 +189,14 @@
                             DisplayMemberPath="Name"
                             SelectedItem="{x:Bind SceneVm.Protagonist, Mode=TwoWay, Converter={StaticResource ToStoryElement}}" />
                         <TextBlock Grid.Column="1" MinWidth="50"/>
-                        <editors:SfComboBox IsEditable="True" Header="Feelings" Grid.Column="2" MinWidth="200"
+                        <ComboBox IsEditable="True" Header="Feelings" Grid.Column="2" MinWidth="200"
                                             ItemsSource="{x:Bind SceneVm.EmotionList}"
                                             Text="{x:Bind SceneVm.ProtagEmotion, Mode=TwoWay}" />
                     </Grid>
-                    <editors:SfComboBox IsEditable="True" Header="Protagonist's Goal" Grid.Row="1"  MinWidth="300"
+                    <ComboBox IsEditable="True" Header="Protagonist's Goal" Grid.Row="1"  MinWidth="300"
                                         ItemsSource="{x:Bind SceneVm.GoalList}"
                                         Text="{x:Bind SceneVm.ProtagGoal, Mode=TwoWay}" />
-                    <editors:SfComboBox IsEditable="True" Header="Opposition" Grid.Row="2" Width="400"
+                    <ComboBox IsEditable="True" Header="Opposition" Grid.Row="2" Width="400"
                                         ItemsSource="{x:Bind SceneVm.OppositionList}"
                                         Text="{x:Bind SceneVm.Opposition, Mode=TwoWay}" HorizontalAlignment="Left"/>
                     <Grid Grid.Row="3" HorizontalAlignment="Left">
@@ -210,15 +209,15 @@
                           DisplayMemberPath="Name"
                           SelectedItem ="{x:Bind SceneVm.Antagonist, Mode=TwoWay, Converter={StaticResource ToStoryElement}}" />
                         <TextBlock Grid.Column="1" MinWidth="50"/>
-                        <editors:SfComboBox IsEditable="True" Header="Feelings" Grid.Column="2"  MinWidth="200"
+                        <ComboBox IsEditable="True" Header="Feelings" Grid.Column="2"  MinWidth="200"
                                             ItemsSource="{x:Bind SceneVm.EmotionList}"
                                             Text="{x:Bind SceneVm.AntagEmotion, Mode=TwoWay}" />
                     </Grid>
-                    <editors:SfComboBox IsEditable="True" Header="Antagonist's Goal" Grid.Row="4" MinWidth="300"
+                    <ComboBox IsEditable="True" Header="Antagonist's Goal" Grid.Row="4" MinWidth="300"
                                         ItemsSource="{x:Bind SceneVm.GoalList}"
                                         Text="{x:Bind SceneVm.AntagGoal, Mode=TwoWay}" />
                     <TextBlock Grid.Row="5" Text=" "/>
-                    <editors:SfComboBox IsEditable="True" Header="Outcome" Grid.Row="5" Width="400"
+                    <ComboBox IsEditable="True" Header="Outcome" Grid.Row="5" Width="400"
                                         ItemsSource="{x:Bind SceneVm.OutcomeList}"
                                         Text="{x:Bind SceneVm.Outcome, Mode=TwoWay}" HorizontalAlignment="Left"/>
                 </Grid>
@@ -230,14 +229,14 @@
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
-                    <editors:SfComboBox IsEditable="True" Header="Emotional Response" Grid.Row="0" MinWidth="200"
+                    <ComboBox IsEditable="True" Header="Emotional Response" Grid.Row="0" MinWidth="200"
                                         ItemsSource="{x:Bind SceneVm.EmotionList}"
                                         Text="{x:Bind SceneVm.Emotion, Mode=TwoWay}" />
                     <usercontrols:RichEditBoxExtended Header="Review and Thought" Grid.Row="1"
                                                       RtfText="{x:Bind SceneVm.Review, Mode=TwoWay}" AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                       ScrollViewer.VerticalScrollBarVisibility="Visible" />
-                    <editors:SfComboBox IsEditable="True" Header="New Goal" Grid.Row="2" MinWidth="400"
+                    <ComboBox IsEditable="True" Header="New Goal" Grid.Row="2" MinWidth="400"
                                         ItemsSource="{x:Bind SceneVm.GoalList}"
                                         Text="{x:Bind SceneVm.NewGoal, Mode=TwoWay}" />
                 </Grid>

--- a/StoryCAD/Views/SettingPage.xaml
+++ b/StoryCAD/Views/SettingPage.xaml
@@ -6,7 +6,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="using:StoryCAD.Views"
     xmlns:usercontrols="using:StoryCAD.Controls"
-    xmlns:editors="using:Syncfusion.UI.Xaml.Editors"
     xmlns:viewModels="using:StoryCAD.ViewModels"
     mc:Ignorable="d" >
 
@@ -35,11 +34,11 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <editors:SfComboBox IsEditable="True" Header="Locale" Grid.Column="0"  MinWidth="200"
+                        <ComboBox IsEditable="True" Header="Locale" Grid.Column="0"  MinWidth="200"
                                   ItemsSource="{x:Bind SettingVm.LocaleList}"
                                   Text="{x:Bind SettingVm.Locale, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         <TextBlock Grid.Column="1" MinWidth="100"/>
-                        <editors:SfComboBox IsEditable="True" Header="Season" Grid.Column="2" MinWidth="200"
+                        <ComboBox IsEditable="True" Header="Season" Grid.Column="2" MinWidth="200"
                                         ItemsSource="{x:Bind SettingVm.SeasonList}"
                                         Text="{x:Bind SettingVm.Season, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     </Grid>

--- a/StoryCADLib/Controls/CharacterName.cs
+++ b/StoryCADLib/Controls/CharacterName.cs
@@ -11,6 +11,7 @@ public sealed class CharacterName : ComboBox
     public CharacterName()
     {
         DefaultStyleKey = typeof(ComboBox);
+        CornerRadius = new(4);
         Loaded += CharacterName_Loaded; 
     }
 

--- a/StoryCADLib/Controls/Conflict.xaml
+++ b/StoryCADLib/Controls/Conflict.xaml
@@ -4,7 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:editors="using:Syncfusion.UI.Xaml.Editors"
     mc:Ignorable="d">
 
     <Grid>
@@ -13,8 +12,8 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <editors:SfComboBox Grid.Row="0" Name="Category" Header="Conflict Categories" MinWidth="200" SelectionChanged="Category_SelectionChanged" ItemsSource="{x:Bind ConflictTypes.Keys}" Margin="5"/>
-        <editors:SfComboBox Grid.Row="1" Name="SubCategory" Header="Subcategories" MinWidth="200" SelectionChanged="SubCategory_SelectionChanged" Margin="5"/>
-        <editors:SfComboBox Grid.Row="2" Name="Example" Header="Examples" MinWidth="200" Loaded="Example_Loaded" SelectionChanged="Example_SelectionChanged" Margin="5"/>
+        <ComboBox Grid.Row="0" Name="Category" Header="Conflict Categories" MinWidth="200" SelectionChanged="Category_SelectionChanged" ItemsSource="{x:Bind ConflictTypes.Keys}" Margin="5"/>
+        <ComboBox Grid.Row="1" Name="SubCategory" Header="Subcategories" MinWidth="200" SelectionChanged="SubCategory_SelectionChanged" Margin="5"/>
+        <ComboBox Grid.Row="2" Name="Example" Header="Examples" MinWidth="200" Loaded="Example_Loaded" SelectionChanged="Example_SelectionChanged" Margin="5"/>
     </Grid>
 </UserControl>

--- a/StoryCADLib/Controls/Conflict.xaml.cs
+++ b/StoryCADLib/Controls/Conflict.xaml.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using StoryCAD.Models;
 using StoryCAD.Models.Tools;
 using StoryCAD.ViewModels;
-using Syncfusion.UI.Xaml.Editors;
 
 namespace StoryCAD.Controls;
 
@@ -20,7 +20,7 @@ public sealed partial class Conflict
     {
         InitializeComponent();
     }
-    private void Category_SelectionChanged(object sender, ComboBoxSelectionChangedEventArgs e)
+    private void Category_SelectionChanged(object sender, SelectionChangedEventArgs selectionChangedEventArgs)
     {
         category = (string)Category.Items[Category.SelectedIndex];
         model = ConflictTypes[category];
@@ -29,7 +29,7 @@ public sealed partial class Conflict
         Example.SelectedIndex = -1;
     }
 
-    private void SubCategory_SelectionChanged(object sender, ComboBoxSelectionChangedEventArgs e)
+    private void SubCategory_SelectionChanged(object sender, SelectionChangedEventArgs selectionChangedEventArgs)
     {
         if (SubCategory.SelectedIndex > -1)
         {
@@ -38,7 +38,7 @@ public sealed partial class Conflict
         }
     }
 
-    private void Example_SelectionChanged(object sender, ComboBoxSelectionChangedEventArgs e)
+    private void Example_SelectionChanged(object sender, SelectionChangedEventArgs selectionChangedEventArgs)
     {
         ExampleText = (string)Example.SelectedItem;
     }

--- a/StoryCADLib/Controls/ProblemName.cs
+++ b/StoryCADLib/Controls/ProblemName.cs
@@ -11,6 +11,7 @@ public sealed class ProblemName : ComboBox
     public ProblemName()
     {
         DefaultStyleKey = typeof(ComboBox);
+        CornerRadius = new(4);
         Loaded += ProblemName_Loaded;
     }
 

--- a/StoryCADLib/Controls/RelationshipView.xaml
+++ b/StoryCADLib/Controls/RelationshipView.xaml
@@ -3,7 +3,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:usercontrols="using:StoryCAD.Controls"
-    xmlns:editors="using:Syncfusion.UI.Xaml.Editors"
     xmlns:models="using:StoryCAD.Models">
 
     <ScrollViewer>
@@ -48,8 +47,8 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
-                                <editors:SfComboBox Grid.Row="0" Grid.Column="1" IsEditable="True"  Header= "Trait" MinWidth="150" ItemsSource="{x:Bind CharVM.RelationshipTraitList}" Text="{x:Bind Trait, Mode=TwoWay}" Margin="0,0,10,0" />
-                                <editors:SfComboBox Grid.Row="0" Grid.Column="2" IsEditable="True" Header="Attitude"  MinWidth="150" ItemsSource="{x:Bind CharVM.RelationshipAttitudeList}" Text="{x:Bind Attitude, Mode=TwoWay}"/>
+                                <ComboBox Grid.Row="0" Grid.Column="1" IsEditable="True"  Header= "Trait" MinWidth="150" ItemsSource="{x:Bind CharVM.RelationshipTraitList}" Text="{x:Bind Trait, Mode=TwoWay}" Margin="0,0,10,0" />
+                                <ComboBox Grid.Row="0" Grid.Column="2" IsEditable="True" Header="Attitude"  MinWidth="150" ItemsSource="{x:Bind CharVM.RelationshipAttitudeList}" Text="{x:Bind Attitude, Mode=TwoWay}"/>
                                 <usercontrols:RichEditBoxExtended Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="4" MinHeight="200" HorizontalAlignment="Stretch" Header="Relationship Notes"  RtfText="{x:Bind Notes, Mode=TwoWay}" AcceptsReturn="True" IsSpellCheckEnabled="True" TextWrapping="Wrap" ScrollViewer.VerticalScrollBarVisibility="Visible"/>
                             </Grid>
                         </Expander>

--- a/StoryCADLib/Controls/SettingName.cs
+++ b/StoryCADLib/Controls/SettingName.cs
@@ -11,6 +11,7 @@ public sealed class SettingName : ComboBox
     public SettingName()
     {
         DefaultStyleKey = typeof(ComboBox);
+        CornerRadius = new(4);
         Loaded += SettingName_Loaded;
     }
 

--- a/StoryCADLib/Services/Dialogs/NewRelationshipPage.xaml
+++ b/StoryCADLib/Services/Dialogs/NewRelationshipPage.xaml
@@ -3,23 +3,23 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:editors="using:Syncfusion.UI.Xaml.Editors"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     
     <StackPanel Width="auto" MinWidth="300">
         <StackPanel Orientation="Horizontal" Width="500" HorizontalAlignment="Center">
             <TextBlock  Text="{x:Bind CharVM.Name}" VerticalAlignment="Center" MaxWidth="120" TextWrapping="Wrap"/>
             <TextBlock  Text=" is a " VerticalAlignment="Center" Margin="0,0,5,0"/>
-            <editors:SfComboBox  MinWidth="150" ItemsSource="{x:Bind  NewRelVM.RelationTypes}" IsEditable="True"  SelectedValue="{x:Bind  NewRelVM.RelationType, Mode=TwoWay}" Margin="0,10" VerticalAlignment="Center"/>
+            <ComboBox  MinWidth="150" ItemsSource="{x:Bind  NewRelVM.RelationTypes}" IsEditable="True"  SelectedValue="{x:Bind  NewRelVM.RelationType, Mode=TwoWay}" Margin="0,10" VerticalAlignment="Center"/>
             <TextBlock  Text=" to " VerticalAlignment="Center" Margin="5,0"/>
-            <editors:SfComboBox Name="PartnerBox" IsEditable="False" MinWidth="150" ItemsSource="{x:Bind NewRelVM.ProspectivePartners}" DisplayMemberPath="Name" SelectedItem="{x:Bind  NewRelVM.SelectedPartner, Mode=TwoWay}" VerticalAlignment="Center"/>
+            <ComboBox Name="PartnerBox" IsEditable="False" MinWidth="150" ItemsSource="{x:Bind NewRelVM.ProspectivePartners}" DisplayMemberPath="Name" SelectedItem="{x:Bind  NewRelVM.SelectedPartner, Mode=TwoWay}" VerticalAlignment="Center"/>
         </StackPanel>
 
         <CheckBox Content="Make a relationship on the other character" HorizontalAlignment="Center" Margin="0,20,0,0" IsChecked="{x:Bind NewRelVM.InverseRelationship, Mode=TwoWay}"/>
         <StackPanel Orientation="Horizontal" Width="500" HorizontalAlignment="Center">
             <TextBlock Text="{x:Bind  NewRelVM.SelectedPartner.Name, Mode=TwoWay}" VerticalAlignment="Center" MaxWidth="120" TextWrapping="Wrap"/>
             <TextBlock  Text=" is a " VerticalAlignment="Center" Margin="2,0,0,0"/>
-            <editors:SfComboBox   MinWidth="150" ItemsSource="{x:Bind  NewRelVM.RelationTypes}" VerticalAlignment="Center" IsEditable="True"  SelectedValue="{x:Bind  NewRelVM.InverseRelationType, Mode=TwoWay}" IsEnabled="{x:Bind NewRelVM.InverseRelationship, Mode=TwoWay}"/>
+            <ComboBox   MinWidth="150" ItemsSource="{x:Bind  NewRelVM.RelationTypes}" VerticalAlignment="Center" IsEditable="True"  SelectedValue="{x:Bind  NewRelVM.InverseRelationType, Mode=TwoWay}" IsEnabled="{x:Bind NewRelVM.InverseRelationship, Mode=TwoWay}"/>
             <TextBlock  Text=" to" VerticalAlignment="Center" Margin="5,0"/>
             <TextBlock  Text="{x:Bind CharVM.Name}"  VerticalAlignment="Center" MaxWidth="120" TextWrapping="Wrap"/>
         </StackPanel>

--- a/StoryCADLib/Services/Dialogs/Tools/MasterPlotsDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/MasterPlotsDialog.xaml
@@ -3,13 +3,12 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:editors="using:Syncfusion.UI.Xaml.Editors"                    
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"      
     mc:Ignorable="d"
     >
   
     <StackPanel Width="500" Height="400">
-        <editors:SfComboBox Margin="20" HorizontalAlignment="Center" Header="Master Plot" Width="300" ItemsSource="{x:Bind MasterPlotsVm.MasterPlotNames}" SelectedItem="{x:Bind MasterPlotsVm.MasterPlotName, Mode=TwoWay}" />
+        <ComboBox Margin="20" HorizontalAlignment="Center" Header="Master Plot" Width="300" ItemsSource="{x:Bind MasterPlotsVm.MasterPlotNames}" SelectedItem="{x:Bind MasterPlotsVm.MasterPlotName, Mode=TwoWay}" />
         <TextBlock Margin="20" VerticalAlignment="Center" HorizontalAlignment="Stretch" TextWrapping="Wrap" Text="{x:Bind MasterPlotsVm.MasterPlotNotes, Mode=TwoWay}" />
     </StackPanel>
 </Page>

--- a/StoryCADLib/StoryCADLib.csproj
+++ b/StoryCADLib/StoryCADLib.csproj
@@ -102,7 +102,6 @@
 	<PackageReference Include="NLog" Version="5.3.2" />
 	<PackageReference Include="NLog.Extensions.Logging" Version="5.3.11" />
 	<PackageReference Include="Octokit" Version="12.0.0" />
-	<PackageReference Include="Syncfusion.Editors.WinUI" Version="26.1.35" />
 	<PackageReference Include="System.Management" Version="8.0.0" />
     <PackageReference Include="WinUIEx" Version="2.3.4" />
   </ItemGroup>

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -681,10 +681,14 @@ public class ShellViewModel : ObservableRecipient
     {
         ContentDialog Dialog = new()
         {
-            Title = "File missing.",
-            Content = "This copy is missing a key file, if you are working on a branch or fork this is expected and you do not need to do anything about this." +
-                       "\nHowever if you are not a developer then report this as it should not happen.\nThe following may have issues or possible errors\n" +
-                       "Syncfusion related items and error logging.",
+            Title = "Key file missing.",
+            Content = """
+                      Your version of StoryCAD is missing a key file.
+                      If you are a developer you can safely ignore this message.
+                      If you are a user you should report this as you are not supposed to see this message.
+                      
+                      Things such as logging and elmah.io will not work without the key file.
+                      """,
             PrimaryButtonText = "Okay"
         };
         await Window.ShowContentDialog(Dialog);

--- a/StoryCADTests/ENVTests.cs
+++ b/StoryCADTests/ENVTests.cs
@@ -28,14 +28,6 @@ public class ENVTests
         DotEnv.Load(options);
     }
 
-    /// <summary>
-    /// Ensures the SyncFusion license is there,
-    /// This does not check the license is valid as SF
-    /// offers no way to check that, besides the annoying popup it gives in the app.
-    /// </summary>
-    [TestMethod]
-    public void CheckSFLicense() => Assert.IsNotNull(EnvReader.GetStringValue("SYNCFUSION_TOKEN"));
-
 
     [TestMethod]
     public void CheckDoppler()


### PR DESCRIPTION
This PR does two things
Firstly and foremost, completely strips out all references to SyncFusion. StoryCAD in the past has relied on SyncFusion as WinUI has had Comboboxes that were for the most part broken. I am glad to say WinUI has finally rectified the multitude of problems with the combobox, as such while we are extremly greatful to syncfusion for all the help they have provided us, it is no longer worth our time dealing with updating and maintaining Syncfusion. One of the largest problems with WinUI Comboboxes was them being cut off with the window if the combox extended past the bounds of the window; this has been fixed.

Secondly while we are on the topic of ComboBoxes,  this PR fixes the handful of them scattered throughout StoryCAD that aren't styled correctly. This occured because a few Comboboxes of StoryCAD inherit the combobox style but not the CornerRadius value, this led these few comboboxes having square edges breaking visual consistency. As a stopgap measure I've added CornerRadius=4 to the three custom comboboxes. I say this is a stop gap measure as I personally don't think these warrant being classes at all as all they do is set the itemsource to some filter of StoryModel.StoryElements and this could be done much more gracefully by referencing ShellVM or perhaps even adding a reference to StoryModel.GetModel() within the relevant page so its bindable as two out of three clases are only used within a single XAML page, the last is used in three.

Updated box look (look at the StoryProblem Box)
![image](https://github.com/storybuilder-org/StoryCAD/assets/49795711/d935c80f-e371-45cf-bb1c-7f785cd58f0e)
![image](https://github.com/storybuilder-org/StoryCAD/assets/49795711/0cafe485-af87-49ab-86c4-80ca2a69cee1)