### PR TITLE
Correct NullToGuildConverter.ConvertBack() to always return a valid G…

### DIFF
--- a/StoryCADLib/Converters/NullToGuidConverter.cs
+++ b/StoryCADLib/Converters/NullToGuidConverter.cs
@@ -10,6 +10,6 @@ public class NullToGuidConverter : IValueConverter
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)
     {
-        return value is Guid guid && guid == Guid.Empty ? null : value;
+        return value is Guid guid ? guid : Guid.Empty;
     }
 }


### PR DESCRIPTION
…uild. If the value passed is null, return Guild.Empty.