### PR TITLE
2.14.3 fixes

### DIFF
--- a/StoryCAD.sln.DotSettings
+++ b/StoryCAD.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=evergreenbootstrapper/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/StoryCAD/Views/Shell.xaml.cs
+++ b/StoryCAD/Views/Shell.xaml.cs
@@ -74,10 +74,10 @@ public sealed partial class Shell
         Windowing.UpdateWindowTitle();
         if (!Ioc.Default.GetService<AppState>()!.EnvPresent) { await ShellVm.ShowDotEnvWarningAsync(); }
 
-        if (!await Ioc.Default.GetRequiredService<WebViewModel>().CheckWebviewState())
+        if (!await Ioc.Default.GetRequiredService<WebViewModel>().CheckWebViewState())
         {
             ShellVm._canExecuteCommands = false;
-            await Ioc.Default.GetRequiredService<WebViewModel>().ShowWebviewDialog();
+            await Ioc.Default.GetRequiredService<WebViewModel>().ShowWebViewDialog();
             ShellVm._canExecuteCommands = true;
         }
 

--- a/StoryCADLib/Models/Windowing.cs
+++ b/StoryCADLib/Models/Windowing.cs
@@ -166,28 +166,49 @@ public class Windowing : ObservableRecipient
     /// <returns>A ContentDialogResult enum value.</returns>
     public async Task<ContentDialogResult> ShowContentDialog(ContentDialog Dialog, bool force=false)
     {
+	    LogService logger = Ioc.Default.GetRequiredService<LogService>();
+		logger.Log(LogLevel.Info, $"Requested to show dialog {Dialog.Title}");
+
 		//force close any other dialog if one is open
 		//(if force is enabled)
-	    if (force && _IsContentDialogOpen && OpenDialog != null)
+		if (force && _IsContentDialogOpen && OpenDialog != null)
 	    {
-		    OpenDialog.Hide();
+		    logger.Log(LogLevel.Info, $"Force closing open content dialog: ({OpenDialog.Title})");
+			OpenDialog.Hide();
 
 			//This will be unset eventually but because we have called
 			//Hide() already we can unset this early.
 			_IsContentDialogOpen = false;
-	    }
+			logger.Log(LogLevel.Info, $"Closed content dialog: ({OpenDialog.Title})");
+		}
 
-	    //Checks a content dialog isn't already open
-        if (!_IsContentDialogOpen) 
+		//Checks a content dialog isn't already open
+		if (!_IsContentDialogOpen) 
         {
-	        OpenDialog = Dialog;
+			logger.Log(LogLevel.Trace, $"Showing dialog {OpenDialog.Title}");
+			OpenDialog = Dialog;
+
 			//Set XAML root and correct theme.
 			OpenDialog.XamlRoot = XamlRoot;
 			OpenDialog.RequestedTheme = RequestedTheme;
 
             _IsContentDialogOpen = true;
+            
+			//Show and log result.
             ContentDialogResult Result = await OpenDialog.ShowAsync();
-            _IsContentDialogOpen = false;
+            switch (Result)
+            {
+	            case ContentDialogResult.None:
+		            logger.Log(LogLevel.Info, "User selected no option.");
+					break;
+	            case ContentDialogResult.Primary:
+		            logger.Log(LogLevel.Info, $"User selected primary option {Dialog.PrimaryButtonText}");
+					break;
+	            case ContentDialogResult.Secondary:
+		            logger.Log(LogLevel.Info, $"User selected secondary option {Dialog.SecondaryButtonText}");
+					break;
+            }
+			_IsContentDialogOpen = false;
             OpenDialog = null;
             return Result;
         }

