### PR TITLE
Fix #990 by removing double Pref write.

### DIFF
--- a/StoryCADLib/Services/Locking/SerializationLock.cs
+++ b/StoryCADLib/Services/Locking/SerializationLock.cs
@@ -62,7 +62,7 @@ public class SerializationLock : IDisposable
 
         // Set your _canExecuteCommands flag to false
         // (Assuming you can access it via a shared service or static member)
-        _logger.Log(LogLevel.Warn, $"{_caller} has locked commands");
+        _logger.Log(LogLevel.Info, $"{_caller} has locked commands");
         _canExecuteCommands = false;
     }
 
@@ -72,7 +72,7 @@ public class SerializationLock : IDisposable
     public void EnableCommands()
     {
         _canExecuteCommands = true;
-        _logger.Log(LogLevel.Warn, $"{_caller} has unlocked commands");
+        _logger.Log(LogLevel.Info, $"{_caller} has unlocked commands");
         currentHolder = null;
 
     }

--- a/StoryCADLib/ViewModels/FileOpenVM.cs
+++ b/StoryCADLib/ViewModels/FileOpenVM.cs
@@ -337,9 +337,6 @@ public class FileOpenVM : ObservableRecipient
         }
 
         Close(); //Stop more dialog clicks
-
-        PreferencesIo loader = new();
-        await loader.WritePreferences(_preferences.Model);
     }
 
     public async Task<string> CreateFile()


### PR DESCRIPTION
This PR does two things:
- Remove a second unneeded preferences write when creating a story
- Downgrades lock logging messages when created or release to just an information message.