### PR TITLE
Fix ComboBox binding.

### DIFF
--- a/StoryCAD/Views/CharacterPage.xaml
+++ b/StoryCAD/Views/CharacterPage.xaml
@@ -23,7 +23,7 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    <ComboBox IsEditable="True" Header="Role" Grid.Row="0"  MinWidth="200" ItemsSource="{x:Bind CharVm.RoleList}" Text="{x:Bind CharVm.Role, Mode=TwoWay}" />
+                    <ComboBox IsEditable="True" Header="Role" Grid.Row="0"  MinWidth="200" ItemsSource="{x:Bind CharVm.RoleList}" Text="{x:Bind CharVm.Role, Mode=TwoWay}"  PlaceholderText="{x:Bind CharVm.Role, Mode=TwoWay}" />
                     <ComboBox Header="Story Role" Grid.Row="1" IsEditable="False" MinWidth="200" ItemsSource="{x:Bind CharVm.StoryRoleList}" SelectedItem="{x:Bind CharVm.StoryRole, Mode=TwoWay}" />
                     <ComboBox Header="Archetype" Grid.Row="2" IsEditable="False" MinWidth="200" ItemsSource="{x:Bind CharVm.ArchetypeList}" SelectedItem="{x:Bind CharVm.Archetype, Mode=TwoWay}" />
                     <usercontrols:RichEditBoxExtended Header="Character Sketch" Grid.Row="3" RtfText="{x:Bind CharVm.CharacterSketch, Mode=TwoWay}" AcceptsReturn="True" IsSpellCheckEnabled="True" TextWrapping="Wrap" ScrollViewer.VerticalScrollBarVisibility="Visible" />
@@ -72,11 +72,13 @@
                         </Grid.ColumnDefinitions>
                         <ComboBox IsEditable="True" Header="Eye Color" Grid.Column="0" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.EyesList}"
-                                  Text="{x:Bind CharVm.Eyes, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Eyes, Mode=TwoWay}"
+                                  PlaceholderText="{x:Bind CharVm.Eyes, Mode=TwoWay}" />
                         <TextBlock Grid.Column="1" MinWidth="100"/>
                         <ComboBox IsEditable="True" Header="Hair Color" Grid.Column="2"  MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.HairList}"
-                                  Text="{x:Bind CharVm.Hair, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Hair, Mode=TwoWay}" 
+                                  PlaceholderText="{x:Bind CharVm.Hair, Mode=TwoWay}" />
                     </Grid>
                     <Grid Grid.Row="3" HorizontalAlignment="Left">
                         <Grid.ColumnDefinitions>
@@ -86,11 +88,13 @@
                         </Grid.ColumnDefinitions>
                         <ComboBox IsEditable="True" Header="Build" Grid.Column="0" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.BuildList}"
-                                  Text="{x:Bind CharVm.Build, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Build, Mode=TwoWay}"
+                                  PlaceholderText="{x:Bind CharVm.Build, Mode=TwoWay}" />
                         <TextBlock Grid.Column="1" MinWidth="100"/>
                         <ComboBox IsEditable="True" Header="Complexion" Grid.Column="2" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.SkinList}"
-                                  Text="{x:Bind CharVm.Complexion, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Complexion, Mode=TwoWay}"
+                                  PlaceholderText="{x:Bind CharVm.Complexion, Mode=TwoWay}" />
                     </Grid>
                     <Grid Grid.Row="4" HorizontalAlignment="Left">
                         <Grid.ColumnDefinitions>
@@ -100,11 +104,13 @@
                         </Grid.ColumnDefinitions>
                         <ComboBox IsEditable="True" Header="Race" Grid.Column="0"  MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.RaceList}"
-                                  Text="{x:Bind CharVm.Race, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Race, Mode=TwoWay}"
+                                  PlaceholderText="{x:Bind CharVm.Race, Mode=TwoWay}" />
                         <TextBlock Grid.Column="1" MinWidth="100"/>
                         <ComboBox IsEditable="True" Header="Nationality" Grid.Column="2" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.NationalityList}"
