### PR TITLE
Convert StoryElement placeholders from SelectedValue to SelectedItem

### DIFF
--- a/StoryCAD/Views/OverviewPage.xaml
+++ b/StoryCAD/Views/OverviewPage.xaml
@@ -1,14 +1,8 @@
 <usercontrols:BindablePage NavigationCacheMode="Required"
     x:Class="StoryCAD.Views.OverviewPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"                  
-    xmlns:local="using:StoryCAD.Views"
-    xmlns:usercontrols="using:StoryCAD.Controls" 
-    xmlns:converters="using:StoryCAD.Converters">
-
-    <usercontrols:BindablePage.Resources>
-        <converters:NullToGuidConverter x:Key="NullToGuidConverter"/>
-    </usercontrols:BindablePage.Resources>
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:usercontrols="using:StoryCAD.Controls">
 
     <Grid>
         <Grid.RowDefinitions>
@@ -60,9 +54,8 @@
                     </Grid.RowDefinitions>
                     <ComboBox Header="Story Problem" Grid.Row="0" IsEditable="False" MinWidth="300"
                               DisplayMemberPath="Name"
-                              SelectedValue="{x:Bind OverviewVm.StoryProblem, Mode=TwoWay, Converter={StaticResource NullToGuidConverter}}"
-                              SelectedValuePath="Uuid"
-                              ItemsSource="{x:Bind OverviewVm.Problems}" />
+                              SelectedItem="{x:Bind OverviewVm.SelectedProblem, Mode=TwoWay}"
+                              ItemsSource="{x:Bind OverviewVm.Problems, Mode=OneWay}" />
                     <TextBlock Grid.Row="1" Text=" "/>
                     <usercontrols:RichEditBoxExtended Header="Premise" Grid.Row="2" 
                                     RtfText="{x:Bind OverviewVm.Premise, Mode=TwoWay}" AcceptsReturn="True"
@@ -111,9 +104,8 @@
                     </Grid>
                     <ComboBox Header="Viewpoint Character" Grid.Row="2" IsEditable="False" MinWidth="300"
                               DisplayMemberPath="Name"
-                              SelectedValue="{x:Bind OverviewVm.ViewpointCharacter, Mode=TwoWay, Converter={StaticResource NullToGuidConverter}}"
-                              SelectedValuePath="Uuid"
-                              ItemsSource="{x:Bind OverviewVm.Characters}" />
+                              SelectedItem="{x:Bind OverviewVm.SelectedViewpointCharacter, Mode=TwoWay}"
+                              ItemsSource="{x:Bind OverviewVm.Characters, Mode=OneWay}" />
                     <Grid Grid.Row="3" HorizontalAlignment="Left" >
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="2*"/>

--- a/StoryCAD/Views/ProblemPage.xaml
+++ b/StoryCAD/Views/ProblemPage.xaml
@@ -4,12 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"               
     xmlns:usercontrols="using:StoryCAD.Controls"
     xmlns:viewModels="using:StoryCAD.ViewModels"
-    xmlns:tools="using:StoryCAD.ViewModels.Tools"
-    xmlns:converters="using:StoryCAD.Converters">
-
-    <usercontrols:BindablePage.Resources>
-        <converters:NullToGuidConverter x:Key="NullToGuidConverter"/>
-    </usercontrols:BindablePage.Resources>
+    xmlns:tools="using:StoryCAD.ViewModels.Tools">
 
     <Grid>
         <Grid.RowDefinitions>
@@ -74,9 +69,8 @@
                     </Grid.RowDefinitions>
                     <ComboBox Header="Protagonist" Grid.Row="0" IsEditable="False" MinWidth="300"
                               DisplayMemberPath="Name"
-                              SelectedValue="{x:Bind ProblemVm.Protagonist, Mode=TwoWay, Converter={StaticResource NullToGuidConverter}}"
-                              SelectedValuePath="Uuid"
-                              ItemsSource="{x:Bind ProblemVm.Characters}" />
+                              SelectedItem="{x:Bind ProblemVm.SelectedProtagonist, Mode=TwoWay}"
+                              ItemsSource="{x:Bind ProblemVm.Characters, Mode=OneWay}" />
                     <ComboBox IsEditable="True" Header="Goal" Grid.Row="1" 
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.GoalList}"
                               Text="{x:Bind ProblemVm.ProtGoal, Mode=TwoWay}" 
