### PR TITLE
Memory leak fixes

### DIFF
--- a/StoryCAD/Views/ProblemPage.xaml
+++ b/StoryCAD/Views/ProblemPage.xaml
@@ -184,7 +184,7 @@
 									<DataTemplate x:DataType="tools:StructureBeatViewModel">
 										<Grid DataContext="{x:Bind}" MinWidth="200" AllowDrop="True" DragOver="UIElement_OnDragOver"
 										      Background="Transparent" CanDrag="False" Drop="DroppedItem" Margin="0,5,10,5"
-										      BorderBrush="White" BorderThickness="1" CornerRadius="4" 
+										      BorderBrush="White" BorderThickness="1" CornerRadius="4"
 										      Padding="5,10,10,10">
 											<Grid.ColumnDefinitions>
 												<ColumnDefinition Width="Auto"/>

--- a/StoryCAD/Views/ProblemPage.xaml.cs
+++ b/StoryCAD/Views/ProblemPage.xaml.cs
@@ -94,6 +94,11 @@ public sealed partial class ProblemPage : BindablePage
 
             structureBeatsModel.Guid = uuid;
             stackPanel.DataContext = structureBeatsModel;
+
+
+            //Fix theming issue, since the text might need its font color updating
+            RichEditBoxExtended rtfex = (RichEditBoxExtended)stackPanel.Children.First(RTF => RTF.GetType() == typeof(RichEditBoxExtended));
+            rtfex.UpdateTheme(null, null);
         }
         catch (Exception ex)
         {

--- a/StoryCADLib/Controls/RichEditBoxExtended.cs
+++ b/StoryCADLib/Controls/RichEditBoxExtended.cs
@@ -38,40 +38,30 @@ public class RichEditBoxExtended : RichEditBox
         CornerRadius = new(5);
         
 		//Fix theme issues.
-        Loaded += RichEditBoxExtended_Loaded;
-        ActualThemeChanged += RichEditBoxExtended_ActualThemeChanged;
-        SetTextColorBasedOnTheme();
+        Loaded += UpdateTheme;
+        UpdateTheme(null, null);
 	}
 
-    private void RichEditBoxExtended_Loaded(object sender, RoutedEventArgs e)
+    public void UpdateTheme(object sender, RoutedEventArgs e)
     {
-	    SetTextColorBasedOnTheme();
+        var theme = ActualTheme;
+
+        ITextCharacterFormat format = Document.GetDefaultCharacterFormat();
+
+        if (theme == ElementTheme.Dark)
+        {
+            // Set text color to white
+            format.ForegroundColor = Colors.White;
+        }
+        else
+        {
+            // Set text color to black
+            format.ForegroundColor = Colors.Black;
+        }
+
+        Document.SetDefaultCharacterFormat(format);
     }
 
-    private void RichEditBoxExtended_ActualThemeChanged(FrameworkElement sender, object args)
-    {
-	    SetTextColorBasedOnTheme();
-    }
-
-    private void SetTextColorBasedOnTheme()
-    {
-	    var theme = ActualTheme;
-
-	    ITextCharacterFormat format = Document.GetDefaultCharacterFormat();
-
-	    if (theme == ElementTheme.Dark)
-	    {
-		    // Set text color to white
-		    format.ForegroundColor = Colors.White;
-	    }
-	    else
-	    {
-		    // Set text color to black
-		    format.ForegroundColor = Colors.Black;
-	    }
-
-	    Document.SetDefaultCharacterFormat(format);
-    }
 
 	public string RtfText
     {
@@ -95,12 +85,8 @@ public class RichEditBoxExtended : RichEditBox
                 RtfText = text.TrimEnd('\0'); // remove end of string marker
             }
             _lockChangeExecution = false;
-
-			//Update theme in edge cases like Structure Pages
-            SetTextColorBasedOnTheme();
-
         }
-	}
+    }
 
 	private static void RtfTextPropertyChanged(DependencyObject dependencyObject,
         DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)

--- a/StoryCADLib/Controls/RichEditBoxExtended.cs
+++ b/StoryCADLib/Controls/RichEditBoxExtended.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.UI;
 using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Media;
-using Org.BouncyCastle.Ocsp;
 
 namespace StoryCAD.Controls;
 
@@ -38,6 +36,7 @@ public class RichEditBoxExtended : RichEditBox
         CornerRadius = new(5);
         
 		//Fix theme issues.
+        PointerEntered += (((sender, args) => UpdateTheme(null, null)));
         Loaded += UpdateTheme;
         UpdateTheme(null, null);
 	}


### PR DESCRIPTION
This PR fixes a regression itnroduced by #873 where Storycad would constantly keep allocating memory and never free it due to a loop that would occur when fixing the theme.

