### PR TITLE
Fix crash when open outline is clicked and no outline is selected

### DIFF
--- a/StoryCADLib/ViewModels/FileOpenVM.cs
+++ b/StoryCADLib/ViewModels/FileOpenVM.cs
@@ -305,8 +305,12 @@ public class FileOpenVM : ObservableRecipient
         {
             //Open recent file and update list
             case "Recent":
-                filePath = _preferences.Model.RecentFiles[SelectedRecentIndex];
-                await _outlineVm.OpenFile(filePath);
+                if (SelectedRecentIndex != -1)
+                {
+                    filePath = _preferences.Model.RecentFiles[SelectedRecentIndex];
+                    await _outlineVm.OpenFile(filePath);
+                }
+                else{ return; }
                 break;
 
             case "New":

--- a/StoryCADTests/FileOpenMenu.xaml
+++ b/StoryCADTests/FileOpenMenu.xaml
@@ -1,0 +1,132 @@
+﻿<Page
+    x:Class="StoryCAD.Services.Dialogs.FileOpenMenuPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d" Height="500" Width="800">
+
+    <NavigationView OverflowLabelMode="NoLabel" IsBackButtonVisible="Collapsed"
+                    SelectedItem="{x:Bind FileOpenVM.CurrentTab, Mode=TwoWay}"
+                    IsSettingsVisible="False" PaneDisplayMode="Left" IsPaneToggleButtonVisible="False">
+        <NavigationView.MenuItems>
+            <!-- New button -->
+            <NavigationViewItem Content="Create new outline" Tag="New">
+                <NavigationViewItem.Icon>
+                    <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE710;"/>
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
+
+            <!-- Recents button -->
+            <NavigationViewItem Content="Recently opened" Tag="Recent">
+                <NavigationViewItem.Icon>
+                    <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xEC92;"/>
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
+
+            <!-- Samples button -->
+            <NavigationViewItem Content="Sample outlines" Tag="Sample">
+                <NavigationViewItem.Icon>
+                    <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE753;"/>
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
+        </NavigationView.MenuItems>
+
+        <!-- Open from file -->
+        <NavigationView.PaneFooter>
+            <Button HorizontalAlignment="Center" Click="{x:Bind FileOpenVM.LoadStoryFromFile}">
+                <Button.Content>
+                    <StackPanel Orientation="Horizontal">
+                        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE838;"/>
+                        <TextBlock Text="Open Outline from file" Margin="10,0,0,0"/>
+                    </StackPanel>
+                </Button.Content>
+            </Button>
+        </NavigationView.PaneFooter>
+
+        <Grid Margin="10" Background="Transparent">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title and warning -->
+            <TextBlock Text="{x:Bind FileOpenVM.TitleText, Mode=TwoWay}" FontSize="25" HorizontalAlignment="Center"
+                       VerticalAlignment="Top" Grid.Row="0"/>
+
+            <InfoBar Grid.Row="1" IsOpen="{x:Bind FileOpenVM.ShowWarning, Mode=TwoWay}" Severity="Warning" IsClosable="False"
+                     Message="{x:Bind FileOpenVM.WarningText, Mode=TwoWay}" HorizontalAlignment="Center"/>
+
+            <ScrollView Grid.Row="2" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Auto">
+                <Grid>
+                    <!-- Recents tab -->
+                    <Grid Visibility="{x:Bind FileOpenVM.RecentsTabContentVisibility, Mode=TwoWay}" >
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="40"/>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="50"/>
+                        </Grid.RowDefinitions>
+
+                        <ListBox Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Center" 
+                             ItemsSource="{x:Bind FileOpenVM.RecentsUI}"
+                             SelectedIndex="{x:Bind FileOpenVM.SelectedRecentIndex, Mode=TwoWay}"/>
+                    </Grid>
+
+                    <!-- New tab -->
+                    <Grid Visibility="{x:Bind FileOpenVM.NewTabContentVisibility, Mode=TwoWay}">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <ComboBox Grid.Row="0" Header="Template:" HorizontalAlignment="Stretch" Margin="20"
+                              SelectedIndex="{x:Bind FileOpenVM.SelectedTemplateIndex, Mode=TwoWay}">
+                            <x:String>Blank Outline</x:String>
+                            <x:String>Overview and Story Problem</x:String>
+                            <x:String>Folders</x:String>
+                            <x:String>External and Internal Problems</x:String>
+                            <x:String>Protagonist and Antagonist</x:String>
+                            <x:String>Problems and Characters</x:String>
+                        </ComboBox>
+
+                        <TextBox Grid.Row="1" HorizontalContentAlignment="Center" PlaceholderText="You can't put files here"
+                                 Header="Project path:"  HorizontalAlignment="Stretch" Margin="20"
+                                 Text="{x:Bind FileOpenVM.OutlineFolder, Mode=TwoWay}"/>
+
+                        <Button Grid.Row="2" Content="Browse" Click="{x:Bind FileOpenVM.Browse_Click}" HorizontalAlignment="Center"/>
+
+                        <TextBox Grid.Row="3" MinWidth="250"  HorizontalAlignment="Stretch" Margin="20"
+                                 Header="Project Name: " Text="{x:Bind FileOpenVM.OutlineName, Mode=TwoWay}"/>
+                    </Grid>
+
+                    <!-- Samples tab -->
+                    <Grid Visibility="{x:Bind FileOpenVM.SamplesTabContentVisibility, Mode=TwoWay}">
+                        <ListBox HorizontalAlignment="Center" VerticalAlignment="Center"
+                             ItemsSource="{x:Bind FileOpenVM.SampleNames}" CornerRadius="4"
+                             SelectedIndex="{x:Bind FileOpenVM.SelectedSampleIndex, Mode=TwoWay}"/>
+                    </Grid>
+                </Grid>
+            </ScrollView>
+
+
+            <!-- Footer buttons -->
+            <Grid Grid.Row="3" HorizontalAlignment="Stretch">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition MinWidth="10"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition MinWidth="10"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- buttons -->
+                <Button Grid.Column="1" Content="{x:Bind FileOpenVM.ConfirmButtonText, Mode=TwoWay}"
+                        Click="{x:Bind FileOpenVM.ConfirmClicked}" HorizontalAlignment="Stretch" />
+                <Button Grid.Column="2" Content="Close" HorizontalAlignment="Stretch" Click="{x:Bind FileOpenVM.Close}"/>
+            </Grid>
+        </Grid>
+    </NavigationView>
+</Page>

--- a/StoryCADTests/FileOpenMenu.xaml.cs
+++ b/StoryCADTests/FileOpenMenu.xaml.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.UI.Xaml;
+namespace StoryCAD.Services.Dialogs;
+
+/// <summary>
+/// File open menu page, allows user to open and create outlines/samples
+/// </summary>
+public sealed partial class FileOpenMenuPage
+{
+    public FileOpenVM FileOpenVM = Ioc.Default.GetRequiredService<FileOpenVM>();
+
+    public FileOpenMenuPage()
+    {
+        InitializeComponent();
+        FileOpenVM.RecentsTabContentVisibility = Visibility.Collapsed;
+        FileOpenVM.SamplesTabContentVisibility = Visibility.Collapsed;
+        FileOpenVM.NewTabContentVisibility = Visibility.Collapsed;
+        FileOpenVM.OutlineName = "";
+        FileOpenVM.CurrentTab = new NavigationViewItem() { Tag = "Recent" };
+
+        //Set recent files.
+        var preferences = Ioc.Default.GetRequiredService<PreferenceService>();
+        FileOpenVM.RecentsUI.Clear();
+        foreach (var file in preferences.Model.RecentFiles)
+        {
+            //Skip entries that don't exist or are empty
+            if (string.IsNullOrWhiteSpace(file) || !File.Exists(file)) continue;
+
+            //Create
+            StackPanel item = new() { Width = 300 };
+            ToolTipService.SetToolTip(item, file);
+            item.Children.Add(new TextBlock { Text = Path.GetFileNameWithoutExtension(file), FontSize = 20 });
+            item.Children.Add(new TextBlock
+            {
+                Text = "Last edited: " + File.GetLastWriteTime(file),
+                FontSize = 10,
+                VerticalAlignment = VerticalAlignment.Center
+            });
+            FileOpenVM.RecentsUI.Add(item);
+        }
+    }
+}

--- a/StoryCADTests/FileOpenMenu.xaml.cs
+++ b/StoryCADTests/FileOpenMenu.xaml.cs
@@ -1,4 +1,9 @@
-﻿using Microsoft.UI.Xaml;
+﻿using System.IO;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using StoryCAD.ViewModels;
+
 namespace StoryCAD.Services.Dialogs;
 
 /// <summary>

--- a/StoryCADTests/StoryCADTests.csproj
+++ b/StoryCADTests/StoryCADTests.csproj
@@ -11,6 +11,8 @@
 		<RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
 		<EnableMsixTooling>true</EnableMsixTooling>
 		<UseWinUI>true</UseWinUI>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+		
 		<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
 	</PropertyGroup>
 	<ItemGroup>


### PR DESCRIPTION
This PR fixes a crash when open outline is clicked on the recents tab and nothing is selected.