### PR TITLE
Fix unauthorised path error

### DIFF
--- a/StoryCADLib/Services/Dialogs/NewProjectPage.xaml
+++ b/StoryCADLib/Services/Dialogs/NewProjectPage.xaml
@@ -27,10 +27,13 @@
         <TextBox x:Name="ProjectName" x:FieldModifier="public" MinWidth="250" 
                  HorizontalAlignment="Center" Header="Project Name: "
                  Text="{x:Bind UnifiedVM.ProjectName, Mode=TwoWay}" Margin="0,20"/>
- 
-		<TextBlock Text="Your story name contains disallowed characters."
+
+		<TextBlock Text="Your outline name contains disallowed characters."
 		           HorizontalAlignment="Center" TextWrapping="Wrap"
 		           Visibility="{x:Bind UnifiedVM.ProjectNameErrorVisibility, Mode=TwoWay}"/>
+        <TextBlock Text="You cannot store your outlines there."
+                   HorizontalAlignment="Center" TextWrapping="Wrap"
+                   Visibility="{x:Bind UnifiedVM.ProjectFolderErrorVisibilty, Mode=TwoWay}"/>
 
 		<Button Content="Create project" Margin="5,20" HorizontalAlignment="Center" 
 		        Click="{x:Bind UnifiedVM.CheckValidity}"/>

--- a/StoryCADLib/ViewModels/UnifiedVM.cs
+++ b/StoryCADLib/ViewModels/UnifiedVM.cs
@@ -22,11 +22,17 @@ public class UnifiedVM : ObservableRecipient
 	private ShellViewModel _shell = Ioc.Default.GetService<ShellViewModel>();
     private PreferenceService Preferences = Ioc.Default.GetService<PreferenceService>();
 
-    public Visibility _ProjectNameErrorVisibility;
+    private Visibility _ProjectNameErrorVisibility;
     public Visibility ProjectNameErrorVisibility
     {
 	    get => _ProjectNameErrorVisibility;
 	    set => SetProperty(ref _ProjectNameErrorVisibility, value);
+	}
+    private Visibility _ProjectFolderErrorVisibilty;
+    public Visibility ProjectFolderErrorVisibilty
+	{
+	    get => _ProjectFolderErrorVisibilty;
+	    set => SetProperty(ref _ProjectFolderErrorVisibilty, value);
     }
 
 	private int _selectedRecentIndex;


### PR DESCRIPTION
This PR fixes a wierd edge case that result in data loss if the user saves their outline in a place storycad does not have access to, such as C:\ or program files. If this occurs again, the user will be notifed that they can't save there and the file will instead be saved in the project folder, additionally the unified menu is updated to block creating files in directories that aren't allowed to be written to. In the case of the former, the users recently opened files will be updated to reflect this.