### PR TITLE
fix invalid chars

### DIFF
--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap17="http:schemas.microsoft.com/appx/manifest/uap/windows10/17" IgnorableNamespaces="uap rescap uap3 uap17">
-  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.14.3.65535" />
+  <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="2.14.6.65535" />
   <Properties>
     <DisplayName>StoryCAD</DisplayName>
     <PublisherDisplayName>STORYBUILDER ORG</PublisherDisplayName>

--- a/StoryCADLib/Services/Dialogs/NewProjectPage.xaml
+++ b/StoryCADLib/Services/Dialogs/NewProjectPage.xaml
@@ -27,6 +27,10 @@
         <TextBox x:Name="ProjectName" x:FieldModifier="public" MinWidth="250" 
                  HorizontalAlignment="Center" Header="Project Name: "
                  Text="{x:Bind UnifiedVM.ProjectName, Mode=TwoWay}" Margin="0,20"/>
+ 
+		<TextBlock Text="Your story name contains disallowed characters."
+		           HorizontalAlignment="Center" TextWrapping="Wrap"
+		           Visibility="{x:Bind UnifiedVM.ProjectNameErrorVisibility, Mode=TwoWay}"/>
 
 		<Button Content="Create project" Margin="5,20" HorizontalAlignment="Center" 
 		        Click="{x:Bind UnifiedVM.CheckValidity}"/>

--- a/StoryCADLib/Services/Dialogs/NewProjectPage.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/NewProjectPage.xaml.cs
@@ -7,6 +7,7 @@ public sealed partial class NewProjectPage : Page
 {
 	public NewProjectPage(UnifiedVM vm)
 	{
+		vm.ProjectNameErrorVisibility = Visibility.Collapsed;
 		InitializeComponent();
 		UnifiedVM = vm;
 	}


### PR DESCRIPTION
This PR does two things

- Bumps the version id of StoryCAD to 2.14.6
- Fixes the implementation of how StoryCAD checks for invalid characters in file names (#785) 