### PR TITLE
Update IO code to fix crashes

### DIFF
--- a/StoryCADLib/DAL/StoryIO.cs
+++ b/StoryCADLib/DAL/StoryIO.cs
@@ -3,6 +3,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Windows.Storage;
 using StoryCAD.Services;
+using Microsoft.UI.Xaml;
+using System.Diagnostics;
 
 namespace StoryCAD.DAL;
 
@@ -176,14 +178,20 @@ public class StoryIO
 	/// </summary>
 	/// <param name="file">StorageFile Object</param>
 	/// <returns>StoryModel</returns>
-	public async Task<StoryModel> MigrateModel(StorageFile file)
+	public async Task<StoryModel>  MigrateModel(StorageFile file)
 	{
 		StoryModel old = new();
 		try
 		{
-			
-			//Read Legacy file
-			_logService.Log(LogLevel.Info, $"Migrating Old STBX File from {file.Path}");
+			//Check file exists first.
+            if (!await CheckFileAvailability(file.Path))
+            {
+				_logService.Log(LogLevel.Warn,"File is unavailable or doesn't exist.");
+                return new();
+            }
+
+            //Read Legacy file
+            _logService.Log(LogLevel.Info, $"Migrating Old STBX File from {file.Path}");
 			LegacyXMLReader reader = new(_logService);
 			old = await reader.ReadFile(file);
 
@@ -213,4 +221,72 @@ public class StoryIO
 
 		return await Task.FromResult(old);
 	}
+
+	/// <summary>
+	/// Checks if a file exists and is genuniely available.
+	/// </summary>
+	/// <remarks>
+	///	Cloud storage can report a file as available here even if it's not.
+	/// </remarks>
+	/// <returns></returns>
+    public async Task<bool> CheckFileAvailability(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            return false;
+        }
+
+        var fileAttributes = File.GetAttributes(filePath);
+        StorageFile file = await StorageFile.GetFileFromPathAsync(filePath);
+        bool showOfflineError = false;
+        if (file.IsAvailable) // Microsoft thinks the file is accessible
+        {
+            try
+            {
+                //Test read file before continuing.
+                //If the file is saved on a cloud provider and not locally this should force
+                //the file to be pulled locally if possible. A file could be unavailable for
+                //many reasons, such as the user being offline, server outage, etc.
+                //Windows might pause StoryCAD while it syncs the file.
+                File.ReadAllText(file.Path);
+            }
+            catch (IOException) { showOfflineError = true; }
+        }
+        else { showOfflineError = true; }
+
+        //Failed to access network file
+        if (showOfflineError && (fileAttributes & System.IO.FileAttributes.Offline) == 0)
+        {
+            //The file is actually inaccessible and microsoft is wrong.
+            _logService.Log(LogLevel.Error, $"File {file.Path} is unavailable.");
+
+            //Show warning so user knows their file isn't lost and is just on onedrive.
+            var result = await Ioc.Default.GetRequiredService<Windowing>().ShowContentDialog(new()
+            {
+                Title = "File unavailable.",
+                Content = """
+                          The story outline you are trying to open is stored on a cloud service, and isn't available currently.
+                          Try going online and syncing the file, then try again. 
+
+                          Click show help article for more information.
+                          """,
+                PrimaryButtonText = "Show help article",
+                SecondaryButtonText = "Close",
+            }, true);
+
+            //Open help article in default browser
+            if (result == ContentDialogResult.Primary)
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName =
+                        "https://storybuilder-org.github.io/StoryCAD/docs/Miscellaneous/Troubleshooting_Cloud_Storage_Providers.html",
+                    UseShellExecute = true
+                });
+            }
+        }
+
+        return !showOfflineError;
+    }
+
 }

