### PR TITLE
Upgrade to artifacts v4

### DIFF
--- a/.github/workflows/AutoBuilder.yml
+++ b/.github/workflows/AutoBuilder.yml
@@ -130,7 +130,9 @@ jobs:
     
     # Upload the MSIX package: https://github.com/marketplace/actions/upload-a-build-artifact
     - name: Upload MSIX package
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: StoryCAD
-        path: D:\a\StoryCAD\StoryCAD\StoryCAD\Packages\*
+        path: StoryCAD/StoryCAD/StoryCAD/Packages/*
+        compression-level: 9
+        include-hidden-files: true


### PR DESCRIPTION
This PR fixes an upcoming issue as GitHub will be deprecating artifacts v3 at some point soon enough to email me about the fact we are still using it so this PR updates AutoBuilder and Release Builder to Artifacts V4.

Notable changes:
- I set compression to max
- I included hidden files since this used to be default but isn't, I don't know if not including hidden files will cause any problems so I turned it on.