@@ -104,9 +98,9 @@
                     </Grid.RowDefinitions>
                     <ComboBox Header="Antagonist" Grid.Row="0" IsEditable="False" MinWidth="300"
                               DisplayMemberPath="Name"
-                              SelectedValue="{x:Bind ProblemVm.Protagonist, Mode=TwoWay, Converter={StaticResource NullToGuidConverter}}"
+                              SelectedItem="{x:Bind ProblemVm.SelectedAntagonist, Mode=TwoWay}"
                               SelectedValuePath="Uuid"
-                              ItemsSource="{x:Bind ProblemVm.Characters}" />
+                              ItemsSource="{x:Bind ProblemVm.Characters, Mode=OneWay}" />
                     <ComboBox IsEditable="True" Header="Goal" Grid.Row="1" 
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.GoalList}"
                               Text="{x:Bind ProblemVm.AntagGoal, Mode=TwoWay}" 

--- a/StoryCAD/Views/ScenePage.xaml
+++ b/StoryCAD/Views/ScenePage.xaml
@@ -7,11 +7,9 @@
     xmlns:models="using:StoryCAD.Models"            
     xmlns:usercontrols="using:StoryCAD.Controls"
     xmlns:viewModels="using:StoryCAD.ViewModels"
-    xmlns:converters="using:StoryCAD.Converters"
     mc:Ignorable="d" >
 
     <usercontrols:BindablePage.Resources>
-        <converters:NullToGuidConverter x:Key="NullToGuidConverter"/>
       
         <TeachingTip x:Name="ViewpointCharacterTip"
                      Title="Reminder:"
@@ -56,9 +54,8 @@
                         <ComboBox x:Name="ViewpointCharacter" Header="Viewpoint Character" 
                                   Grid.Column="4" IsEditable="False" MinWidth="250"
                                   DisplayMemberPath="Name"
-                                  SelectedValue="{x:Bind SceneVm.ViewpointCharacter, Mode=TwoWay, Converter={StaticResource NullToGuidConverter}}"
-                                  SelectedValuePath="Uuid"
-                                  ItemsSource="{x:Bind SceneVm.Characters}" />
+                                  SelectedItem="{x:Bind SceneVm.SelectedViewpointCharacter, Mode=TwoWay}"
+                                  ItemsSource="{x:Bind SceneVm.Characters, Mode=OneWay}" />
                     </Grid>
                     <Grid Grid.Row="1" HorizontalAlignment="Left">
                         <Grid.ColumnDefinitions>
@@ -69,9 +66,8 @@
                         <ComboBox Header="Setting" Grid.Column="0" IsEditable="False" 
                                   MinWidth="300"  Margin="0,0,0,10"
                                   DisplayMemberPath="Name"
-                                  SelectedValue="{x:Bind SceneVm.Setting, Mode=TwoWay, Converter={StaticResource NullToGuidConverter}}"
-                                  SelectedValuePath="Uuid"
-                                  ItemsSource="{x:Bind SceneVm.Settings}" />
+                                  SelectedItem="{x:Bind SceneVm.SelectedSetting, Mode=TwoWay}"
+                                  ItemsSource="{x:Bind SceneVm.Settings, Mode=OneWay}" />
                         <TextBlock Grid.Column="1" MinWidth="50"/>
                         <ComboBox IsEditable="True" Header="SceneType" Grid.Column="2" MinWidth="200"
                                             ItemsSource="{x:Bind SceneVm.SceneTypeList}"
@@ -201,9 +197,8 @@
                         </Grid.ColumnDefinitions>
                         <ComboBox Header="Protagonist" Grid.Row="0" IsEditable="False" MinWidth="300"
                                   DisplayMemberPath="Name"
-                                  SelectedValue="{x:Bind SceneVm.Protagonist, Mode=TwoWay, Converter={StaticResource NullToGuidConverter}}"
-                                  SelectedValuePath="Uuid"
-                                  ItemsSource="{x:Bind SceneVm.Characters}" />
+                                  SelectedItem="{x:Bind SceneVm.SelectedProtagonist, Mode=TwoWay}"
+                                  ItemsSource="{x:Bind SceneVm.Characters, Mode=OneWay}" />  
                         <TextBlock Grid.Column="1" MinWidth="50"/>
                         <ComboBox IsEditable="True" Header="Feelings" Grid.Column="2" MinWidth="200"
                                             ItemsSource="{x:Bind SceneVm.EmotionList}"