--- a/StoryCADLib/Models/Windowing.cs
+++ b/StoryCADLib/Models/Windowing.cs
@@ -185,7 +185,7 @@ public class Windowing : ObservableRecipient
 		//Checks a content dialog isn't already open
 		if (!_IsContentDialogOpen) 
         {
-			logger.Log(LogLevel.Trace, $"Showing dialog {OpenDialog.Title}");
+			logger.Log(LogLevel.Trace, $"Showing dialog {Dialog.Title}");
 			OpenDialog = Dialog;
 
 			//Set XAML root and correct theme.

--- a/StoryCADLib/ViewModels/OverviewViewModel.cs
+++ b/StoryCADLib/ViewModels/OverviewViewModel.cs
@@ -285,32 +285,44 @@ public class OverviewViewModel : ObservableRecipient, INavigable
     {
         try
         {
-            // Story.Uuid is read-only and cannot be assigned
-            Model.Name = Name;
-            IsTextBoxFocused = false;
-            Model.DateCreated = DateCreated;
-            Model.Author = Author;
-            Model.DateModified = DateModified;
-            Model.StoryType = StoryType;
-            Model.StoryGenre = StoryGenre;
-            Model.Viewpoint = Viewpoint;
-            Model.ViewpointCharacter = ViewpointCharacter;
-            Model.Voice = Voice;
-            Model.LiteraryDevice = LiteraryTechnique;
-            Model.Style = Style;
-            Model.Tense = Tense;
-            Model.Style = Style;
-            Model.Tone = Tone;
-            Model.StoryProblem = StoryProblem;
-            Model.StoryIdea = StoryIdea;
-            Model.Concept = Concept;
-            Model.Premise = Premise;
-            if (_syncPremise)
-            {
-                _storyProblemModel.Premise = Premise;
-            }
-            Model.StructureNotes = StructureNotes;
-            Model.Notes = Notes;
+	        if (Model != null) //ensure model isn't null.
+	        {
+		        // Story.Uuid is read-only and cannot be assigned
+		        Model.Name = Name ?? "";
+		        IsTextBoxFocused = false;
+		        Model.DateCreated = DateCreated ?? "";
+		        Model.Author = Author ?? "";
+		        Model.DateModified = DateModified;
+		        Model.StoryType = StoryType ?? "";
+		        Model.StoryGenre = StoryGenre ?? "";
+		        Model.Viewpoint = Viewpoint ?? "";
+		        Model.ViewpointCharacter = ViewpointCharacter ?? "";
+		        Model.Voice = Voice ?? "";
+		        Model.LiteraryDevice = LiteraryTechnique ?? "";
+		        Model.Style = Style ?? "";
+		        Model.Tense = Tense ?? "";
+		        Model.Style = Style ?? "";
+		        Model.Tone = Tone ?? "";
+		        Model.StoryProblem = StoryProblem ?? "";
+		        Model.StoryIdea = StoryIdea ?? "";
+		        Model.Concept = Concept ?? "";
+		        Model.Premise = Premise ?? "";
+		        if (_syncPremise)
+		        {
+			        if (_storyProblemModel != null)
+			        {
+				        _storyProblemModel.Premise = Premise;
+			        }
+		        }
+		        Model.StructureNotes = StructureNotes ?? "";
+		        Model.Notes = Notes ?? "";
+			}
+	        else
+	        {
+				_logger.Log(LogLevel.Fatal, "OverViewModel.Model is null, THIS SHOULDN'T HAPPEN.");
+				Model = new OverviewModel("Overview", ShellViewModel.GetModel());
+	        }
+
         }
         catch (Exception ex)
         {

--- a/StoryCADLib/ViewModels/WebViewModel.cs
+++ b/StoryCADLib/ViewModels/WebViewModel.cs
@@ -100,10 +100,10 @@ public class WebViewModel : ObservableRecipient, INavigable
     #region Methods
 
     /// <summary>
-    /// This checks if webview is installed
+    /// This checks if web view is installed
     /// </summary>
-    /// <returns>True if webview is installed</returns>
-    public Task<bool> CheckWebviewState()
+    /// <returns>True if web view is installed</returns>
+    public Task<bool> CheckWebViewState()
     {
         try
         {
@@ -118,35 +118,35 @@ public class WebViewModel : ObservableRecipient, INavigable
 
 
     /// <summary>
-    /// This method installs the Evergreen webview runtime.
+    /// This method installs the Evergreen Web View runtime.
     /// </summary>
-    public async Task ShowWebviewDialog()
+    public async Task ShowWebViewDialog()
     {
-        Ioc.Default.GetRequiredService<LogService>().Log(LogLevel.Error, "Showing webview install dialog.");
+	    _logger.Log(LogLevel.Error, "Showing WebView install dialog.");
 
         ContentDialog _dialog = new()
         {
-            Title = "Webview is missing.",
+            Title = "Web View is missing.",
             Content = "This computer is missing the WebView2 Runtime, without it some features may not work.\nWould you like to install this now?",
             PrimaryButtonText = "Yes",
             SecondaryButtonText = "No"
         };
 
-        ContentDialogResult _result = await Ioc.Default.GetService<Windowing>().ShowContentDialog(_dialog);
+        ContentDialogResult _result = await Window.ShowContentDialog(_dialog);
         _logger.Log(LogLevel.Error, $"User clicked {_result}");
 
         //Ok clicked
-        if (_result == ContentDialogResult.Primary) { await InstallWebview(); }
+        if (_result == ContentDialogResult.Primary) { await InstallWebView(); }
     }
 
     /// <summary>
-    /// This installs the evergreen webview runtime
+    /// This installs the evergreen WebView runtime
     /// </summary>
-    public async Task InstallWebview()
+    public async Task InstallWebView()
     {
         try
         {
-            Ioc.Default.GetRequiredService<LogService>().Log(LogLevel.Error, "Installing webview...");
+	        _logger.Log(LogLevel.Error, "Installing WebView runtime");
 
             //Download file
             HttpResponseMessage _httpResult =
@@ -167,28 +167,30 @@ public class WebViewModel : ObservableRecipient, INavigable
             ContentDialog _dialog = new() { PrimaryButtonText = "Ok" };
             try
             {
-                _dialog.Title = "Webview installed!";
+                _dialog.Title = "WebView installed!";
                 _dialog.Content = "You are good to go, everything should work now.";
-                _logger.Log(LogLevel.Info, "Webview installed");
+                _logger.Log(LogLevel.Info, "WebView installed");
             }
             catch (Exception _ex)
             {
                 _dialog.Title = "Something went wrong.";
-                _dialog.Content =
-                    "Looks like something went wrong, you can still use StoryCAD however some features may not work.";
-                _logger.Log(LogLevel.Warn,
-                    $"An error occurred installing the Evergreen Webview Runtime ({_ex.Message})");
+                _dialog.Content = "Looks like something went wrong, you can still use StoryCAD " +
+                                  "however some features may not work.";
+                _logger.Log(LogLevel.Warn, $"An error occurred installing the Evergreen" +
+                                           $" WebView Runtime ({_ex.Message})");
             }
 
-            await Ioc.Default.GetService<Windowing>().ShowContentDialog(_dialog);
-            _logger.Log(LogLevel.Warn, "Finished installing webview runtime.");
+            await Window.ShowContentDialog(_dialog);
+            _logger.Log(LogLevel.Warn, "Finished installing WebView runtime.");
         }
         catch (Exception _ex)
         {
-            _logger.LogException(LogLevel.Error, _ex,  "Error installing webview runtime.");
+            _logger.LogException(LogLevel.Warn, _ex,  $"Error installing WebView runtime. " +
+                                                      $"({_ex.Message})");
         }
     }
     #endregion
+
     #region Relay Commands
 
     public RelayCommand RefreshCommand { get; }
@@ -245,8 +247,7 @@ public class WebViewModel : ObservableRecipient, INavigable
         }
         catch (Exception ex)
         {
-            Ioc.Default.GetRequiredService<LogService>().LogException(LogLevel.Error,
-                ex, $"Failed to save webview model - {ex.Message}");
+	        _logger.LogException(LogLevel.Error, ex, $"Failed to save WebVM {ex.Message}");
         }
 
     }


### PR DESCRIPTION
This PR does a few things in preparation for a 2.14.3 bug fix launch.

- Cleans up a bit of the webview model code and stops install failures from being reported to Elmah.io (fixes #759)
- Updates Windowing.ShowContentDialog to have logging that shows what dialog is being shown and what option was picked 
- Uses null coealessing in OverviewViewModel to prevent NullRefs from occuring during saves. (fixes #755)