### PR TITLE
Add ElementPicker 

### DIFF
--- a/StoryCADLib/Models/SceneModel.cs
+++ b/StoryCADLib/Models/SceneModel.cs
@@ -229,7 +229,37 @@ public class SceneModel : StoryElement
         Notes = string.Empty;
     }
 
-    public SceneModel(IXmlNode xn, StoryModel model) : base(xn, model)
+    public SceneModel(string name, StoryModel model) : base(name, StoryItemType.Scene, model)
+
+	{
+	    ViewpointCharacter = string.Empty;
+	    Date = string.Empty;
+	    Time = string.Empty;
+	    Setting = string.Empty;
+	    SceneType = string.Empty;
+	    CastMembers = new List<string>();
+	    Remarks = string.Empty;
+	    ScenePurpose = new List<string>();
+	    ValueExchange = string.Empty;
+	    Protagonist = string.Empty;
+	    ProtagEmotion = string.Empty;
+	    ProtagGoal = string.Empty;
+	    Antagonist = string.Empty;
+	    AntagEmotion = string.Empty;
+	    AntagGoal = string.Empty;
+	    Opposition = string.Empty;
+	    Outcome = string.Empty;
+	    Emotion = string.Empty;
+	    NewGoal = string.Empty;
+	    Events = string.Empty;
+	    Consequences = string.Empty;
+	    Significance = string.Empty;
+	    Realization = string.Empty;
+	    Review = string.Empty;
+	    Notes = string.Empty;
+    }
+
+	public SceneModel(IXmlNode xn, StoryModel model) : base(xn, model)
     {
         ViewpointCharacter = string.Empty;
         Date = string.Empty;

--- a/StoryCADLib/Models/SettingModel.cs
+++ b/StoryCADLib/Models/SettingModel.cs
@@ -130,8 +130,25 @@ public class SettingModel : StoryElement
         Notes = string.Empty;
         SettingNames.Add(Name);
     }
+    public SettingModel(string name, StoryModel model) : base(name, StoryItemType.Setting, model)
+    {
+	    Locale = string.Empty;
+	    Season = string.Empty;
+	    Period = string.Empty;
+	    Lighting = string.Empty;
+	    Weather = string.Empty;
+	    Temperature = string.Empty;
+	    Props = string.Empty;
+	    Summary = string.Empty;
+	    Sights = string.Empty;
+	    Sounds = string.Empty;
+	    Touch = string.Empty;
+	    SmellTaste = string.Empty;
+	    Notes = string.Empty;
+	    SettingNames.Add(Name);
+    }
 
-    public SettingModel(IXmlNode xn, StoryModel model) : base(xn, model)
+	public SettingModel(IXmlNode xn, StoryModel model) : base(xn, model)
     {
         Locale = string.Empty;
         Season = string.Empty;

--- a/StoryCADLib/Models/Windowing.cs
+++ b/StoryCADLib/Models/Windowing.cs
@@ -152,28 +152,45 @@ public class Windowing : ObservableRecipient
         }
 	}
 
+	/// <summary>
+	/// Reference to currently open dialog.
+	/// </summary>
+    private ContentDialog OpenDialog;
+
     /// <summary>
     /// This takes a ContentDialog and shows it to the user
     /// It will handle theming, XAMLRoot and showing the dialog.
     /// </summary>
     /// <param name="Dialog">Content dialog to show</param>