-                                  Text="{x:Bind CharVm.Nationality, Mode=TwoWay}"/>
+                                  Text="{x:Bind CharVm.Nationality, Mode=TwoWay}"
+                                  PlaceholderText="{x:Bind CharVm.Nationality, Mode=TwoWay}"/>
                     </Grid>
                     <TextBox Header="General Health" Grid.Row="5"
                              Text="{x:Bind CharVm.Health, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
@@ -195,11 +201,13 @@
                         </Grid.ColumnDefinitions>
                         <ComboBox IsEditable="True" Header="Intelligence"  Grid.Column="0" Width="200"
                                   ItemsSource="{x:Bind CharVm.IntelligenceList}"
-                                  Text="{x:Bind CharVm.Intelligence, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Intelligence, Mode=TwoWay}"
+                                  PlaceholderText="{x:Bind CharVm.Intelligence, Mode=TwoWay}"/>
                         <TextBlock Width="100"  Grid.Column="1" />
                         <ComboBox IsEditable="True" Header="Values"  Grid.Column="2"  Width="200"
                                   ItemsSource="{x:Bind CharVm.ValuesList}"
-                                  Text="{x:Bind CharVm.Values, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Values, Mode=TwoWay}" 
+                                  PlaceholderText="{x:Bind CharVm.Values, Mode=TwoWay}" />
                     </Grid>
                     <Grid Grid.Row="2" HorizontalAlignment="Left">
                         <Grid.ColumnDefinitions>
@@ -209,11 +217,13 @@
                         </Grid.ColumnDefinitions>
                         <ComboBox IsEditable="True" Header="Focus"  Grid.Column="0" Width="200"
                                   ItemsSource="{x:Bind CharVm.FocusList}"
-                                  Text="{x:Bind CharVm.Focus, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Focus, Mode=TwoWay}"
+                                  PlaceholderText="{x:Bind CharVm.Focus, Mode=TwoWay}"/>
                         <TextBlock Width="100"  Grid.Column="1" />
                         <ComboBox IsEditable="True" Header="Abnormality"  Grid.Column="2"  Width="200"
                                   ItemsSource="{x:Bind CharVm.AbnormalityList}"
-                                  Text="{x:Bind CharVm.Abnormality, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Abnormality, Mode=TwoWay}"
+                                  PlaceholderText="{x:Bind CharVm.Abnormality, Mode=TwoWay}" />
                     </Grid>
                     <usercontrols:RichEditBoxExtended Header="Psych Notes" Grid.Row="3" 
                                                 RtfText="{x:Bind CharVm.PsychNotes, Mode=TwoWay}" AcceptsReturn="True"
@@ -238,41 +248,53 @@
                     </Grid.RowDefinitions>
                     <ComboBox IsEditable="True" Header="Adventureousness" Grid.Column="0" Grid.Row="0"  MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.AdventurousnessList}"
-                                  Text="{x:Bind CharVm.Adventurousness, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Adventurousness, Mode=TwoWay}"
+                                  PlaceholderText="{x:Bind CharVm.Adventurousness, Mode=TwoWay}" />
                     <ComboBox IsEditable="True" Header="Confidence" Grid.Column="0" Grid.Row="1" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.ConfidenceList}"
-                                  Text="{x:Bind CharVm.Confidence, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Confidence, Mode=TwoWay}"
+                                  PlaceholderText="{x:Bind CharVm.Confidence, Mode=TwoWay}" />
                     <ComboBox IsEditable="True" Header="Creativity" Grid.Column="0" Grid.Row="2" MinWidth="200" 
                                   ItemsSource="{x:Bind CharVm.CreativityList}"
-                                  Text="{x:Bind CharVm.Creativity, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Creativity, Mode=TwoWay}" 
+                                  PlaceholderText="{x:Bind CharVm.Creativity, Mode=TwoWay}" />
                     <ComboBox IsEditable="True" Header="Enthusiasm" Grid.Column="0" Grid.Row="3"  MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.EnthusiasmList}"
