### PR TITLE
More help

### DIFF
--- a/StoryCAD/Views/Shell.xaml.cs
+++ b/StoryCAD/Views/Shell.xaml.cs
@@ -88,13 +88,17 @@ public sealed partial class Shell
 			await new Services.Dialogs.Changelog().ShowChangeLog();
         }
 
-        ContentDialog CD = new()
+        if (Preferences.ShowStartupDialog)
         {
-			Title = "Need help getting started?",
-			Content = new HelpPage(),
-			PrimaryButtonText = "Close",
-		};
-        await Ioc.Default.GetRequiredService<Windowing>().ShowContentDialog(CD);
+	        ContentDialog CD = new()
+	        {
+		        Title = "Need help getting started?",
+		        Content = new HelpPage(),
+		        PrimaryButtonText = "Close",
+	        };
+	        await Ioc.Default.GetRequiredService<Windowing>().ShowContentDialog(CD);
+		}
+
         //If StoryCAD was loaded from a .STBX File then instead of showing the Unified menu
         //We will instead load the file instead.
         Logger.Log(LogLevel.Info, $"Filepath to launch {ShellVm.FilePathToLaunch}");

--- a/StoryCAD/Views/Shell.xaml.cs
+++ b/StoryCAD/Views/Shell.xaml.cs
@@ -88,6 +88,13 @@ public sealed partial class Shell
 			await new Services.Dialogs.Changelog().ShowChangeLog();
         }
 
+        ContentDialog CD = new()
+        {
+			Title = "Need help getting started?",
+			Content = new HelpPage(),
+			PrimaryButtonText = "Close",
+		};
+        await Ioc.Default.GetRequiredService<Windowing>().ShowContentDialog(CD);
         //If StoryCAD was loaded from a .STBX File then instead of showing the Unified menu
         //We will instead load the file instead.
         Logger.Log(LogLevel.Info, $"Filepath to launch {ShellVm.FilePathToLaunch}");

--- a/StoryCADLib/DAL/PreferencesIO.cs
+++ b/StoryCADLib/DAL/PreferencesIO.cs
@@ -200,7 +200,9 @@ public class PreferencesIo
 					case "AdvancedLogging":
 						_model.AdvancedLogging = _tokens[1] == "True";
 						break;
-
+					case "StartupPage":
+						_model.ShowStartupDialog = _tokens[1] == "True";
+						break;
 				}
 			}
 
@@ -279,6 +281,7 @@ public class PreferencesIo
 		                          CummulativeTimeUsed={_model.CumulativeTimeUsed}
 		                          LastReviewDate={_model.LastReviewDate}
 		                          AdvancedLogging={_model.AdvancedLogging}