--- a/StoryCADLib/ViewModels/ProblemViewModel.cs
+++ b/StoryCADLib/ViewModels/ProblemViewModel.cs
@@ -352,7 +352,6 @@ public class ProblemViewModel : ObservableRecipient, INavigable
     {
         _changeable = false;
         _changed = false;
-        Characters = ShellViewModel.GetModel().StoryElements.Characters;
 
         Uuid = Model.Uuid;
         Name = Model.Name;
@@ -395,8 +394,7 @@ public class ProblemViewModel : ObservableRecipient, INavigable
 		//Ensure correct set of Elements are loaded for Structure Lists
 		Problems = Ioc.Default.GetService<ShellViewModel>().StoryModel.StoryElements.Problems;
         Scenes = Ioc.Default.GetService<ShellViewModel>().StoryModel.StoryElements.Scenes;
-
-        _changeable = true;
+		_changeable = true;
 	}
 
     internal void SaveModel()
@@ -544,6 +542,7 @@ public class ProblemViewModel : ObservableRecipient, INavigable
     public ProblemViewModel()
     {
         _logger = Ioc.Default.GetService<LogService>();
+        Characters = ShellViewModel.GetModel().StoryElements.Characters;
 
         ProblemType = string.Empty;
         ConflictType = string.Empty;

--- a/StoryCADLib/ViewModels/ProblemViewModel.cs
+++ b/StoryCADLib/ViewModels/ProblemViewModel.cs
@@ -352,6 +352,7 @@ public class ProblemViewModel : ObservableRecipient, INavigable
     {
         _changeable = false;
         _changed = false;
+        Characters = ShellViewModel.GetModel().StoryElements.Characters;
 
         Uuid = Model.Uuid;
         Name = Model.Name;
@@ -394,7 +395,8 @@ public class ProblemViewModel : ObservableRecipient, INavigable
 		//Ensure correct set of Elements are loaded for Structure Lists
 		Problems = Ioc.Default.GetService<ShellViewModel>().StoryModel.StoryElements.Problems;
         Scenes = Ioc.Default.GetService<ShellViewModel>().StoryModel.StoryElements.Scenes;
-		_changeable = true;
+
+        _changeable = true;
 	}
 
     internal void SaveModel()
@@ -542,7 +544,6 @@ public class ProblemViewModel : ObservableRecipient, INavigable
     public ProblemViewModel()
     {
         _logger = Ioc.Default.GetService<LogService>();
-        Characters = ShellViewModel.GetModel().StoryElements.Characters;
 
         ProblemType = string.Empty;
         ConflictType = string.Empty;

--- a/StoryCADTests/FileTests.cs
+++ b/StoryCADTests/FileTests.cs
@@ -482,7 +482,7 @@ public class FileTests
     public async Task CheckFileAvailability()
     {
         var _storyIO = Ioc.Default.GetRequiredService<StoryIO>();
-        string _legacyFilePath = "/Migrations/LegacyTest.stbx";
+        string _legacyFilePath = Path.Combine(App.InputDir,"Migrations","LegacyTest.stbx");
         bool result = await _storyIO.CheckFileAvailability(_legacyFilePath);
         Assert.IsTrue(result, $"Expected legacy file at {_legacyFilePath} to be available.");
     }

--- a/StoryCADTests/FileTests.cs
+++ b/StoryCADTests/FileTests.cs
@@ -478,4 +478,13 @@ public class FileTests
 		Assert.AreEqual("Excellent", loadedCharacter.Health);
 	}
 
+    [TestMethod]
+    public async Task CheckFileAvailability()
+    {
+        var _storyIO = Ioc.Default.GetRequiredService<StoryIO>();
+        string _legacyFilePath = "/Migrations/LegacyTest.stbx";
+        bool result = await _storyIO.CheckFileAvailability(_legacyFilePath);
+        Assert.IsTrue(result, $"Expected legacy file at {_legacyFilePath} to be available.");
+    }
+
 }

--- a/StoryCADTests/StoryCADTests.csproj
+++ b/StoryCADTests/StoryCADTests.csproj
@@ -36,6 +36,9 @@
 		<None Update="TestInputs\Migrations\Hamlet.stbx">
 		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