-                                  Text="{x:Bind CharVm.Enthusiasm, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Enthusiasm, Mode=TwoWay}"
+                                  PlaceholderText="{x:Bind CharVm.Enthusiasm, Mode=TwoWay}" />
                     <ComboBox IsEditable="True" Header="Sensitivity" Grid.Column="0" Grid.Row="4" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.SensitivityList}"
-                                  Text="{x:Bind CharVm.Sensitivity, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Sensitivity, Mode=TwoWay}"
+                                  PlaceholderText="{x:Bind CharVm.Sensitivity, Mode=TwoWay}" />
                     <ComboBox IsEditable="True" Header="Sociability" Grid.Column="0" Grid.Row="5" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.SociabilityList}"
-                                  Text="{x:Bind CharVm.Sociability, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Sociability, Mode=TwoWay}" 
+                                  PlaceholderText="{x:Bind CharVm.Sociability, Mode=TwoWay}" />
                     <TextBlock Grid.Column="1" Grid.Row="0" MinWidth="100"/>
                     <ComboBox IsEditable="True" Header="Aggression" Grid.Column="2" Grid.Row="0" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.AggressionList}"
-                                  Text="{x:Bind CharVm.Aggression, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Aggression, Mode=TwoWay}" 
+                                  PlaceholderText="{x:Bind CharVm.Aggression, Mode=TwoWay}" />
                     <ComboBox IsEditable="True" Header="Conscientiousness" Grid.Column="2" Grid.Row="1" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.ConscientiousnessList}"
-                                  Text="{x:Bind CharVm.Conscientiousness, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Conscientiousness, Mode=TwoWay}" 
+                                  PlaceholderText="{x:Bind CharVm.Conscientiousness, Mode=TwoWay}" />
                     <ComboBox IsEditable="True" Header="Dominance" Grid.Column="2" Grid.Row="2" MinWidth="200" 
                                   ItemsSource="{x:Bind CharVm.DominanceList}"
-                                  Text="{x:Bind CharVm.Dominance, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Dominance, Mode=TwoWay}"
+                                  PlaceholderText="{x:Bind CharVm.Dominance, Mode=TwoWay}"/>
                     <ComboBox IsEditable="True" Header="Self Assurance" Grid.Column="2" Grid.Row="3" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.AssuranceList}"
-                                  Text="{x:Bind CharVm.Assurance, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Assurance, Mode=TwoWay}" 
+                                  PlaceholderText="{x:Bind CharVm.Assurance, Mode=TwoWay}" />
                     <ComboBox IsEditable="True" Header="Shrewdness" Grid.Column="2" Grid.Row="4" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.ShrewdnessList}"
-                                  Text="{x:Bind CharVm.Shrewdness, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Shrewdness, Mode=TwoWay}"
+                                  PlaceholderText="{x:Bind CharVm.Shrewdness, Mode=TwoWay}" />
                     <ComboBox IsEditable="True" Header="Stability" Grid.Column="2" Grid.Row="5" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.StabilityList}"
-                                  Text="{x:Bind CharVm.Stability, Mode=TwoWay}" />
+                                  Text="{x:Bind CharVm.Stability, Mode=TwoWay}" 
+                                  PlaceholderText="{x:Bind CharVm.Stability, Mode=TwoWay}" />
                 </Grid>
             </PivotItem>
             <PivotItem Header="Outer Traits">

--- a/StoryCAD/Views/ProblemPage.xaml
+++ b/StoryCAD/Views/ProblemPage.xaml
@@ -32,25 +32,30 @@
                         </Grid.ColumnDefinitions>
                         <ComboBox Grid.Column="0" IsEditable="True" Header="Problem Type" Grid.Row="0"  MinWidth="200"
                               ItemsSource="{x:Bind ProblemVm.ProblemTypeList}"
-                              Text="{x:Bind ProblemVm.ProblemType, Mode=TwoWay}" />
+                              Text="{x:Bind ProblemVm.ProblemType, Mode=TwoWay}"
+                              PlaceholderText="{x:Bind ProblemVm.ProblemType, Mode=TwoWay}"/>
                         <TextBlock Grid.Column="1" Grid.Row="0" MinWidth="300"/>
                         <ComboBox Grid.Column="2" IsEditable="True" Header="Conflict Type" Grid.Row="0"  MinWidth="200"
                                     ItemsSource="{x:Bind ProblemVm.ConflictTypeList}"
