### PR TITLE
Fix empty trash index exception

### DIFF
--- a/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
+++ b/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
@@ -1127,6 +1127,13 @@ public class OutlineViewModel : ObservableRecipient
         }
 
         //TODO: Add dialog to confirm restore
+        if (shellVm.DataSource.Count <= 1)
+        {
+            logger.Log(LogLevel.Warn, "Failed to restore element - Trash can not available in current view.");
+            Messenger.Send(new StatusChangedMessage(new("Unable to restore - Trash not available", LogLevel.Warn)));
+            return;
+        }
+
         ObservableCollection<StoryNodeItem> _target = shellVm.DataSource[0].Children;
         shellVm.DataSource[1].Children.Remove(shellVm.RightTappedNode);
         _target.Add(shellVm.RightTappedNode);
@@ -1170,6 +1177,13 @@ public class OutlineViewModel : ObservableRecipient
         {
             Messenger.Send(new StatusChangedMessage(new("You need to load a story first!", LogLevel.Warn)));
             logger.Log(LogLevel.Info, "Failed to empty trash as DataSource is null. (Is a story loaded?)");
+            return;
+        }
+
+        if (shellVm.DataSource.Count <= 1)
+        {
+            logger.Log(LogLevel.Warn, "Failed to empty trash - Trash can not available in current view.");
+            Messenger.Send(new StatusChangedMessage(new("No Deleted StoryElements to empty", LogLevel.Warn)));
             return;
         }
 


### PR DESCRIPTION
## Summary
- add checks for missing trash node when restoring items
- guard against absent trash when emptying trash

## Testing
- `dotnet test --no-build` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_b_6865510b37e08330a92c1ad814290e16