-    /// <param name="force">Force show content dialog, bypasses protections;
-    /// This will crash the app unless you are immediately hiding the ContentDialog before this one.
-    /// Please do not use this unless you know what you are doing, and it is absolutely necessary.
+    /// <param name="force">Force show content dialog, will close currently open dialog if one
+    /// is already open
     /// </param>
     /// <returns>A ContentDialogResult enum value.</returns>
     public async Task<ContentDialogResult> ShowContentDialog(ContentDialog Dialog, bool force=false)
     {
-        //Checks a content dialog isn't already open
-        if (!_IsContentDialogOpen || force)
+		//force close any other dialog if one is open
+		//(if force is enabled)
+	    if (force && _IsContentDialogOpen && OpenDialog != null)
+	    {
+		    OpenDialog.Hide();
+
+			//This will be unset eventually but because we have called
+			//Hide() already we can unset this early.
+			_IsContentDialogOpen = false;
+	    }
+
+	    //Checks a content dialog isn't already open
+        if (!_IsContentDialogOpen) 
         {
-            //Set XAML root and correct theme.
-            Dialog.XamlRoot = XamlRoot;
-            Dialog.RequestedTheme = RequestedTheme;
+	        OpenDialog = Dialog;
+			//Set XAML root and correct theme.
+			OpenDialog.XamlRoot = XamlRoot;
+			OpenDialog.RequestedTheme = RequestedTheme;
 
             _IsContentDialogOpen = true;
-            ContentDialogResult Result = await Dialog.ShowAsync();
+            ContentDialogResult Result = await OpenDialog.ShowAsync();
             _IsContentDialogOpen = false;
+            OpenDialog = null;
             return Result;
         }
         return ContentDialogResult.None; 

--- a/StoryCADLib/Services/Dialogs/ElementPicker.xaml
+++ b/StoryCADLib/Services/Dialogs/ElementPicker.xaml
@@ -1,0 +1,47 @@
+﻿<Page
+    x:Class="StoryCAD.Services.Dialogs.ElementPicker"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <StackPanel>
+
+		<!-- ElementType Picker -->
+	    <ComboBox SelectedItem="{x:Bind PickerVM.SelectedType, Mode=TwoWay}"
+	              PlaceholderText="Click here to select an element type" HorizontalAlignment="Center"
+	              MinWidth="200" SelectionChanged="Selector_OnSelectionChanged">
+			<ComboBoxItem Content="Problem"/>
+			<ComboBoxItem Content="Character"/>
+			<ComboBoxItem Content="Setting"/>
+			<ComboBoxItem Content="Scene"/>
+		</ComboBox>
+
+		<!-- Element Picker -->
+		<ScrollViewer Height="450">
+			<ListBox Name="ElementBox" IsEnabled="False" HorizontalAlignment="Center"
+			         SelectedItem="{x:Bind PickerVM.SelectedElement, Mode=TwoWay}" 
+			         DisplayMemberPath="Name" Margin="0,10,0,0"
+			         MinWidth="200"/>
+		</ScrollViewer>
+
+		<Border Margin="30,10" HorizontalAlignment="Stretch"
+		        BorderBrush="Gray" BorderThickness="1"/>
+
+		<!-- Create new element UI -->
+		<Button  HorizontalAlignment="Center" Content="+ Create a new element" 
+		         Name="NewButton" IsEnabled="False">
+			<Button.Flyout>
+				<Flyout>
+					<StackPanel>
+						<TextBox Header="Element name:" Width="200"
+						         Text="{x:Bind PickerVM.NewNodeName, Mode=TwoWay}"/>
+						<Button Content="Create" HorizontalAlignment="Center"
+						        Margin="0,20,0,0" Click="{x:Bind PickerVM.CreateNode}"/>
+					</StackPanel>
+				</Flyout>
+			</Button.Flyout>
+		</Button>
+	</StackPanel>
+</Page>

--- a/StoryCADLib/Services/Dialogs/ElementPicker.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/ElementPicker.xaml.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.UI.Xaml.Controls;
+using StoryCAD.Models;
+using StoryCAD.ViewModels;
+
+namespace StoryCAD.Services.Dialogs;
+
+/// <summary>
+/// A simple picker allowing a user to pick the
+/// type of element they want
+/// </summary>
+public sealed partial class ElementPicker : Page
+{
+	private ElementPickerVM PickerVM = Ioc.Default.GetRequiredService<ElementPickerVM>();
+
+	/// <summary>
+	/// Don't spawn this on its own, use ElementPickerVM.ShowPicker()
+	/// </summary>
+	public ElementPicker() { InitializeComponent(); }
+
+	/// <summary>
+	/// This just handles the UI when the type Combobox is changed
+	/// </summary>
+	private void Selector_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		//Get elements
+		ComboBoxItem Type = PickerVM.SelectedType as ComboBoxItem;
+		StoryItemType type = Enum.Parse<StoryItemType>(Type.Content.ToString()!, 
+			true);
+
+		//Reset the UIs, so we can't enter an invalid state
+		PickerVM.SelectedElement = null;
+		ElementBox.ItemsSource = null;
+		NewButton.IsEnabled = true;
+
+		var elements = ShellViewModel.GetModel().StoryElements
+			.Where(element => element.Type == type);
+		if (elements.Count() == 0) // no elements so disable picker
+		{
+			ElementBox.IsEnabled = false;
+		}
+		else
+		{
+			//Update element box
+			ElementBox.IsEnabled = true; //Enable elements box
+			ElementBox.ItemsSource = elements;
+		}
+	}
+}