@@ -227,9 +222,8 @@
                         </Grid.ColumnDefinitions>
                         <ComboBox Header="Antagonist" Grid.Row="0" IsEditable="False" MinWidth="300"
                                   DisplayMemberPath="Name"
-                                  SelectedValue="{x:Bind SceneVm.Antagonist, Mode=TwoWay, Converter={StaticResource NullToGuidConverter}}"
-                                  SelectedValuePath="Uuid"
-                                  ItemsSource="{x:Bind SceneVm.Characters}" />
+                                  SelectedItem="{x:Bind SceneVm.SelectedAntagonist, Mode=TwoWay}"
+                                  ItemsSource="{x:Bind SceneVm.Characters, Mode=OneWay}" /> 
                         <TextBlock Grid.Column="1" MinWidth="50"/>
                         <ComboBox IsEditable="True" Header="Feelings" Grid.Column="2"  MinWidth="200"
                                             ItemsSource="{x:Bind SceneVm.EmotionList}"

--- a/StoryCADLib/Converters/NullToGuidConverter.cs
+++ b/StoryCADLib/Converters/NullToGuidConverter.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml.Data;
 namespace StoryCAD.Converters;
 public class NullToGuidConverter : IValueConverter
 {
+    //TODO: Delete Converter when no longer used
     public object Convert(object value, Type targetType, object parameter, string language)
     {
         return value ?? Guid.Empty;

--- a/StoryCADLib/Models/StoryElementCollection.cs
+++ b/StoryCADLib/Models/StoryElementCollection.cs
@@ -14,7 +14,8 @@ public class StoryElementCollection : ObservableCollection<StoryElement>
     public Dictionary<Guid, StoryElement> StoryElementGuids;
     public ObservableCollection<StoryElement> Characters;
     public ObservableCollection<StoryElement> Settings;
-    public ObservableCollection<StoryElement> Problems;
+    public ObservableCollection<StoryElement> Problems { get; } = new ObservableCollection<StoryElement>();
+
     public ObservableCollection<StoryElement> Scenes;
 
     public StoryElementCollection()
@@ -23,8 +24,11 @@ public class StoryElementCollection : ObservableCollection<StoryElement>
         StoryElementGuids = new Dictionary<Guid, StoryElement>();
         Characters = new ObservableCollection<StoryElement>();
         Settings = new ObservableCollection<StoryElement>();
-        Problems = new ObservableCollection<StoryElement>();
         Scenes = new ObservableCollection<StoryElement>();
+        Problems!.Add(new StoryElement {Type = StoryItemType.Problem,Name="(none)"});
+        Characters!.Add(new StoryElement {Type = StoryItemType.Character,Name="(none)"});
+        Settings!.Add(new StoryElement {Type = StoryItemType.Setting,Name="(none)"});
+        Scenes!.Add(new StoryElement {Type = StoryItemType.Scene,Name="(none)"});
     }
 
     /// <summary>

--- a/StoryCADLib/ViewModels/ProblemViewModel.cs
+++ b/StoryCADLib/ViewModels/ProblemViewModel.cs
@@ -107,11 +107,25 @@ public class ProblemViewModel : ObservableRecipient, INavigable
 
     // Problem protagonist data
 
-    private Guid _protagonist;  // The Guid of a Character StoryElement
+    private Guid _protagonist;  // The Guid of a Character  
     public Guid Protagonist
     {
         get => _protagonist;
         set => SetProperty(ref _protagonist, value);
+    }
+
+    private StoryElement _selectedProtagonist;   
+    public StoryElement SelectedProtagonist
+    {
+        get => _selectedProtagonist;
+        set
+        {
+            if (SetProperty(ref _selectedProtagonist, value))
+            {
+                // Update Protagonist GUID when SelectedProtagonist changes
+                Protagonist = _selectedProtagonist?.Uuid ?? Guid.Empty;
+            }
+        }
     }
 
     private string _protGoal;
@@ -142,6 +156,20 @@ public class ProblemViewModel : ObservableRecipient, INavigable
     {
         get => _antagonist;
         set => SetProperty(ref _antagonist, value);
+    }
+
+    private StoryElement _selectedAntagonist;   
+    public StoryElement SelectedAntagonist
+    {
+        get => _selectedAntagonist;
+        set
+        {
+            if (SetProperty(ref _selectedAntagonist, value))
+            {
+                // Update Antagonist GUID when SelectedAntagonist changes
+                Antagonist = _selectedAntagonist?.Uuid ?? Guid.Empty;
+            }
+        }
     }
 
     private string _antagGoal;
@@ -335,15 +363,13 @@ public class ProblemViewModel : ObservableRecipient, INavigable
         Subject = Model.Subject;
         StoryQuestion = Model.StoryQuestion;
         ProblemSource = Model.ProblemSource;
-        // Character instances like Protagonist and Antagonist are 
-        // read and written as the CharacterModel's StoryElement Guid 
-        // A binding converter, StringToStoryElementConverter,
-        // provides the UI the corresponding StoryElement itself.
         Protagonist = Model.Protagonist;
+        SelectedProtagonist = Characters.FirstOrDefault(p => p.Uuid == Protagonist);
         ProtGoal = Model.ProtGoal;
         ProtMotive = Model.ProtMotive;
         ProtConflict = Model.ProtConflict;
         Antagonist = Model.Antagonist;
+        SelectedAntagonist = Characters.FirstOrDefault(p => p.Uuid == Antagonist);
         AntagGoal = Model.AntagGoal;
         AntagMotive = Model.AntagMotive;
         AntagConflict = Model.AntagConflict;
@@ -367,7 +393,6 @@ public class ProblemViewModel : ObservableRecipient, INavigable
 		
 		//Ensure correct set of Elements are loaded for Structure Lists
 		Problems = Ioc.Default.GetService<ShellViewModel>().StoryModel.StoryElements.Problems;
-        Characters = Ioc.Default.GetService<ShellViewModel>().StoryModel.StoryElements.Characters;
         Scenes = Ioc.Default.GetService<ShellViewModel>().StoryModel.StoryElements.Scenes;
 		_changeable = true;
 	}
