### PR TITLE
Fix report crash

### DIFF
--- a/StoryCADLib/Models/StoryElement.cs
+++ b/StoryCADLib/Models/StoryElement.cs
@@ -74,7 +74,7 @@ public class StoryElement : ObservableObject
     public static StoryElement GetByGuid(Guid guid)
     {
         if (guid.Equals(Guid.Empty))
-            return new StoryElement();
+             return new StoryElement();
         // Get the current StoryModel's StoryElementsCollection
         ShellViewModel shell = Ioc.Default.GetService<ShellViewModel>();
         StoryElementCollection elements = shell!.StoryModel.StoryElements;
@@ -104,7 +104,6 @@ public class StoryElement : ObservableObject
 	/// <summary>
 	/// Parameterless constructor for JSON Deserialization.
 	/// Don't remove.
-	///
 	/// </summary>
     public StoryElement()
     {

--- a/StoryCADLib/Services/Reports/ReportFormatter.cs
+++ b/StoryCADLib/Services/Reports/ReportFormatter.cs
@@ -96,10 +96,7 @@ public class ReportFormatter
         ProblemModel problem = (ProblemModel)element;
         string[] lines = _templates["Problem Description"];
         RtfDocument doc = new(string.Empty);
-
-        StoryElement vpProtagonist = (CharacterModel)_model.StoryElements.StoryElementGuids[problem.Protagonist];
-        StoryElement vpAntagonist = (CharacterModel)_model.StoryElements.StoryElementGuids[problem.Antagonist];
-
+		
         // Parse and write the report
         foreach (string line in lines)
         {
@@ -132,8 +129,9 @@ public class ReportFormatter
             else { sb.Replace("@ProtagGoal", problem.ProtGoal); }
             
             if (problem.Protagonist != Guid.Empty)
-            {
-                if (String.IsNullOrEmpty(vpProtagonist.Name)) { sb.Replace("@ProtagName", ""); }
+			{
+				StoryElement vpProtagonist = (CharacterModel)StoryElement.GetByGuid(problem.Protagonist);
+				if (String.IsNullOrEmpty(vpProtagonist.Name)) { sb.Replace("@ProtagName", ""); }
                 else { sb.Replace("@ProtagName", vpProtagonist.Name); }
             }
             else { sb.Replace("@ProtagName", ""); }
@@ -143,7 +141,9 @@ public class ReportFormatter
 
             if (problem.Antagonist != Guid.Empty)
             {
-                if (String.IsNullOrEmpty(vpAntagonist.Name)) { sb.Replace("@AntagName", ""); }
+	            StoryElement vpAntagonist = (CharacterModel)StoryElement.GetByGuid(problem.Antagonist);
+
+				if (String.IsNullOrEmpty(vpAntagonist.Name)) { sb.Replace("@AntagName", ""); }
                 else { sb.Replace("@AntagName", vpAntagonist.Name); }
             }
             else { sb.Replace("@AntagName", ""); }

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -371,18 +371,20 @@ public class ShellViewModel : ObservableRecipient
 
 	public async Task PrintCurrentNodeAsync()
     {
-        if (RightTappedNode == null)
+	    _canExecuteCommands = false;
+
+		if (RightTappedNode == null)
         {
-            _canExecuteCommands = false;
             Messenger.Send(new StatusChangedMessage(new("Right tap a node to print", LogLevel.Warn)));
             Logger.Log(LogLevel.Info, "Print node failed as no node is selected");
             _canExecuteCommands = true;
             return;
         }
         await Ioc.Default.GetRequiredService<PrintReportDialogVM>().PrintSingleNode(RightTappedNode);
-    }
+        _canExecuteCommands = true;
+	}
 
-    private void CloseUnifiedMenu() { _contentDialog.Hide(); }
+	private void CloseUnifiedMenu() { _contentDialog.Hide(); }
 
     public async Task OpenUnifiedMenu()
     {


### PR DESCRIPTION
This PR fixes two issues:
 - Possible deadlock within StoryCAD when printing a node
 - Crash when printing a problem with no elements.