### PR TITLE
Add preference to hide key file warning

### DIFF
--- a/StoryCAD/Views/Shell.xaml.cs
+++ b/StoryCAD/Views/Shell.xaml.cs
@@ -75,7 +75,11 @@ public sealed partial class Shell
         ShellVm.ShowHomePage();
         ShellVm.ShowConnectionStatus();
         Windowing.UpdateWindowTitle();
-        if (!Ioc.Default.GetService<AppState>()!.EnvPresent) { await ShellVm.ShowDotEnvWarningAsync(); }
+        if (!Ioc.Default.GetService<AppState>()!.EnvPresent &&
+            !Preferences.HideKeyFileWarning)
+        {
+            await ShellVm.ShowDotEnvWarningAsync();
+        }
 
         if (!await Ioc.Default.GetRequiredService<WebViewModel>().CheckWebViewState())
         {

--- a/StoryCADLib/Models/Tools/PreferencesModel.cs
+++ b/StoryCADLib/Models/Tools/PreferencesModel.cs
@@ -195,15 +195,22 @@ public class PreferencesModel : ObservableObject
 	/// Should the startup dialog (HelpPage) be shown
 	/// </summary>
 	[JsonInclude]
-	[JsonPropertyName("ShowStartupDialog")]
-	public bool ShowStartupDialog { get; set; }
+        [JsonPropertyName("ShowStartupDialog")]
+        public bool ShowStartupDialog { get; set; }
 
-	/// <summary>
-	/// Do we want to log more in depth
-	/// </summary>
-	[JsonInclude]
-	[JsonPropertyName("AdvancedLogging")]
-	public bool AdvancedLogging { get; set; }
+        /// <summary>
+        /// Do we want to log more in depth
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("AdvancedLogging")]
+        public bool AdvancedLogging { get; set; }
+
+        /// <summary>
+        /// Hide the key file missing warning dialog.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("HideKeyFileWarning")]
+        public bool HideKeyFileWarning { get; set; } = false;
 #endregion
 
 	#region Constructor
@@ -232,10 +239,11 @@ public class PreferencesModel : ObservableObject
 		PreferredSearchEngine = BrowserType.DuckDuckGo;
 		ThemePreference = ElementTheme.Default; // Use system theme
 		HideRatingPrompt = false;
-		CumulativeTimeUsed = 0;
-		AdvancedLogging = false;
-		LastReviewDate = DateTime.MinValue;
-		ShowStartupDialog = true;
-	}
-	#endregion
+                CumulativeTimeUsed = 0;
+                AdvancedLogging = false;
+                HideKeyFileWarning = false;
+                LastReviewDate = DateTime.MinValue;
+                ShowStartupDialog = true;
+        }
+        #endregion
 }

--- a/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
@@ -135,8 +135,11 @@
                         <Button Content="Throw exception" Click="ThrowException" Width="150" Margin="0,5"/>
                         <Button Content="Attach Elmah" Click="{x:Bind Logger.AddElmahTarget}" Width="150" Margin="0,5"/>
 						<Button Content="Refresh Dev Stats" Click="RefreshDevStats" Width="150" Margin="0,5"/>
-						<Button Content="Open Picker UI" Click="OpenPickerUI" Width="150" Margin="0,5"/>
-					</StackPanel>
+                        <Button Content="Open Picker UI" Click="OpenPickerUI" Width="150" Margin="0,5"/>
+                        <CheckBox Content="Hide key file warning"
+                                  IsChecked="{x:Bind PreferencesVm.HideKeyFileWarning, Mode=TwoWay}"
+                                  Width="150" Margin="0,5"/>
+                                        </StackPanel>
                     <ScrollViewer MaxHeight="400">
                         <StackPanel>
                             <TextBlock Name="DevInfo"  Width="300" Height="250" Margin="5,0" />

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -456,6 +456,7 @@ public class ShellViewModel : ObservableRecipient
                       If you are a user you should report this as you are not supposed to see this message.
                       
                       Things such as logging and elmah.io will not work without the key file.
+                      You can disable this warning in the dev menu.
                       """,
             PrimaryButtonText = "Okay"
         };

--- a/StoryCADLib/ViewModels/Tools/PreferencesViewModel.cs
+++ b/StoryCADLib/ViewModels/Tools/PreferencesViewModel.cs
@@ -177,13 +177,21 @@ public class PreferencesViewModel : ObservableValidator
     public bool _advancedLogging;
     public bool AdvancedLogging
     {
-	    get => _advancedLogging;
-	    set => SetProperty(ref _advancedLogging, value);
+            get => _advancedLogging;
+            set => SetProperty(ref _advancedLogging, value);
     }
 
-	// Show startup page.
+    // Hide missing key file warning
+    public bool _hideKeyFileWarning;
+    public bool HideKeyFileWarning
+    {
+            get => _hideKeyFileWarning;
+            set => SetProperty(ref _hideKeyFileWarning, value);
+    }
+
+        // Show startup page.
     private bool _ShowStartupPage;
-	public bool ShowStartupPage
+        public bool ShowStartupPage
     {
 	    get => _ShowStartupPage;
 	    set => SetProperty(ref _ShowStartupPage, value);
@@ -220,6 +228,7 @@ public class PreferencesViewModel : ObservableValidator
         PreferredSearchEngine = CurrentModel.PreferredSearchEngine;
         PreferedTheme = CurrentModel.ThemePreference;
         AdvancedLogging = CurrentModel.AdvancedLogging;
+        HideKeyFileWarning = CurrentModel.HideKeyFileWarning;
         ShowStartupPage = CurrentModel.ShowStartupDialog;
     }
 
@@ -248,6 +257,7 @@ public class PreferencesViewModel : ObservableValidator
         CurrentModel.RecordVersionStatus = RecordVersionStatus;
         CurrentModel.PreferredSearchEngine = PreferredSearchEngine;
         CurrentModel.AdvancedLogging = AdvancedLogging;
+        CurrentModel.HideKeyFileWarning = HideKeyFileWarning;
 
         if (CurrentModel.ThemePreference != PreferedTheme)
         {


### PR DESCRIPTION
## Summary
- add `HideKeyFileWarning` preference to the model and view model
- expose checkbox in the dev tab to control the warning
- only show missing .env dialog when the preference isn't set
- mention the setting in the key missing prompt

## Testing
- `dotnet test 2>&1 | tail -n 20` *(fails: NETSDK1100)*