### PR TITLE
downgrade buildtools

### DIFF
--- a/StoryCAD/StoryCAD.csproj
+++ b/StoryCAD/StoryCAD.csproj
@@ -41,7 +41,7 @@
 	<ItemGroup>
 		<PackageReference Include="dotenv.net" Version="3.2.0" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240627000" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Core" Version="7.1.2" />
 		<PackageReference Include="NLog" Version="5.3.2" />

--- a/StoryCADLib/StoryCADLib.csproj
+++ b/StoryCADLib/StoryCADLib.csproj
@@ -104,7 +104,7 @@
 	<PackageReference Include="Octokit" Version="13.0.1" />
     <PackageReference Include="WinUIEx" Version="2.3.4" />
     <PackageReference Include="Betalgo.OpenAI" Version="8.6.0" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
   </ItemGroup>
 
   <ItemGroup>

--- a/StoryCADTests/StoryCADTests.csproj
+++ b/StoryCADTests/StoryCADTests.csproj
@@ -51,7 +51,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240627000" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Core" Version="7.1.2" />
 		<PackageReference Include="MSTest.TestAdapter">


### PR DESCRIPTION
This PR fixes an issue with submitting StoryCAD to the microsoft store as uploading the appx packages gives an error of 
uses an unsupported version of file makepri.exe (10.0.26100.1). The following versions are allowed ...

This is some issue from last month that hasn't been fixed yet and users are reporting that downgrading to 10.0.22621.3233 works.

src:
https://github.com/microsoft/WindowsAppSDK/issues/4480