### PR TITLE
Update getting started dialog

### DIFF
--- a/StoryCADLib/Services/Dialogs/HelpPage.xaml
+++ b/StoryCADLib/Services/Dialogs/HelpPage.xaml
@@ -17,7 +17,7 @@ however are still a good place to get started" TextWrapping="Wrap" Margin="10,10
 		<HyperlinkButton Content="StoryCAD Concepts (Video)" NavigateUri="https://www.youtube.com/watch?v=Oi7G9TEKsro"/>
 		<HyperlinkButton Content="A 5-minute Introduction to StoryCAD (Video)" NavigateUri="https://www.youtube.com/watch?v=qFpTI15-q7A"/>
 		<HyperlinkButton Content="Frequently Asked Questions" NavigateUri="https://www.storybuilder.org/faq"/>
-		<HyperlinkButton Content="Tutorial" NavigateUri="https://storybuilder-org.github.io/StoryCAD/Tutorial_Creating_a_Story.html"/>
+		<HyperlinkButton Content="Tutorial" NavigateUri="https://storybuilder-org.github.io/StoryCAD/docs/Tutorial%20Creating%20a%20Story/Tutorial_Creating_a_Story.html"/>
 		<HyperlinkButton Content="User manual" NavigateUri="https://storybuilder-org.github.io/StoryCAD/"/>
 		<HyperlinkButton Content="Events" NavigateUri="https://storybuilder.org/events/"/>
 

--- a/StoryCADLib/Services/Dialogs/HelpPage.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/HelpPage.xaml.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Xaml;
+using StoryCAD.DAL;
 
 namespace StoryCAD.Services.Dialogs;
 
@@ -9,9 +10,11 @@ public sealed partial class HelpPage : Page
 	/// <summary>
 	/// Update preferences to hide/show menu
 	/// </summary>
-	private void Clicked(object sender, RoutedEventArgs e)
+	private async void Clicked(object sender, RoutedEventArgs e)
 	{
-		Ioc.Default.GetRequiredService<PreferenceService>().Model.ShowStartupDialog = 
-			(bool)(sender as CheckBox).IsChecked;
+		PreferenceService Pref = Ioc.Default.GetService<PreferenceService>();
+		Pref.Model.ShowStartupDialog = !(bool)(sender as CheckBox).IsChecked;
+		PreferencesIo _prfIo = new(Pref.Model, Ioc.Default.GetRequiredService<AppState>().RootDirectory);
+		await _prfIo.WritePreferences();
 	}
 }


### PR DESCRIPTION
This PR does two things to the getting started dialog:
-  Updates the Tutorial URL to work with the new manual changes
- Fixes a logic error where hitting don't show again would do nothing as the variable Prefernces.ShowHelpPage was being set to DontShowAgain.IsChecked, when it should be the inverse of this value (turning it off in settings would work however)