-                                    Text="{x:Bind ProblemVm.ConflictType, Mode=TwoWay}" />
+                                    Text="{x:Bind ProblemVm.ConflictType, Mode=TwoWay}"
+                                    PlaceholderText="{x:Bind ProblemVm.ConflictType, Mode=TwoWay}"  />
                     </Grid>
                     <ComboBox IsEditable="True" Header="Problem Category" Grid.Row="1" MinWidth="300"
                                         ItemsSource="{x:Bind ProblemVm.ProblemCategoryList}"
-                                        Text="{x:Bind ProblemVm.ProblemCategory, Mode=TwoWay}" />
+                                        Text="{x:Bind ProblemVm.ProblemCategory, Mode=TwoWay}" 
+                                        PlaceholderText="{x:Bind ProblemVm.ProblemCategory, Mode=TwoWay}" />
                     <ComboBox IsEditable="True" Header="Subject" Grid.Row="2" MinWidth="300"
                                     ItemsSource="{x:Bind ProblemVm.SubjectList}"
-                                    Text="{x:Bind ProblemVm.Subject, Mode=TwoWay}" />
+                                    Text="{x:Bind ProblemVm.Subject, Mode=TwoWay}" 
+                                    PlaceholderText="{x:Bind ProblemVm.Subject, Mode=TwoWay}" />
                     <usercontrols:RichEditBoxExtended Header="Story Question" Grid.Row="3"
                                                           RtfText="{x:Bind ProblemVm.StoryQuestion, Mode=TwoWay}" AcceptsReturn="True"
                                                           IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                           ScrollViewer.VerticalScrollBarVisibility="Visible" />
                     <ComboBox IsEditable="True" Header="Problem Source" Grid.Row="4" MinWidth="300"
                                     ItemsSource="{x:Bind ProblemVm.ProblemSourceList}"
-                                    Text="{x:Bind ProblemVm.ProblemSource, Mode=TwoWay}" />
+                                    Text="{x:Bind ProblemVm.ProblemSource, Mode=TwoWay}"
+                                    PlaceholderText="{x:Bind ProblemVm.ProblemSource, Mode=TwoWay}" />
                 </Grid>
             </PivotItem>
             <PivotItem Header="Protagonist" >
@@ -67,10 +72,12 @@
                               SelectedItem="{x:Bind ProblemVm.Protagonist, Mode=TwoWay, Converter={StaticResource ToStoryElement}}" />
                     <ComboBox IsEditable="True" Header="Goal" Grid.Row="1" 
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.GoalList}"
-                              Text="{x:Bind ProblemVm.ProtGoal, Mode=TwoWay}" />
+                              Text="{x:Bind ProblemVm.ProtGoal, Mode=TwoWay}" 
+                              PlaceholderText="{x:Bind ProblemVm.ProtGoal, Mode=TwoWay}" />
                     <ComboBox IsEditable="True" Header="Motivation" Grid.Row="2" 
                                     MinWidth="300" ItemsSource="{x:Bind ProblemVm.MotiveList}"
-                                    Text="{x:Bind ProblemVm.ProtMotive, Mode=TwoWay}" />
+                                    Text="{x:Bind ProblemVm.ProtMotive, Mode=TwoWay}" 
+                                    PlaceholderText="{x:Bind ProblemVm.ProtMotive, Mode=TwoWay}" />
                     <Button  Content="Conflict Builder" Grid.Row="3" HorizontalAlignment="Left" Margin="0,10,10,10" 
                              Command="{x:Bind ProblemVm.ConflictCommand, Mode=OneWay}" />
                     <usercontrols:RichEditBoxExtended Header="Conflict" Grid.Row="4"  