--- a/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
@@ -118,6 +118,7 @@
                         <Button Content="Throw exception" Click="ThrowException" Width="150" Margin="0,5"/>
                         <Button Content="Attach Elmah" Click="{x:Bind Logger.AddElmahTarget}" Width="150" Margin="0,5"/>
 						<Button Content="Refresh Dev Stats" Click="RefreshDevStats" Width="150" Margin="0,5"/>
+						<Button Content="Open Picker UI" Click="OpenPickerUI" Width="150" Margin="0,5"/>
 					</StackPanel>
                     <ScrollViewer MaxHeight="400">
                         <StackPanel>

--- a/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml.cs
@@ -12,6 +12,7 @@ using StoryCAD.ViewModels.Tools;
 using WinRT;
 using Microsoft.UI.Xaml.Controls;
 using StoryCAD.Services.Ratings;
+using StoryCAD.ViewModels;
 
 namespace StoryCAD.Services.Dialogs.Tools;
 
@@ -180,4 +181,22 @@ public sealed partial class PreferencesDialog
         //Launch relevant app (browser/mail client)
         Process.Start(URL);
     }
+    /// <summary>
+	/// Spawns the element picker UI and shows the result
+	/// </summary>
+    private async void OpenPickerUI(object sender, RoutedEventArgs e)
+    {
+	    // Show dialog
+		StoryElement Element = await Ioc.Default.GetRequiredService<ElementPickerVM
+			>().ShowPicker();
+
+		if (Element == null) return; // User cancelled (or error occurred)
+		// Show result
+	    await Ioc.Default.GetRequiredService<Windowing>().ShowContentDialog(new()
+	    {
+		    Title = "Result",
+		    Content = "User picked item " + Element.Name,
+			PrimaryButtonText = "OK"
+		}, true);
+	}
 }

--- a/StoryCADLib/Services/IoC/ServiceConfigurator.cs
+++ b/StoryCADLib/Services/IoC/ServiceConfigurator.cs
@@ -62,6 +62,7 @@ public class ServiceConfigurator
              .AddSingleton<NewRelationshipViewModel>()
              .AddSingleton<PrintReportDialogVM>()
              .AddSingleton<NarrativeToolVM>()
+             .AddSingleton<ElementPickerVM>()
              // Register Tools ViewModels  
              .AddSingleton<KeyQuestionsViewModel>()
              .AddSingleton<TopicsViewModel>()

--- a/StoryCADLib/StoryCADLib.csproj
+++ b/StoryCADLib/StoryCADLib.csproj
@@ -58,6 +58,7 @@
     <None Remove="Controls\Flaw.xaml" />
     <None Remove="Controls\RelationshipView.xaml" />
     <None Remove="Controls\Traits.xaml" />
+    <None Remove="Services\Dialogs\ElementPicker.xaml" />
     <None Remove="Services\Dialogs\FeedbackDialog.xaml" />
     <None Remove="Services\Dialogs\NewProjectPage.xaml" />
     <None Remove="Services\Dialogs\NewRelationshipPage.xaml" />
@@ -157,6 +158,9 @@
     <None Update="NLog.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Page Update="Services\Dialogs\ElementPicker.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Update="Services\Dialogs\FeedbackDialog.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/StoryCADLib/ViewModels/ElementPickerVM.cs
