### PR TITLE
Update docs for NRtfTree repository separation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,29 @@
 version: 2
 updates:
-
-  # StoryCAD project
   - package-ecosystem: "nuget"
     directory: "/StoryCAD/StoryCAD.csproj"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
     versioning-strategy: "auto"
-    ignore:
-      - dependency-name: "Syncfusion.Editors.WinUI"
+
     commit-message:
       prefix: "StoryCAD"
 
-  # StoryCADLib project
   - package-ecosystem: "nuget"
     directory: "/StoryCADLib/StoryCADLib.csproj"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
     versioning-strategy: "auto"
-    ignore:
-      - dependency-name: "Syncfusion.Editors.WinUI"
     commit-message:
       prefix: "StoryCADLib"
 
-  # StoryCADTests project
   - package-ecosystem: "nuget"
     directory: "/StoryCADTests/StoryCADTests.csproj"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
     versioning-strategy: "auto"
-    ignore:
-      - dependency-name: "Syncfusion.Editors.WinUI"
     commit-message:
       prefix: "StoryCADTests"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,5 @@
 version: 2
 updates:
-  # NRTFTree project
-  - package-ecosystem: "nuget"
-    directory: "/NRtfTree/NRTFTree.csproj"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
-    versioning-strategy: "auto"
-    ignore:
-      - dependency-name: "Syncfusion.Editors.WinUI"
-    commit-message:
-      prefix: "NRTFTree"
 
   # StoryCAD project
   - package-ecosystem: "nuget"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
-    versioning-strategy: "auto"
 
     commit-message:
       prefix: "StoryCAD"
@@ -15,7 +14,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
-    versioning-strategy: "auto"
     commit-message:
       prefix: "StoryCADLib"
 
@@ -24,6 +22,5 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
-    versioning-strategy: "auto"
     commit-message:
       prefix: "StoryCADTests"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and suspenseful plots, and settings that appeal to the senses.
 * [Windows App SDK][2]
 * [Windows Community Toolkit][3]
 * [elmah.io][4]
-* [NRtfTree][5]
+* [NRtfTree][5] (maintained separately with asynchronous IO support)
 * [Scrivener][6]
 
 WinUI is the UI Framework for StoryCAD and is [source available](https://github.com/microsoft/microsoft-ui-xaml/tree/main/src)
@@ -33,7 +33,7 @@ Windows Community Toolkit is available under the [MIT License][14].
 
 elmah.io is a commercial cloud-based error logging and uptime monitor service. elmah.io graciously provides a [free subscription][15] to public repository open source projects. We are grateful for their support.
 
-NRtfTree is available under the [GNU GPL V3 License][16]. StoryCAD has changed this software locally to allowasynchronous IO.
+NRtfTree is available under the [GNU GPL V3 License][16]. We maintain our asynchronous IO fork in a separate repository.
 
 [Scrivener][6] is a commercial writing application widely used by novelists, screenwriters, playwrights, and short fiction writers. 
 StoryCAD contains a feature that inserts StoryCAD reports into a Scrivener project using their Scrivener 3 File Formatting Specification API. 
@@ -87,7 +87,7 @@ We are most grateful for all of them especially those who toil in the arena:
 [2]:https://github.com/microsoft/WindowsAppSDK#readme
 [3]:https://github.com/CommunityToolkit/Windows
 [4]:https://elmah.io/
-[5]:https://github.com/sgolivernet/nrtftree#readme
+[5]:https://github.com/StoryBuilder-org/NRTFTree-Async
 [6]:https://www.literatureandlatte.com/scrivener/overview
 [7]:https://www.syncfusion.com/winui-controls
 [8]:https://storybuilder-org.github.io/StoryCAD/

--- a/docs/For Developers/Acknowledgements.md
+++ b/docs/For Developers/Acknowledgements.md
@@ -34,7 +34,7 @@ StoryCAD uses or links to the following software:
 * [Windows App SDK][2]
 * [Windows Community Toolkit][3]
 * [Elmah.io][4]
-* [NRtfTree][5]
+* [NRtfTree][5] (maintained separately with asynchronous IO support)
 * [Scrivener][6]
 
 We are especially grateful to elmah.io commercial products who make their
@@ -101,6 +101,6 @@ https://dotnetfoundation.org/projects/windowscommunitytoolkit
 [2]:https://github.com/microsoft/WindowsAppSDK
 [3]:https://github.com/CommunityToolkit/WindowsCommunityToolkit
 [4]:https://elmah.io/
-[5]:https://github.com/sgolivernet/nrtftree
+[5]:https://github.com/StoryBuilder-org/NRTFTree-Async
 [6]:https://www.literatureandlatte.com/scrivener
 [7]:https://www.syncfusion.com/winui-controls

--- a/docs/For Developers/Changelog.md
+++ b/docs/For Developers/Changelog.md
@@ -19,7 +19,7 @@ StoryCAD 2.13.1.0 Was released in January 2024.
 StoryCAD 2.13.0.0 was release on November 28th 2023.
 **This version removes support for versions of Windows older than Windows 10 20H2**
 
- - Added option to set StoryCAD's theme independtly of the system theme (#668, 666)
+ - Added option to set StoryCAD's theme independently of the system theme (#668, 666)
  -  Removed Install Service to boost load times (#660)
  - Updated StoryCAD to use an automated testing suite to prevent regressions (#661, #658, #655)
  - Updated dependencies (#665)
@@ -29,7 +29,7 @@ StoryCAD 2.13.0.0 was release on November 28th 2023.
  - Cleaned up code (#680)
  - Fixed issues connecting to the backend server (#682, #677)
  - Fixed potential issue with file open launches (#686)
- - Fixed rare crash that could occur when opening a content dialog too fast after initalisation (#679)
+ - Fixed rare crash that could occur when opening a content dialog too fast after initialization (#679)
 
 
 #### Release 2.12.0.0

--- a/docs/For Developers/Developer_Notes.md
+++ b/docs/For Developers/Developer_Notes.md
@@ -14,7 +14,7 @@ has_toc: false
 StoryCAD is written in C# and XAML and is a Windows desktop app. 
 It's written using [WinUI 3][2], [MVVM][6], [Project Reunion APIs][3], and [.NET][8]. 
 Although the only programming skill you need to get started is some C#, familiarity with [asynchronous IO][5] and [MVVM][6] will be useful. 
-We maintain StoryCAD as a Visual Studio Ssolution using Visual Studio 2022.
+We maintain StoryCAD as a Visual Studio solution using Visual Studio 2022.
 StoryCAD began as a UWP program and now uses Windows UI (WinUI 3) [controls][7] and styles. It runs
 as a native Windows (Win32) program, but its UWP roots remain; it uses [UWP asynchronous IO][4].
 This allows StoryCAD outlines, which are JSON files, to be stored locally or on cloud storage services like OneDrive, Dropbox, Google Drive or Box.


### PR DESCRIPTION
## Summary
- note that NRtfTree is maintained separately
- mention asynchronous IO fork is in another repository
- remove obsolete dependabot entry for NRtfTree