@@ -517,6 +542,7 @@ public class ProblemViewModel : ObservableRecipient, INavigable
     public ProblemViewModel()
     {
         _logger = Ioc.Default.GetService<LogService>();
+        Characters = ShellViewModel.GetModel().StoryElements.Characters;
 
         ProblemType = string.Empty;
         ConflictType = string.Empty;

--- a/StoryCADLib/ViewModels/SceneViewModel.cs
+++ b/StoryCADLib/ViewModels/SceneViewModel.cs
@@ -82,6 +82,19 @@ public class SceneViewModel : ObservableRecipient, INavigable
             AddCastMember(StoryElement.GetByGuid(value));  // Insure the character is in the cast list
         }
     }
+    private StoryElement _selectedViewpointCharacter;
+    public StoryElement SelectedViewpointCharacter
+    {
+        get => _selectedViewpointCharacter;
+        set
+        {
+            if (SetProperty(ref _selectedViewpointCharacter, value))
+            {
+                // Update StoryProblem GUID when SelectedProblem changes
+                ViewpointCharacter = _selectedViewpointCharacter?.Uuid ?? Guid.Empty;
+            }
+        }
+    }
 
     private string _date;
     public string Date
@@ -103,6 +116,21 @@ public class SceneViewModel : ObservableRecipient, INavigable
         get => _setting;
         set => SetProperty(ref _setting, value);
     }
+
+    private StoryElement _selectedSetting;
+    public StoryElement SelectedSetting
+    {
+        get => _selectedSetting;
+        set
+        {
+            if (SetProperty(ref _selectedSetting, value))
+            {
+                // Update Setting GUID when SelectedSetting changes
+                Setting = _selectedSetting?.Uuid ?? Guid.Empty;
+            }
+        }
+    }
+
 
     private string _sceneType;
     public string SceneType
@@ -200,6 +228,20 @@ public class SceneViewModel : ObservableRecipient, INavigable
         set => SetProperty(ref _protagonist, value);
     }
 