@@ -93,10 +100,12 @@
                               SelectedItem="{x:Bind ProblemVm.Antagonist, Mode=TwoWay, Converter={StaticResource ToStoryElement}}" />
                     <ComboBox IsEditable="True" Header="Goal" Grid.Row="1" 
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.GoalList}"
-                              Text="{x:Bind ProblemVm.AntagGoal, Mode=TwoWay}" />
+                              Text="{x:Bind ProblemVm.AntagGoal, Mode=TwoWay}" 
+                              PlaceholderText="{x:Bind ProblemVm.AntagGoal, Mode=TwoWay}" />
                     <ComboBox IsEditable="True" Header="Motivation" Grid.Row="2" 
                               MinWidth="300" ItemsSource="{x:Bind ProblemVm.MotiveList}"
-                              Text="{x:Bind ProblemVm.AntagMotive, Mode=TwoWay}" />
+                              Text="{x:Bind ProblemVm.AntagMotive, Mode=TwoWay}" 
+                              PlaceholderText="{x:Bind ProblemVm.AntagMotive, Mode=TwoWay}" />
                     <Button  Content="Conflict Builder" Grid.Row="3" HorizontalAlignment="Left" Margin="0,10,10,10" 
                              Command="{x:Bind ProblemVm.ConflictCommand, Mode=OneWay}" />
                     <usercontrols:RichEditBoxExtended Header="Conflict" Grid.Row="4"  
@@ -115,13 +124,16 @@
                     </Grid.RowDefinitions>
                     <ComboBox IsEditable="True" Header="Outcome" Grid.Row="0" 
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.OutcomeList}"
-                              Text="{x:Bind ProblemVm.Outcome, Mode=TwoWay}" />
+                              Text="{x:Bind ProblemVm.Outcome, Mode=TwoWay}"
+                              PlaceholderText="{x:Bind ProblemVm.Outcome, Mode=TwoWay}" />
                     <ComboBox IsEditable="True" Header="Method" Grid.Row="1" 
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.MethodList}"
-                              Text="{x:Bind ProblemVm.Method, Mode=TwoWay}" />
+                              Text="{x:Bind ProblemVm.Method, Mode=TwoWay}" 
+                              PlaceholderText="{x:Bind ProblemVm.Method, Mode=TwoWay}" />
                     <ComboBox IsEditable="True" Header="Theme" Grid.Row="2" 
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.ThemeList}"
-                              Text="{x:Bind ProblemVm.Theme, Mode=TwoWay}" />
+                              Text="{x:Bind ProblemVm.Theme, Mode=TwoWay}" 
+                              PlaceholderText="{x:Bind ProblemVm.Theme, Mode=TwoWay}" />
                     <usercontrols:RichEditBoxExtended Header="Premise" Grid.Row="3"
                               RtfText="{x:Bind ProblemVm.Premise, Mode=TwoWay}" AcceptsReturn="True"
                               IsSpellCheckEnabled="True" TextWrapping="Wrap"

--- a/StoryCAD/Views/ScenePage.xaml
+++ b/StoryCAD/Views/ScenePage.xaml
@@ -69,7 +69,8 @@
                         <TextBlock Grid.Column="1" MinWidth="50"/>
                         <ComboBox IsEditable="True" Header="SceneType" Grid.Column="2" MinWidth="200"
                                             ItemsSource="{x:Bind SceneVm.SceneTypeList}"
-                                            Text="{x:Bind SceneVm.SceneType, Mode=TwoWay}" />
+                                            Text="{x:Bind SceneVm.SceneType, Mode=TwoWay}"
+                                            PlaceholderText="{x:Bind SceneVm.SceneType, Mode=TwoWay}"/>
                     </Grid>
                     <usercontrols:RichEditBoxExtended Header="Scene Sketch" Grid.Row="3"
                                                       RtfText="{x:Bind SceneVm.Remarks, Mode=TwoWay}"
@@ -191,14 +192,18 @@
                         <TextBlock Grid.Column="1" MinWidth="50"/>
                         <ComboBox IsEditable="True" Header="Feelings" Grid.Column="2" MinWidth="200"
                                             ItemsSource="{x:Bind SceneVm.EmotionList}"
