### PR TITLE
Reset NavigationView and hide WizardWindow on Collaborator's exit. Th…

### DIFF
--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -398,7 +398,6 @@
                     </SymbolIcon>
                 </Button.Content>
             </Button>
-
         </StackPanel>
     </Grid>
 </Page>

--- a/StoryCADLib/Collaborator/ViewModels/WizardViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WizardViewModel.cs
@@ -7,6 +7,7 @@ using StoryCAD.Services.Navigation;
 //using StoryCollaborator.Models;
 using StoryCAD.Collaborator.Views;
 using StoryCAD.Services.Collaborator;
+using Microsoft.UI.Xaml.Controls;
 
 namespace StoryCAD.Collaborator.ViewModels;
 
@@ -23,6 +24,13 @@ public class WizardViewModel : ObservableRecipient
     public string Description { get; set; }
     public ObservableCollection<NavigationViewItem> MenuSteps
     { get; set; }
+
+    private object _selectedItem;
+    public object SelectedItem
+    {
+        get => _selectedItem;
+        set => SetProperty(ref _selectedItem, value);
+    }
 
     private StoryElement _model;
     public StoryElement Model
@@ -48,14 +56,14 @@ public class WizardViewModel : ObservableRecipient
         set => SetProperty(ref _currentStep, value);
     }
 
-    private Visibility _acceptVisibility;
+    private Visibility _acceptVisibility = Visibility.Visible;
     public Visibility AcceptVisibility
     {
         get => _acceptVisibility;
         set => SetProperty(ref _acceptVisibility, value);
     }
 
-    private Visibility _exitVisibility;
+    private Visibility _exitVisibility = Visibility.Visible;
     public Visibility ExitVisibility
     {
         get => _exitVisibility;
@@ -141,6 +149,8 @@ public class WizardViewModel : ObservableRecipient
     public void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
     {
         var item = args.SelectedItem as NavigationViewItem;
+        if (item is null)
+            return;
         CurrentItem = item;
         CollaboratorService collab = Ioc.Default.GetService<CollaboratorService>();
         collab.LoadWizardStep(Model, (string)item!.Content);
@@ -255,29 +265,30 @@ public class WizardViewModel : ObservableRecipient
     /// <summary>
     /// Process the ExitComand button.
     ///
-    /// Resets the VM and hides the Collaborator window.
+    /// Resets the NavigationView and hides the Collaborator window.
     /// </summary>
     private void ExitCollaborator()
     {
-    
-        // Clear NavigationView items
-        //navigationView.MenuItems.Clear();
-
+        // Remove the event handler
+        SetCurrentPage(typeof(WelcomePage));
+        NavView.SelectionChanged -= NavView_SelectionChanged;
+        // Reset the NavigationView.
+        MenuSteps.Clear();
         // Optionally, clear FooterMenuItems if used
-        //navigationView.FooterMenuItems.Clear();
-
+        // FooterMenuItems.Clear();
         // Reset the selected item
-        //navigationView.SelectedItem = null;
+        SelectedItem = null;
 
-        // Optionally, reset any associated content or state
-        //contentFrame.Navigate(typeof(DefaultPage));
+        // Reset the current page (without navigation)
+        //ContentFrame.Navigate(typeof(WelcomePage));
 
         collaborator.CollaboratorWindow.AppWindow.Hide();
-        // Assuming 'navigationView' is your NavigationView instance
-
-
     }
 
+    public void EnableNavigation()
+    {
+        NavView.SelectionChanged -= NavView_SelectionChanged;
+    }
 
 
     #endregion

--- a/StoryCADLib/Collaborator/Views/WizardShell.xaml
+++ b/StoryCADLib/Collaborator/Views/WizardShell.xaml
@@ -4,29 +4,27 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:winUiEx="using:WinUIEx"
     MinHeight="500"
     MinWidth="500"
     mc:Ignorable="d">
-
-    <NavigationView x:Name="NavView"
-                    Grid.Row="1"
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <NavigationView x:Name="NavView"
+                    Grid.Row="0"
                     IsBackButtonVisible="Collapsed"
-                    MenuItemsSource="{x:Bind WizardVm.MenuSteps, Mode=OneWay}" 
+                    MenuItemsSource="{x:Bind WizardVm.MenuSteps, Mode=OneWay}"
+                    SelectedItem="{x:Bind WizardVm.SelectedItem, Mode=TwoWay}"
                     IsSettingsVisible="False"
                     SelectionChanged="NavView_SelectionChanged"
                     PaneDisplayMode="Left">
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="auto"/>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="50"/>
-            </Grid.RowDefinitions>
-            <Frame Grid.Row="1" x:Name="StepFrame" Navigated="StepFrame_OnNavigated" Margin="5,0,5,5" />
-
-            <CommandBar Grid.Row="0">
+            <Frame x:Name="StepFrame" Navigated="StepFrame_OnNavigated" Margin="5,0,5,5" />
+        </NavigationView>
+        <CommandBar Grid.Row="1">
                 <CommandBar.PrimaryCommands>
-                    <AppBarButton Label="Help" ToolTipService.ToolTip="Help">
+                    <AppBarButton Label="Help" ToolTipService.ToolTip="Help" Margin="5">
                         <AppBarButton.Icon>
                             <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE897;"/>
                         </AppBarButton.Icon>
@@ -44,12 +42,8 @@
                     </AppBarButton>
                 </CommandBar.PrimaryCommands>
             </CommandBar>
-            <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Stretch">
+            <!--StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Stretch"-->
                 <!--<TextBlock Text="{x:Bind UsageText, Mode=OneWay}" Width="100" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="10"/>-->
                 <!-- <AutoSuggestBox Height="35" Width="auto" MinWidth="500" HorizontalAlignment="Stretch" PlaceholderText="Type your ideas here..." QueryIcon="Send"/> -->
-
-
-            </StackPanel>
         </Grid>
-    </NavigationView>
 </Page>

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -1217,6 +1217,7 @@ public class ShellViewModel : ObservableRecipient
             CollabArgs.StoryModel = StoryModel;
             Ioc.Default.GetService<CollaboratorService>()!.LoadWizardModel(CollabArgs);
             Ioc.Default.GetService<CollaboratorService>()!.CollaboratorWindow.Show();
+            Ioc.Default.GetService<WizardViewModel>()!.EnableNavigation();
             Ioc.Default.GetRequiredService<WizardViewModel>()!.LoadModel();
         }
     }


### PR DESCRIPTION
…is is currently wired to the Exit button on WizardShell.

Note that there is a hide process associated with the AppWindow Close event, but it's not being called and does not reset the Navigation View.