+    private StoryElement _selectedProtagonist;   
+    public StoryElement SelectedProtagonist
+    {
+        get => _selectedProtagonist;
+        set
+        {
+            if (SetProperty(ref _selectedProtagonist, value))
+            {
+                // Update Protagonist GUID when SelectedProtagonist changes
+                Protagonist = _selectedProtagonist?.Uuid ?? Guid.Empty;
+            }
+        }
+    }
+
     private string _protagEmotion;
     public string ProtagEmotion
     {
@@ -219,6 +261,20 @@ public class SceneViewModel : ObservableRecipient, INavigable
     {
         get => _antagonist;
         set => SetProperty(ref _antagonist, value);
+    }
+
+    private StoryElement _selectedAntagonist;   
+    public StoryElement SelectedAntagonist
+    {
+        get => _selectedAntagonist;
+        set
+        {
+            if (SetProperty(ref _selectedAntagonist, value))
+            {
+                // Update Antagonist GUID when SelectedAntagonist changes
+                Antagonist = _selectedAntagonist?.Uuid ?? Guid.Empty;
+            }
+        }
     }
 
     private string _antagEmotion;
@@ -354,6 +410,7 @@ public class SceneViewModel : ObservableRecipient, INavigable
         Date = Model.Date;
         Time = Model.Time;
         Setting = Model.Setting;
+        SelectedSetting = Settings.FirstOrDefault(p => p.Uuid == Setting);
         SceneType = Model.SceneType;
 
         // The list of cast members is loaded from the Model
@@ -361,6 +418,7 @@ public class SceneViewModel : ObservableRecipient, INavigable
         // CharacterList is the StoryModel's list of all Character StoryElements
         CharacterList = ShellViewModel.ShellInstance.StoryModel.StoryElements.Characters;
         ViewpointCharacter = Model.ViewpointCharacter; // Add viewpoint character if missing
+        SelectedViewpointCharacter = Characters.FirstOrDefault(p => p.Uuid == ViewpointCharacter);
         // Now set the correct view and initialize the cast elements    
         AllCharacters = CastList.Count == 0;
         InitializeCharacterList();
@@ -382,9 +440,11 @@ public class SceneViewModel : ObservableRecipient, INavigable
 
         ValueExchange = Model.ValueExchange;
         Protagonist = Model.Protagonist;
+        SelectedProtagonist = Characters.FirstOrDefault(p => p.Uuid == Protagonist);
         ProtagEmotion = Model.ProtagEmotion;
         ProtagGoal = Model.ProtagGoal;
         Antagonist = Model.Antagonist;
+        SelectedAntagonist = Characters.FirstOrDefault(p => p.Uuid == Antagonist);
         AntagEmotion = Model.AntagEmotion;
         AntagGoal = Model.AntagGoal;
         Opposition = Model.Opposition;
@@ -399,11 +459,6 @@ public class SceneViewModel : ObservableRecipient, INavigable
         Review = Model.Review;
         Notes = Model.Notes;
         UpdateViewpointCharacterTip();
-        
-        Characters = Ioc.Default.GetService<ShellViewModel>()!.StoryModel.StoryElements.Characters;
-       
-        Settings = Ioc.Default.GetService<ShellViewModel>()!.StoryModel.StoryElements.Settings;
-
         _changeable = true;
     }
 
@@ -639,6 +694,8 @@ public class SceneViewModel : ObservableRecipient, INavigable
     public SceneViewModel()
     {
         _logger = Ioc.Default.GetService<LogService>();
+        Characters = Ioc.Default.GetService<ShellViewModel>()!.StoryModel.StoryElements.Characters;
+        Settings = Ioc.Default.GetService<ShellViewModel>()!.StoryModel.StoryElements.Settings;
 
         Date = string.Empty;
         Time = string.Empty;


### PR DESCRIPTION
Add the SelectedItem properties to viewmodels immediately after the placeholder Guid property.

In StoryElementCollection constructor, add an empty StoryElement to the StoryElementCollection lists (Character, Problem, Setting, Scene) but not to the StoryELements collection itself. Then the Storylement loading (in StoryIO) will add the actual values. Binding the xaml for a control, for example, Protagonist, to its SelectedItem (SelectedProtagonist  will display the Characters list as ItemsSource for the StoryElement SelecctedProtagonist. The setter for the SelectedItem also updastes the placeholder Guild. So changing SelectedProtagonist from the dropdow will update Protagonist to the corresponding Guid. This includes the empty first item "(none)",  which sets Protagonis to Guid.Empty. We now can undo these placeholder ComboBox controls.