-                                            Text="{x:Bind SceneVm.ProtagEmotion, Mode=TwoWay}" />
+                                            Text="{x:Bind SceneVm.ProtagEmotion, Mode=TwoWay}" 
+                                            PlaceholderText="{x:Bind SceneVm.ProtagEmotion, Mode=TwoWay}" />
                     </Grid>
                     <ComboBox IsEditable="True" Header="Protagonist's Goal" Grid.Row="1"  MinWidth="300"
                                         ItemsSource="{x:Bind SceneVm.GoalList}"
-                                        Text="{x:Bind SceneVm.ProtagGoal, Mode=TwoWay}" />
+                                        Text="{x:Bind SceneVm.ProtagGoal, Mode=TwoWay}"
+                                        PlaceholderText="{x:Bind SceneVm.ProtagGoal, Mode=TwoWay}"/>
                     <ComboBox IsEditable="True" Header="Opposition" Grid.Row="2" Width="400"
                                         ItemsSource="{x:Bind SceneVm.OppositionList}"
-                                        Text="{x:Bind SceneVm.Opposition, Mode=TwoWay}" HorizontalAlignment="Left"/>
+                                        Text="{x:Bind SceneVm.Opposition, Mode=TwoWay}" 
+                                        PlaceholderText="{x:Bind SceneVm.Opposition, Mode=TwoWay}" 
+                                        HorizontalAlignment="Left"/>
                     <Grid Grid.Row="3" HorizontalAlignment="Left">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="3*"/>
@@ -211,15 +216,19 @@
                         <TextBlock Grid.Column="1" MinWidth="50"/>
                         <ComboBox IsEditable="True" Header="Feelings" Grid.Column="2"  MinWidth="200"
                                             ItemsSource="{x:Bind SceneVm.EmotionList}"
-                                            Text="{x:Bind SceneVm.AntagEmotion, Mode=TwoWay}" />
+                                            Text="{x:Bind SceneVm.AntagEmotion, Mode=TwoWay}" 
+                                            PlaceholderText="{x:Bind SceneVm.AntagEmotion, Mode=TwoWay}" />
                     </Grid>
                     <ComboBox IsEditable="True" Header="Antagonist's Goal" Grid.Row="4" MinWidth="300"
                                         ItemsSource="{x:Bind SceneVm.GoalList}"
-                                        Text="{x:Bind SceneVm.AntagGoal, Mode=TwoWay}" />
+                                        Text="{x:Bind SceneVm.AntagGoal, Mode=TwoWay}" 
+                                        PlaceholderText="{x:Bind SceneVm.AntagGoal, Mode=TwoWay}" />
                     <TextBlock Grid.Row="5" Text=" "/>
                     <ComboBox IsEditable="True" Header="Outcome" Grid.Row="5" Width="400"
                                         ItemsSource="{x:Bind SceneVm.OutcomeList}"
-                                        Text="{x:Bind SceneVm.Outcome, Mode=TwoWay}" HorizontalAlignment="Left"/>
+                                        Text="{x:Bind SceneVm.Outcome, Mode=TwoWay}"
+                                        PlaceholderText="{x:Bind SceneVm.Outcome, Mode=TwoWay}"
+                                        HorizontalAlignment="Left"/>
                 </Grid>
             </PivotItem>
             <PivotItem Header="Sequel">
@@ -231,14 +240,16 @@
                     </Grid.RowDefinitions>
                     <ComboBox IsEditable="True" Header="Emotional Response" Grid.Row="0" MinWidth="200"
                                         ItemsSource="{x:Bind SceneVm.EmotionList}"
-                                        Text="{x:Bind SceneVm.Emotion, Mode=TwoWay}" />
+                                        Text="{x:Bind SceneVm.Emotion, Mode=TwoWay}" 
+                                        PlaceholderText="{x:Bind SceneVm.Emotion, Mode=TwoWay}" />
                     <usercontrols:RichEditBoxExtended Header="Review and Thought" Grid.Row="1"
                                                       RtfText="{x:Bind SceneVm.Review, Mode=TwoWay}" AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                       ScrollViewer.VerticalScrollBarVisibility="Visible" />
                     <ComboBox IsEditable="True" Header="New Goal" Grid.Row="2" MinWidth="400"
                                         ItemsSource="{x:Bind SceneVm.GoalList}"
