### PR TITLE
Story node item logging

### DIFF
--- a/StoryCADLib/ViewModels/StoryNodeItem.cs
+++ b/StoryCADLib/ViewModels/StoryNodeItem.cs
@@ -1,11 +1,9 @@
 ﻿using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Windows.Data.Xml.Dom;
-using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using StoryCAD.Services;
-using LogLevel = StoryCAD.Services.Logging.LogLevel;
 
 namespace StoryCAD.ViewModels;
 
@@ -330,14 +328,13 @@ public class StoryNodeItem : INotifyPropertyChanged
 
     // Overloaded constructor without logger
     public StoryNodeItem(StoryElement node, StoryNodeItem parent,
-        StoryItemType type = StoryItemType.Unknown) : this(null, node, parent, type)
+        StoryItemType type = StoryItemType.Unknown) : this(Ioc.Default.GetRequiredService<ILogService>(), node, parent, type)
     {
-	    ;
     }
 
     public StoryNodeItem(ILogService logger, StoryNodeItem parent, IXmlNode node)
     {
-         _logger = logger;
+        _logger = logger;
         
         XmlNamedNodeMap _attrs = node.Attributes;
         if (_attrs != null)
@@ -411,17 +408,15 @@ public class StoryNodeItem : INotifyPropertyChanged
     }
 
     // Overloaded constructor without logger
-    public StoryNodeItem(StoryNodeItem parent, IXmlNode node) : this(null, parent, node)
+    public StoryNodeItem(StoryNodeItem parent, IXmlNode node) : this(Ioc.Default.GetRequiredService<ILogService>(), parent, node)
     {
-	    
     }
 
     #endregion
 
-    public void Delete(ILogService logger, StoryViewType storyView)
+	public void Delete(StoryViewType storyView)
     {
-	    _logger = logger;
-		_logger.Log(LogLevel.Trace, $"Starting to delete element {Name} ({Uuid}) from {storyView}");
+        _logger.Log(LogLevel.Trace, $"Starting to delete element {Name} ({Uuid}) from {storyView}");
         //Sanity check
         if (Type == StoryItemType.TrashCan || IsRoot)
         {

--- a/StoryCADLib/ViewModels/StoryNodeItem.cs
+++ b/StoryCADLib/ViewModels/StoryNodeItem.cs
@@ -328,7 +328,7 @@ public class StoryNodeItem : INotifyPropertyChanged
 
     // Overloaded constructor without logger
     public StoryNodeItem(StoryElement node, StoryNodeItem parent,
-        StoryItemType type = StoryItemType.Unknown) : this(null, node, parent, type) 
+        StoryItemType type = StoryItemType.Unknown) : this(Ioc.Default.GetRequiredService<ILogService>(), node, parent, type)
     {
     }
 
@@ -408,13 +408,13 @@ public class StoryNodeItem : INotifyPropertyChanged
     }
 
     // Overloaded constructor without logger
-    public StoryNodeItem(StoryNodeItem parent, IXmlNode node) : this(null, parent, node)
+    public StoryNodeItem(StoryNodeItem parent, IXmlNode node) : this(Ioc.Default.GetRequiredService<ILogService>(), parent, node)
     {
     }
 
     #endregion
 
-        public void Delete(StoryViewType storyView)
+	public void Delete(StoryViewType storyView)
     {
         _logger.Log(LogLevel.Trace, $"Starting to delete element {Name} ({Uuid}) from {storyView}");
         //Sanity check

--- a/StoryCADLib/ViewModels/StoryNodeItem.cs
+++ b/StoryCADLib/ViewModels/StoryNodeItem.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Windows.Data.Xml.Dom;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using StoryCAD.Services;
+using LogLevel = StoryCAD.Services.Logging.LogLevel;
 
 namespace StoryCAD.ViewModels;
 
@@ -328,13 +330,14 @@ public class StoryNodeItem : INotifyPropertyChanged
 
     // Overloaded constructor without logger
     public StoryNodeItem(StoryElement node, StoryNodeItem parent,
-        StoryItemType type = StoryItemType.Unknown) : this(Ioc.Default.GetRequiredService<ILogService>(), node, parent, type)
+        StoryItemType type = StoryItemType.Unknown) : this(null, node, parent, type)
     {
+	    ;
     }
 
     public StoryNodeItem(ILogService logger, StoryNodeItem parent, IXmlNode node)
     {
-        _logger = logger;
+         _logger = logger;
         
         XmlNamedNodeMap _attrs = node.Attributes;
         if (_attrs != null)
@@ -408,15 +411,17 @@ public class StoryNodeItem : INotifyPropertyChanged
     }
 
     // Overloaded constructor without logger
-    public StoryNodeItem(StoryNodeItem parent, IXmlNode node) : this(Ioc.Default.GetRequiredService<ILogService>(), parent, node)
+    public StoryNodeItem(StoryNodeItem parent, IXmlNode node) : this(null, parent, node)
     {
+	    
     }
 
     #endregion
 
-	public void Delete(StoryViewType storyView)
+    public void Delete(ILogService logger, StoryViewType storyView)
     {
-        _logger.Log(LogLevel.Trace, $"Starting to delete element {Name} ({Uuid}) from {storyView}");
+	    _logger = logger;
+		_logger.Log(LogLevel.Trace, $"Starting to delete element {Name} ({Uuid}) from {storyView}");
         //Sanity check
         if (Type == StoryItemType.TrashCan || IsRoot)
         {

--- a/StoryCADTests/NodeItemTests.cs
+++ b/StoryCADTests/NodeItemTests.cs
@@ -1,0 +1,27 @@
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StoryCAD.Models;
+using StoryCAD.ViewModels;
+
+namespace StoryCADTests;
+
+[TestClass]
+class NodeItemTests
+{
+	/// <summary>
+	/// Creates a new node and tries to delete it.
+	/// </summary>
+	[TestMethod]
+	public void TryDelete()
+	{
+		ShellViewModel Shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+		StoryModel model = new();
+		ProblemModel Overview = new("Overview", model);
+		StoryNodeItem overview = new(null, Overview, null);
+		ProblemModel Problem = new("Test",model);
+		StoryNodeItem Prob = new(null, Problem, overview);
+
+		Shell.StoryModel = model;
+		Prob.Delete(StoryViewType.ExplorerView);
+	}
+}


### PR DESCRIPTION
This PR fixes an issue where storycad would crash when delete was clicked due to changes made in 2.14.5 where logservice was accidentally null in story node item (fixes #791, #792)