### PR TITLE
Fix ReleaseBuilder workflow paths

### DIFF
--- a/.github/workflows/ReleaseBuilder.yml
+++ b/.github/workflows/ReleaseBuilder.yml
@@ -35,18 +35,18 @@ jobs:
       run: |
         $ver="${{ github.event.inputs.VersionNumber }}"
         $regex=' Version="\d+\.\d+\.\d+\.\d+"'
-        (Get-Content "D:\a\StoryCAD\StoryCAD\StoryCAD\Package.appxmanifest") `
+        (Get-Content "${{ github.workspace }}\StoryCAD\Package.appxmanifest") `
           -replace $regex, " Version=""$ver""" |
-          Set-Content "D:\a\StoryCAD\StoryCAD\StoryCAD\Package.appxmanifest" -Encoding utf8
+          Set-Content "${{ github.workspace }}\StoryCAD\Package.appxmanifest" -Encoding utf8
 
     # ─── Cert / env ──────────────────────────────────────────────────────────────
     - name: Decode signing PFX & write .env files
       shell: pwsh
       run: |
-        [IO.File]::WriteAllBytes("GitHubActionsWorkflow.pfx",
+        [IO.File]::WriteAllBytes("${{ github.workspace }}\StoryCAD\GitHubActionsWorkflow.pfx",
           [Convert]::FromBase64String("${{ secrets.BASE64_ENCODED_PFX }}"))
-        [IO.File]::WriteAllText("D:\a\StoryCAD\StoryCAD\StoryCAD\.env",      "${{ secrets.ENV }}")
-        [IO.File]::WriteAllText("D:\a\StoryCAD\StoryCAD\StoryCADTests\.env", "${{ secrets.ENV }}")
+        [IO.File]::WriteAllText("${{ github.workspace }}\StoryCAD\.env",      "${{ secrets.ENV }}")
+        [IO.File]::WriteAllText("${{ github.workspace }}\StoryCADTests\.env", "${{ secrets.ENV }}")
 
     # ─── Restore / build ────────────────────────────────────────────────────────
     - name: Restore solution (Release + Debug)
@@ -77,7 +77,7 @@ jobs:
       shell: pwsh
       run: >
         vstest.console.exe
-        D:\a\StoryCAD\StoryCAD\StoryCADTests\bin\x64\Debug\net8.0-windows10.0.19041.0\StoryCADTests.dll
+        ${{ github.workspace }}\StoryCADTests\bin\x64\Debug\net8.0-windows10.0.19041.0\StoryCADTests.dll
         /Logger:Console /Platform:x64
 
     # ─── App packages ───────────────────────────────────────────────────────────
@@ -94,8 +94,8 @@ jobs:
             /p:Platform=$plat `
             /p:UapAppxPackageBuildMode=$env:Appx_Package_Build_Mode `
             /p:AppxBundle=$env:Appx_Bundle `
-            /p:PackageCertificateKeyFile="D:\a\StoryCAD\StoryCAD\GitHubActionsWorkflow.pfx" `
-            /p:PackageCertificateKeyFile="D:\a\StoryCAD\StoryCAD\GitHubActionsWorkflow.pfx" `
+            /p:PackageCertificateKeyFile="${{ github.workspace }}\StoryCAD\GitHubActionsWorkflow.pfx" `
+            /p:PackageCertificateKeyFile="${{ github.workspace }}\StoryCAD\GitHubActionsWorkflow.pfx" `
             /p:AppxPackageDir="$env:Appx_Package_Dir" `
             /p:GenerateAppxPackageOnBuild=true `
             /p:NuGetVersion=${{ github.event.inputs.VersionNumber }} `
@@ -104,33 +104,33 @@ jobs:
 
     - name: Remove PFX
       shell: pwsh
-      run: Remove-Item GitHubActionsWorkflow.pfx
+      run: Remove-Item -path "${{ github.workspace }}\StoryCAD\GitHubActionsWorkflow.pfx"
 
     - name: Run MSIX cleaner
       shell: pwsh
       run: >
-        D:\a\StoryCAD\StoryCAD\.github\workflows\MSIX.ps1
-        -TargetDirectory "D:\a\StoryCAD\StoryCAD\StoryCAD\Packages"
+        ${{ github.workspace }}\.github\workflows\MSIX.ps1
+        -TargetDirectory "${{ github.workspace }}\StoryCAD\Packages"
 
     # ─── NuGet repack ───────────────────────────────────────────────────────────
     - name: Move StoryCADLib package into Packages/
       shell: pwsh
       run: |
-        Get-ChildItem -Path "D:\a\StoryCAD\StoryCAD\StoryCADLib\bin\x64\*" `
+        Get-ChildItem -Path "${{ github.workspace }}\StoryCADLib\bin\x64\*" `
           -Include *.nupkg,*.snupkg -File -Recurse |
-          Move-Item -Destination "D:\a\StoryCAD\StoryCAD\StoryCAD\Packages" -Force
+          Move-Item -Destination "${{ github.workspace }}\StoryCAD\Packages" -Force
 
     - name: Repack StoryCADLib with runtime binaries & Assets
       shell: pwsh
       run: |
-        $pkg = Get-ChildItem "D:\a\StoryCAD\StoryCAD" -Filter "StoryCADLib*.nupkg" -Recurse |
+        $pkg = Get-ChildItem "${{ github.workspace }}" -Filter "StoryCADLib*.nupkg" -Recurse |
                Where-Object FullName -Match "\\Release\\" | Select-Object -First 1
         $tmp  = Join-Path $env:TEMP ("nupkg_" + [guid]::NewGuid())
         Expand-Archive  $pkg.FullName $tmp -Force
         $lib  = Join-Path $tmp "lib\net8.0-windows10.0.22621"
         New-Item $lib -ItemType Directory -Force | Out-Null
-        Copy-Item "D:\a\StoryCAD\StoryCAD\StoryCADLib\bin\x64\Release\net8.0-windows10.0.22621.0\*" $lib -Recurse -Force
-        Copy-Item "D:\a\StoryCAD\StoryCAD\StoryCADLib\Assets\*" (Join-Path $lib StoryCADLib) -Recurse -Force
+        Copy-Item "${{ github.workspace }}\StoryCADLib\bin\x64\Release\net8.0-windows10.0.22621.0\*" $lib -Recurse -Force
+        Copy-Item "${{ github.workspace }}\StoryCADLib\Assets\*" (Join-Path $lib StoryCADLib) -Recurse -Force
         Compress-Archive -Path (Join-Path $tmp '*') -DestinationPath $pkg.FullName -Force
         Remove-Item $tmp -Recurse -Force
 
@@ -138,7 +138,7 @@ jobs:
     - name: Write install instructions
       shell: pwsh
       run: |
-        $file = "D:\a\StoryCAD\StoryCAD\StoryCAD\Packages\Install Instructions.txt"
+        $file = "${{ github.workspace }}\StoryCAD\Packages\Install Instructions.txt"
 
         @(
           "Hello, Thank you for using StoryCAD Release ${{ github.event.inputs.VersionNumber }}",
@@ -159,14 +159,14 @@ jobs:
       with:
         type: zip
         filename: Release.zip
-        path: D:\a\StoryCAD\StoryCAD\StoryCAD\Packages\
+        path: ${{ github.workspace }}\StoryCAD\Packages\
 
     # ─── Upload artefacts ──────────────────────────────────────────────────────
     - name: Upload MSIX packages
       uses: actions/upload-artifact@v4
       with:
         name: StoryCAD
-        path: StoryCAD/StoryCAD/StoryCAD/Packages/*
+        path: ${{ github.workspace }}\StoryCAD\Packages\*
         compression-level: 9
         include-hidden-files: true
 
@@ -174,7 +174,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: repacked-nuget-package
-        path: D:\a\StoryCAD\StoryCAD\StoryCADLib\bin\Release\StoryCADLib*.nupkg
+        path: ${{ github.workspace }}\StoryCADLib\bin\Release\StoryCADLib*.nupkg
 
     # ─── Tag & GitHub release ─────────────────────────────────────────────────
     - name: Configure Git


### PR DESCRIPTION
## Summary
- clean up ReleaseBuilder paths to use `${{ github.workspace }}`
- remove hard-coded `D:\a\StoryCAD\StoryCAD` references

## Testing
- `dotnet test` *(fails: EnableWindowsTargeting; network)*

------
https://chatgpt.com/codex/tasks/task_b_686190653e1c8330a1145df5f4ca2177