### PR TITLE
Validate path before creating outline file

### DIFF
--- a/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
+++ b/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
@@ -229,6 +229,20 @@ public class OutlineViewModel : ObservableRecipient
         try
         {
             Messenger.Send(new StatusChangedMessage(new StatusMessage("New project command executing", LogLevel.Info)), true);
+            // Validate the requested file path before making any changes
+            if (!Path.GetExtension(dialogVm.OutlineName)!.Equals(".stbx"))
+            {
+                dialogVm.OutlineName += ".stbx";
+            }
+
+            string newFilePath = Path.Combine(dialogVm.OutlineFolder, dialogVm.OutlineName);
+
+            if (!StoryIO.IsValidPath(newFilePath))
+            {
+                logger.Log(LogLevel.Warn, $"Invalid file path {newFilePath}");
+                Messenger.Send(new StatusChangedMessage(new("Invalid file path", LogLevel.Error)), true);
+                return;
+            }
             using (var serializationLock = new SerializationLock(autoSaveService, backupService, logger))
             {
                 // If the current project needs saved, do so
@@ -241,12 +255,6 @@ public class OutlineViewModel : ObservableRecipient
             // Start with a blank StoryModel
             shellVm.ResetModel();
             shellVm.ShowHomePage();
-
-            // Ensure the filename has .stbx extension
-            if (!Path.GetExtension(dialogVm.OutlineName)!.Equals(".stbx"))
-            {
-                dialogVm.OutlineName += ".stbx";
-            }
 
             using (var serializationLock = new SerializationLock(autoSaveService, backupService, logger))
             {

--- a/docs/Quick Start/Reading_and_Writing_Outlines.md
+++ b/docs/Quick Start/Reading_and_Writing_Outlines.md
@@ -30,3 +30,5 @@ Clicking on Sample Stories on the left tab displays a list of sample outlines in
 
 Only one story outline can be open at a time.  If you open a new file you'll be prompted to save the current file first if it’s been modified.
 
+If you see an error about invalid characters when creating a new outline, check that both the outline name and folder path contain only characters permitted by your operating system.
+


### PR DESCRIPTION
## Summary
- prevent invalid file paths during outline creation
- document how to fix invalid character errors when creating an outline

## Testing
- `dotnet test` *(fails: EnableWindowsTargeting on this OS)*

------
https://chatgpt.com/codex/tasks/task_b_6863b4c68a8c8330ba20e467e0125c61