+++ b/StoryCADLib/ViewModels/ElementPickerVM.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using OpenAI.ObjectModels;
+using StoryCAD.Models;
+using StoryCAD.Services.Dialogs;
+
+namespace StoryCAD.ViewModels;
+
+/// <summary>
+/// ViewModel for the Element Picker
+/// </summary>
+class ElementPickerVM
+{
+	/// <summary>
+	/// Currently selected item
+	/// </summary>
+	public object SelectedType { get; set; }
+
+	/// <summary>
+	/// Currently selected item
+	/// </summary>
+	public object SelectedElement { get; set; }
+
+	/// <summary>
+	/// Text for new node textbox.
+	/// </summary>
+	public string NewNodeName { get; set; }
+
+	/// <summary>
+	/// Instance of element picker
+	/// </summary>
+	private ContentDialog dialog;
+	/// <summary>
+	/// Spawns an instance of the picker.
+	/// </summary>
+	/// <returns>The element the user picked</returns>
+	public async Task<StoryElement?> ShowPicker()
+	{
+		//Spawn new picker and reset VM
+		ElementPicker UI = new();
+		SelectedType = null;
+		SelectedElement = null;
+		NewNodeName = "";
+
+		//create and show dialog
+		dialog = new()
+		{
+			Title = "Select an element",
+			PrimaryButtonText = "Select",
+			SecondaryButtonText = "Cancel",
+			Content = UI,
+
+		};
+		var res = await Ioc.Default.GetRequiredService<Windowing>()
+			.ShowContentDialog(dialog, true);
+
+		//interpret result
+		if (res != ContentDialogResult.Secondary)
+		{
+			ComboBoxItem Type = SelectedType as ComboBoxItem;
+			if (Type != null) //check user has picked an item
+			{
+				//The name can be parsed to an enum.
+				return SelectedElement as StoryElement;
+			}
+		}
+		
+		return null; //Return unknown if dialog is closed or element isn't selected.
+	}
+
+	/// <summary>
+	/// Creates a new node of the type the user selected
+	/// </summary>
+	public void CreateNode()
+	{
+		StoryElement NewElement;
+		string type = (SelectedType as ComboBoxItem).Content.ToString();
+		switch (type)
+		{
+			case "Problem":
+				NewElement = new ProblemModel(NewNodeName, ShellViewModel.GetModel()); 
+				break;
+			case "Character":
+				NewElement = new CharacterModel(NewNodeName, ShellViewModel.GetModel());
+				break;
+			case "Setting":
+				NewElement = new SettingModel(NewNodeName, ShellViewModel.GetModel());
+				break;
+			case "Scene":
+				NewElement = new SceneModel(NewNodeName, ShellViewModel.GetModel());
+				break;
+			default:
+				//Throw an exception if we are asked to create a node type we don't expect
+				throw new Exception(
+					$"Unexpected element type {type}");
+			break;
+		}
+		
+		//Persist node to tree and set as selected element
+		StoryNodeItem Node = new(NewElement, ShellViewModel.GetModel().ExplorerView[0]);
+		SelectedElement = NewElement;
+
+		//Close popup
+		dialog.Hide();
+	}	
+}


### PR DESCRIPTION
This PR adds a currently unused dialog named ElementPicker which allows a user to pick an element.
Currently ElementPicker can be spawned via the developer menu however it will be used in future storycad development. (note that once the dialog closes another will open to show what element was selected, this is not a part of element picker.)

Element Picker first asks users to pick from a range of StoryElementTypes and then will let the user pick an element.
Element Picker should be invoked via ElementPickerViewModel.ShowPicker(), this will then return the element the user selected/created or Null if none was selected.

Users can also create a new element via this menu, which will then be selected.
![image](https://github.com/storybuilder-org/StoryCAD/assets/49795711/d32541e2-a8d6-421b-84a2-2330ef83d203)
![image](https://github.com/storybuilder-org/StoryCAD/assets/49795711/6674d4b7-a9a6-4581-bc73-1ffe2526c463)

_(Note this PR also tweaks Windowing.ShowContentDialog to modify the force parameter to be safer)_