+		                          StartupPage={_model.ShowStartupDialog}
 		                          """;
 
 		_newPreferences += (_model.WrapNodeNames == TextWrapping.WrapWholeWords

--- a/StoryCADLib/Models/Tools/PreferencesModel.cs
+++ b/StoryCADLib/Models/Tools/PreferencesModel.cs
@@ -90,7 +90,11 @@ public class PreferencesModel : ObservableObject
 	/// DateTime of last review
 	/// </summary>
 	public DateTime LastReviewDate;
-  
+
+	/// <summary>
+	/// Should the startup dialog (HelpPage) be shown
+	/// </summary>
+	public bool ShowStartupDialog;
   
 	/// <summary>
 	/// Do we want to log more in depth
@@ -130,8 +134,9 @@ public class PreferencesModel : ObservableObject
 		ThemePreference = ElementTheme.Default; // Use system theme
 		HideRatingPrompt = false;
 		CumulativeTimeUsed = 0;
-    AdvancedLogging = false;
+		AdvancedLogging = false;
 		LastReviewDate = DateTime.MinValue;
+		ShowStartupDialog = true;
 	}
 	#endregion
 }

--- a/StoryCADLib/Services/Dialogs/HelpPage.xaml
+++ b/StoryCADLib/Services/Dialogs/HelpPage.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="StoryCAD.Services.Dialogs.HelpPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:StoryCAD.Services.Dialogs"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+<StackPanel>
+	<TextBlock Text="StoryCAD can be daunting, so here are some resources to help you get started"/>
+		<HyperlinkButton Content="StoryCAD Concepts (Video)" NavigateUri="https://www.youtube.com/watch?v=Oi7G9TEKsro"/>
+		<HyperlinkButton Content="A 5 minute Introduction to StoryCAD" NavigateUri="https://www.youtube.com/watch?v=qFpTI15-q7A"/>
+		<HyperlinkButton Content="Frequently Asked Questions" NavigateUri="https://www.storybuilder.org/faq"/>
+		<HyperlinkButton Content="Tutorial" NavigateUri="https://storybuilder-org.github.io/StoryCAD/Tutorial_Creating_a_Story.html"/>
+		<HyperlinkButton Content="User manual" NavigateUri="https://storybuilder-org.github.io/StoryCAD/"/>
+		<HyperlinkButton Content="Events" NavigateUri="https://storybuilder.org/events/"/>
+
+		<CheckBox Content="Don't show this again" HorizontalAlignment="Center" VerticalAlignment="Bottom"/>
+	</StackPanel>
+</Page>

--- a/StoryCADLib/Services/Dialogs/HelpPage.xaml
+++ b/StoryCADLib/Services/Dialogs/HelpPage.xaml
@@ -3,20 +3,25 @@
     x:Class="StoryCAD.Services.Dialogs.HelpPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:StoryCAD.Services.Dialogs"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
 <StackPanel>
-	<TextBlock Text="StoryCAD can be daunting, so here are some resources to help you get started"/>
+	<InfoBar Severity="Informational" IsOpen="True" IsClosable="False">
+			<TextBlock Text="The videos below refer to StoryCAD as StoryBuilder,
+however are still a good place to get started" TextWrapping="Wrap" Margin="10,10"/>
+	</InfoBar>
+		<TextBlock Text="StoryCAD can be daunting, so here are some resources to help you get started:" Margin="0,10"/>
+
 		<HyperlinkButton Content="StoryCAD Concepts (Video)" NavigateUri="https://www.youtube.com/watch?v=Oi7G9TEKsro"/>
-		<HyperlinkButton Content="A 5 minute Introduction to StoryCAD" NavigateUri="https://www.youtube.com/watch?v=qFpTI15-q7A"/>
+		<HyperlinkButton Content="A 5-minute Introduction to StoryCAD (Video)" NavigateUri="https://www.youtube.com/watch?v=qFpTI15-q7A"/>
 		<HyperlinkButton Content="Frequently Asked Questions" NavigateUri="https://www.storybuilder.org/faq"/>
 		<HyperlinkButton Content="Tutorial" NavigateUri="https://storybuilder-org.github.io/StoryCAD/Tutorial_Creating_a_Story.html"/>
 		<HyperlinkButton Content="User manual" NavigateUri="https://storybuilder-org.github.io/StoryCAD/"/>
 		<HyperlinkButton Content="Events" NavigateUri="https://storybuilder.org/events/"/>
 
-		<CheckBox Content="Don't show this again" HorizontalAlignment="Center" VerticalAlignment="Bottom"/>
+		<CheckBox Content="Don't show this again" Click="Clicked"
+		          HorizontalAlignment="Center" VerticalAlignment="Bottom"/>
 	</StackPanel>
 </Page>

--- a/StoryCADLib/Services/Dialogs/HelpPage.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/HelpPage.xaml.cs
@@ -1,31 +1,17 @@
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
+namespace StoryCAD.Services.Dialogs;
 
-namespace StoryCAD.Services.Dialogs
+public sealed partial class HelpPage : Page
 {
+	public HelpPage() { InitializeComponent(); }
+
 	/// <summary>
-	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// Update preferences to hide/show menu
 	/// </summary>
-	public sealed partial class HelpPage : Page
+	private void Clicked(object sender, RoutedEventArgs e)
 	{
-		public HelpPage()
-		{
-			this.InitializeComponent();
-		}
+		Ioc.Default.GetRequiredService<PreferenceService>().Model.ShowStartupDialog = 
+			(bool)(sender as CheckBox).IsChecked;
 	}
 }

--- a/StoryCADLib/Services/Dialogs/HelpPage.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/HelpPage.xaml.cs
@@ -1,0 +1,31 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace StoryCAD.Services.Dialogs
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class HelpPage : Page
+	{
+		public HelpPage()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
@@ -35,24 +35,41 @@
                 </StackPanel>
             </PivotItem>
             <PivotItem Header="Other" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
-                <StackPanel HorizontalAlignment="Center">
-                    <CheckBox Content="Send error logs to Team StoryCAD" Margin="8" HorizontalAlignment="Left" IsChecked="{x:Bind PreferencesVm.ErrorCollectionConsent, Mode=TwoWay}"/>
-                    <CheckBox Content="Send me newsletters about StoryCAD" Margin="8" HorizontalAlignment="Left" IsChecked="{x:Bind PreferencesVm.Newsletter, Mode=TwoWay}"/>
-                    <CheckBox Content="Wrap node names" Margin="8" HorizontalAlignment="Left" Click="ToggleWrapping" Name="TextWrap"/>
-					<CheckBox Content="Advanced logging" Margin="8" HorizontalAlignment="Left" IsChecked="{x:Bind PreferencesVm.AdvancedLogging, Mode=TwoWay}"/>  
+                <Grid HorizontalAlignment="Center">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto"/>
+						<RowDefinition Height="Auto"/>
+						<RowDefinition Height="Auto"/>
+						<RowDefinition Height="Auto"/>
+						<RowDefinition Height="Auto"/>
+					</Grid.RowDefinitions>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto"/>
+						<ColumnDefinition Width="Auto"/>
+					</Grid.ColumnDefinitions>
+	                <CheckBox Grid.Row="0" Grid.Column="0" Content="Send error logs" Margin="8" HorizontalAlignment="Left" IsChecked="{x:Bind PreferencesVm.ErrorCollectionConsent, Mode=TwoWay}"/>
+					<CheckBox Grid.Row="0" Grid.Column="1" Content="Send me StoryCAD newsletters" Margin="8" HorizontalAlignment="Left" IsChecked="{x:Bind PreferencesVm.Newsletter, Mode=TwoWay}"/>
+                    <CheckBox Grid.Row="1" Grid.Column="0" Content="Wrap node names" Margin="8" HorizontalAlignment="Left" Click="ToggleWrapping" Name="TextWrap"/>
+					<CheckBox Grid.Row="1" Grid.Column="1" Content="Advanced logging" Margin="8" HorizontalAlignment="Left" IsChecked="{x:Bind PreferencesVm.AdvancedLogging, Mode=TwoWay}"/>
+					<CheckBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Center"
+					          Content="Show startup page" Margin="8" IsChecked="{x:Bind PreferencesVm.ShowStartupPage, Mode=TwoWay}" />
 
-                    <ComboBox Header="Preferred Theme" HorizontalAlignment="Stretch" SelectedIndex="{x:Bind PreferencesVm.PreferredThemeIndex, Mode=TwoWay}" Margin="8">
+					<ComboBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="3" Width="300"
+					          Header="Preferred Theme" HorizontalAlignment="Stretch"
+					          SelectedIndex="{x:Bind PreferencesVm.PreferredThemeIndex, Mode=TwoWay}" Margin="8">
                         <ComboBoxItem Content="Use system theme"/>
                         <ComboBoxItem Content="Light Theme"/>
                         <ComboBoxItem Content="Dark Theme"/>
                     </ComboBox>
-                    <ComboBox Header="Preferred Search Engine" HorizontalAlignment="Stretch" Name="SearchEngine" SelectedIndex="{x:Bind PreferencesVm.SearchEngineIndex, Mode=TwoWay}" Margin="0,4,0,0">
+					<ComboBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="4" Width="300"
+					          Header="Preferred Search Engine" HorizontalAlignment="Stretch" 
+					          Name="SearchEngine" SelectedIndex="{x:Bind PreferencesVm.SearchEngineIndex, Mode=TwoWay}" Margin="0,4,0,0">
                         <ComboBoxItem Content="DuckDuckGo"/>
                         <ComboBoxItem Content="Google"/>
                         <ComboBoxItem Content="Bing"/>
                         <ComboBoxItem Content="Yahoo"/>
                     </ComboBox>
-                </StackPanel>
+                </Grid>
             </PivotItem>
             <PivotItem Header="About" VerticalContentAlignment="Center" VerticalAlignment="Stretch">
                 <StackPanel>

--- a/StoryCADLib/StoryCADLib.csproj
+++ b/StoryCADLib/StoryCADLib.csproj
@@ -63,6 +63,7 @@
     <None Remove="Controls\Traits.xaml" />
     <None Remove="Services\Dialogs\ElementPicker.xaml" />
     <None Remove="Services\Dialogs\FeedbackDialog.xaml" />
+    <None Remove="Services\Dialogs\HelpPage.xaml" />
     <None Remove="Services\Dialogs\NewProjectPage.xaml" />
     <None Remove="Services\Dialogs\NewRelationshipPage.xaml" />
     <None Remove="Services\Dialogs\RecentFiles.xaml" />
@@ -169,6 +170,9 @@
     <None Update="NLog.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Page Update="Services\Dialogs\HelpPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Update="Services\Dialogs\ElementPicker.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/StoryCADLib/ViewModels/Tools/PreferencesViewModel.cs
+++ b/StoryCADLib/ViewModels/Tools/PreferencesViewModel.cs
@@ -186,6 +186,14 @@ public class PreferencesViewModel : ObservableValidator
 	    set => SetProperty(ref _advancedLogging, value);
     }
 
+	// Show startup page.
+    private bool _ShowStartupPage;
+	public bool ShowStartupPage
+    {
+	    get => _ShowStartupPage;
+	    set => SetProperty(ref _ShowStartupPage, value);
+	}
+
 	#endregion
 
 	#region Methods
@@ -221,6 +229,7 @@ public class PreferencesViewModel : ObservableValidator
         PreferredSearchEngine = CurrentModel.PreferredSearchEngine;
         PreferedTheme = CurrentModel.ThemePreference;
         AdvancedLogging = CurrentModel.AdvancedLogging;
+        ShowStartupPage = CurrentModel.ShowStartupDialog;
     }
 
     internal void SaveModel()
@@ -259,6 +268,7 @@ public class PreferencesViewModel : ObservableValidator
             Ioc.Default.GetService<Windowing>().UpdateUIToTheme();
         }
         CurrentModel.ThemePreference = PreferedTheme;
+        CurrentModel.ShowStartupDialog = ShowStartupPage;
     }
 
     /// <summary>


### PR DESCRIPTION
This PR adds a help page that is shown at startup before the Unified FileOpen menu.
It simply gives the user some links to getting started.

Additionally the Other Section in the Preferences tab has been updated since there was too many options in its current form to support an additional option; as such I have made it use a grid and put the checkbox options in two rows to make more space.

The help screen will show at every launch unless the Don't Show again checkbox is hit in the menu or the preference show Startup Page is checked.

This PR fixes #813 and input from @JWilkie1028 would apprechiated since he suggested this feature.