-                                        Text="{x:Bind SceneVm.NewGoal, Mode=TwoWay}" />
+                                        Text="{x:Bind SceneVm.NewGoal, Mode=TwoWay}" 
+                                        PlaceholderText="{x:Bind SceneVm.NewGoal, Mode=TwoWay}" />
                 </Grid>
             </PivotItem>
             <PivotItem Header="Notes">

--- a/StoryCAD/Views/SettingPage.xaml
+++ b/StoryCAD/Views/SettingPage.xaml
@@ -36,11 +36,13 @@
                         </Grid.ColumnDefinitions>
                         <ComboBox IsEditable="True" Header="Locale" Grid.Column="0"  MinWidth="200"
                                   ItemsSource="{x:Bind SettingVm.LocaleList}"
-                                  Text="{x:Bind SettingVm.Locale, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                  Text="{x:Bind SettingVm.Locale, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                  PlaceholderText="{x:Bind SettingVm.Locale, Mode=TwoWay}" />
                         <TextBlock Grid.Column="1" MinWidth="100"/>
                         <ComboBox IsEditable="True" Header="Season" Grid.Column="2" MinWidth="200"
                                         ItemsSource="{x:Bind SettingVm.SeasonList}"
-                                        Text="{x:Bind SettingVm.Season, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                        Text="{x:Bind SettingVm.Season, Mode=TwoWay}" 
+                                        PlaceholderText="{x:Bind SettingVm.Season, Mode=TwoWay}" />
                     </Grid>
                     <Grid Grid.Row="1" HorizontalAlignment="Left">
                         <Grid.ColumnDefinitions>

--- a/StoryCADLib/Controls/RelationshipView.xaml
+++ b/StoryCADLib/Controls/RelationshipView.xaml
@@ -47,8 +47,8 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
-                                <ComboBox Grid.Row="0" Grid.Column="1" IsEditable="True"  Header= "Trait" MinWidth="150" ItemsSource="{x:Bind CharVM.RelationshipTraitList}" Text="{x:Bind Trait, Mode=TwoWay}" Margin="0,0,10,0" />
-                                <ComboBox Grid.Row="0" Grid.Column="2" IsEditable="True" Header="Attitude"  MinWidth="150" ItemsSource="{x:Bind CharVM.RelationshipAttitudeList}" Text="{x:Bind Attitude, Mode=TwoWay}"/>
+                                <ComboBox Grid.Row="0" Grid.Column="1" IsEditable="True"  Header= "Trait" MinWidth="150" ItemsSource="{x:Bind CharVM.RelationshipTraitList}" Text="{x:Bind Trait, Mode=TwoWay}" PlaceholderText="{x:Bind Trait, Mode=TwoWay}" Margin="0,0,10,0" />
+                                <ComboBox Grid.Row="0" Grid.Column="2" IsEditable="True" Header="Attitude"  MinWidth="150" ItemsSource="{x:Bind CharVM.RelationshipAttitudeList}" Text="{x:Bind Attitude, Mode=TwoWay}" PlaceholderText="{x:Bind Attitude, Mode =TwoWay}"/>
                                 <usercontrols:RichEditBoxExtended Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="4" MinHeight="200" HorizontalAlignment="Stretch" Header="Relationship Notes"  RtfText="{x:Bind Notes, Mode=TwoWay}" AcceptsReturn="True" IsSpellCheckEnabled="True" TextWrapping="Wrap" ScrollViewer.VerticalScrollBarVisibility="Visible"/>
                             </Grid>
                         </Expander>

--- a/StoryCADLib/Services/Dialogs/NewRelationshipPage.xaml
+++ b/StoryCADLib/Services/Dialogs/NewRelationshipPage.xaml
@@ -10,7 +10,7 @@
         <StackPanel Orientation="Horizontal" Width="500" HorizontalAlignment="Center">
             <TextBlock  Text="{x:Bind CharVM.Name}" VerticalAlignment="Center" MaxWidth="120" TextWrapping="Wrap"/>
             <TextBlock  Text=" is a " VerticalAlignment="Center" Margin="0,0,5,0"/>
-            <ComboBox  MinWidth="150" ItemsSource="{x:Bind  NewRelVM.RelationTypes}" IsEditable="True"  SelectedValue="{x:Bind  NewRelVM.RelationType, Mode=TwoWay}" Margin="0,10" VerticalAlignment="Center"/>
+            <ComboBox  MinWidth="150" ItemsSource="{x:Bind  NewRelVM.RelationTypes}" IsEditable="True" PlaceholderText="{x:Bind NewRelVM.RelationType}"  SelectedValue="{x:Bind  NewRelVM.RelationType, Mode=TwoWay}" Margin="0,10" VerticalAlignment="Center"/>
             <TextBlock  Text=" to " VerticalAlignment="Center" Margin="5,0"/>
             <ComboBox Name="PartnerBox" IsEditable="False" MinWidth="150" ItemsSource="{x:Bind NewRelVM.ProspectivePartners}" DisplayMemberPath="Name" SelectedItem="{x:Bind  NewRelVM.SelectedPartner, Mode=TwoWay}" VerticalAlignment="Center"/>
         </StackPanel>
@@ -19,7 +19,8 @@
         <StackPanel Orientation="Horizontal" Width="500" HorizontalAlignment="Center">
             <TextBlock Text="{x:Bind  NewRelVM.SelectedPartner.Name, Mode=TwoWay}" VerticalAlignment="Center" MaxWidth="120" TextWrapping="Wrap"/>
             <TextBlock  Text=" is a " VerticalAlignment="Center" Margin="2,0,0,0"/>
-            <ComboBox   MinWidth="150" ItemsSource="{x:Bind  NewRelVM.RelationTypes}" VerticalAlignment="Center" IsEditable="True"  SelectedValue="{x:Bind  NewRelVM.InverseRelationType, Mode=TwoWay}" IsEnabled="{x:Bind NewRelVM.InverseRelationship, Mode=TwoWay}"/>
+            <ComboBox   MinWidth="150" ItemsSource="{x:Bind  NewRelVM.RelationTypes}" VerticalAlignment="Center" IsEditable="True"  SelectedValue="{x:Bind  NewRelVM.InverseRelationType, Mode=TwoWay}"
+                        PlaceholderText="{x:Bind NewRelVM.InverseRelationType, Mode=TwoWay}" IsEnabled="{x:Bind NewRelVM.InverseRelationship, Mode=TwoWay}"/>
             <TextBlock  Text=" to" VerticalAlignment="Center" Margin="5,0"/>
             <TextBlock  Text="{x:Bind CharVM.Name}"  VerticalAlignment="Center" MaxWidth="120" TextWrapping="Wrap"/>
         </StackPanel>

--- a/StoryCADLib/Services/IoC/ServiceLocator.cs
+++ b/StoryCADLib/Services/IoC/ServiceLocator.cs
@@ -25,6 +25,7 @@ namespace StoryCAD.Services.IoC
         {
             Services.AddSingleton<NavigationService>();
             Services.AddSingleton<ILogService, LogService>();
+            Services.AddSingleton<LogService>();
             Services.AddSingleton<SearchService>();
             Services.AddSingleton<ControlLoader>();
             Services.AddSingleton<ListLoader>();


### PR DESCRIPTION
during the creation of 2.14.4 Syncfusion was removed and all Comboboxes were shifted to the default WinUI Comboboxes.

Yesterday I noticed that Comboboxes that allow custom content (IsEditable=True) will NOT load content until clicked.
This does not cause data loss and is merely a UI issue (albeit a major one)

This PR adds an unsanctioned workaround which fixes this issue by simply binding to PlaceholderText, which means populated comboboxes appear populated until clicked at which point they are really populated.

Special thanks to Microsoft's UI team for causing a lot of stress at midnight on a friday with a  problem that has had no offical action in roughly two years.

Releated information
https://github.com/microsoft/microsoft-ui-xaml/issues/7103
https://stackoverflow.com/questions/72255341/winui-3-editable-combobox-not-displaying-bound-text-on-application-start