### PR TITLE
Tweak feedback UI to more dynamic

### DIFF
--- a/StoryCAD/Views/Shell.xaml.cs
+++ b/StoryCAD/Views/Shell.xaml.cs
@@ -543,8 +543,8 @@ private DragAndDropDirection GetMoveDirection(Point position, TreeViewItem targe
 	    {
 		    Content = new FeedbackDialog(),
 		    PrimaryButtonText = "Submit Feedback",
-			SecondaryButtonText = "Close",
-		    Title = "Submit Feedback",
+			SecondaryButtonText = "Discard",
+		    Title = "Submit",
 	    });
 
 	    if (Result == ContentDialogResult.Primary)

--- a/StoryCADLib/Services/Dialogs/FeedbackDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/FeedbackDialog.xaml
@@ -2,10 +2,9 @@
     x:Class="StoryCAD.Services.Dialogs.FeedbackDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:StoryCAD.Services.Dialogs"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d" Width="450" MinHeight="500">
+    mc:Ignorable="d">
 
     <Grid>
 		<Grid.ColumnDefinitions>
@@ -20,8 +19,9 @@
 		</Grid.RowDefinitions>
 
 	    <!-- Warning to users to only submit meaningful feedback -->
-	    <InfoBar Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Content="On" Severity="Informational" Height="50" HorizontalAlignment="Stretch"
-	             Title="Detailed feedback is more likely to be addressed quicker"
+	    <InfoBar Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" 
+                 Severity="Informational" HorizontalAlignment="Stretch"
+	             Title="Detailed feedback is addressed quicker"
 	             IsOpen="True" IsClosable="False" Margin="10,0,10,10"/>
 
 	    <TextBox Grid.Row="1" Grid.Column="1" Header="Issue Title"

--- a/StoryCADLib/Services/Dialogs/FeedbackDialog.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/FeedbackDialog.xaml.cs
@@ -8,7 +8,7 @@ public sealed partial class FeedbackDialog : Microsoft.UI.Xaml.Controls.Page
 
 	public FeedbackDialog()
 	{
-		this.InitializeComponent();
+		InitializeComponent();
 	}
 
 	private void ChangeUIText(object sender, SelectionChangedEventArgs e)

--- a/StoryCADLib/Services/Logging/LogService.cs
+++ b/StoryCADLib/Services/Logging/LogService.cs
@@ -147,7 +147,7 @@ public class LogService : ILogService
                     }
 
                     int ln = 0;
-                    if (LogString.Split("\n").Length > 50)
+                    if (LogString.Split("\n").Length > 250)
                     {
                         foreach (string line in LogString.Split("\n").TakeLast(50))
                         {

--- a/StoryCADLib/ViewModels/Tools/FeedbackViewModel.cs
+++ b/StoryCADLib/ViewModels/Tools/FeedbackViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using Octokit;
+using StoryCAD.Services;
 using StoryCAD.Services.Json;
 
 namespace StoryCAD.ViewModels.Tools;
@@ -142,6 +143,9 @@ public class FeedbackViewModel : ObservableRecipient
 				              """;
 			}
 
+
+            Issue.Body += $"\nFeedback ID: {Ioc.Default.GetService<PreferenceService>()
+                .Model.Email.Substring(0,5)}";
 
 			await client.Issue.Create("storybuilder-org", "StoryCAD", Issue);
 		}


### PR DESCRIPTION
Fixes dynamic sizing issue with Feedback UI, tested at 1920x1080 at 175% scaling

Also:
-  bumps log size to 250 lines
- Feedback report now includes first 5 chars of email
- Tweaks wording of submit feedback to just submit and close to discard.