+		<None Update="TestInputs\Migrations\LegacyTest.stbx">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 		<None Update="TestInputs\Migrations\Rocky.stbx">
 		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>

--- a/StoryCADTests/TestInputs/Migrations/LegacyTest.stbx
+++ b/StoryCADTests/TestInputs/Migrations/LegacyTest.stbx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<StoryCAD Version="Version: 2.13.0">
+  <StoryElements>
+    <Overview UUID="28EC80C2-6199-4DAF-B2DD-4D071AC38778" Name="OpenFromDesktopTest" DateCreated="2023-11-29" DateModified="2023-11-29" Author="Jake" StoryType="" StoryGenre="" ViewPoint="" ViewpointCharacter="" Voice="" LiteraryDevice="" Tense="" Style="" Tone="" StoryIdea="{\rtf1\fbidis\ansi\ansicpg1252\deff0\nouicompat\deflang1033{\fonttbl{\f0\fnil\fcharset0 Segoe UI;}{\f1\fnil Segoe UI;}}&#xD;&#xA;{\colortbl ;\red211\green211\blue211;}&#xD;&#xA;{\*\generator Riched20 3.1.0004}\viewkind4\uc1 &#xD;&#xA;\pard\cf1\f0\fs21\lang2057 Hello, if you have performed the test correctly and can now see this, the test has succeeded.\par&#xD;&#xA;\f1\par&#xD;&#xA;}&#xD;&#xA;" Concept="" StoryProblem="" Premise="" StructureNotes="" Notes="" />
+    <TrashCan UUID="7AB86A9B-6D60-46DB-A097-C965BAB05EA5" Name="Deleted Story Elements" />
+    <Folder UUID="2FE0FD7A-147E-432E-BC4E-7DD21F66A203" Name="Narrative View" Notes="" />
+    <Character UUID="BA8C6350-5DDA-4B34-BEA4-08FCC06609DD" Name="TestCharacter" Role="" StoryRole="" Archetype="" Age="" Sex="" Eyes="" Hair="" Weight="" CharHeight="" Build="" Complexion="" Race="" Nationality="" Health="" Enneagram="" Intelligence="" Values="" Abnormality="" Focus="" Adventureousness="" Aggression="" Confidence="" Conscientiousness="" Creativity="" Dominance="" Enthusiasm="" Assurance="" Sensitivity="" Shrewdness="" Sociability="" Stability="" CharacterSketch="" PhysNotes="" Appearance="" Economic="" Education="" Ethnic="" Religion="" PsychNotes="" Notes="" Flaw="" BackStory="">
+      <Relationships />
+      <CharacterTraits />
+    </Character>
+  </StoryElements>
+  <Explorer>
+    <StoryNode UUID="28EC80C2-6199-4DAF-B2DD-4D071AC38778" Type="StoryOverview" Name="OpenFromDesktopTest" IsExpanded="True" IsSelected="False" IsRoot="True">
+      <StoryNode UUID="BA8C6350-5DDA-4B34-BEA4-08FCC06609DD" Type="Character" Name="TestCharacter" IsExpanded="True" IsSelected="False" IsRoot="False" />
+    </StoryNode>
+    <StoryNode UUID="7AB86A9B-6D60-46DB-A097-C965BAB05EA5" Type="TrashCan" Name="Deleted Story Elements" IsExpanded="False" IsSelected="False" IsRoot="True" />
+  </Explorer>
+  <Narrator>
+    <StoryNode UUID="2FE0FD7A-147E-432E-BC4E-7DD21F66A203" Type="Folder" Name="Narrative View" IsExpanded="False" IsSelected="False" IsRoot="True" />
+  </Narrator>
+  <Settings />
+</StoryCAD>


### PR DESCRIPTION
This PR addresses two issues:
- Potential Null Ref that can happen if cancel is pressed on the file open dialog.
- Crash that occurs if a outline is unavailable during migration 
 
fixes #917, #916, #915, #914, #910, #909, #902, #898