### PR TITLE
Fix "crash" on shutdown

### DIFF
--- a/StoryCAD/Views/Shell.xaml.cs
+++ b/StoryCAD/Views/Shell.xaml.cs
@@ -124,6 +124,10 @@ public sealed partial class Shell
 		{
 			rateService.OpenRatingPrompt();
 		}
+
+        // Track when the application is shutting down
+        
+        Windowing.MainWindow.Closed += ((_, _) => ShellVm.IsClosing = true);
     }
 
     /// <summary>

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -75,6 +75,7 @@ public class ShellViewModel : ObservableRecipient
     private ObservableCollection<StoryNodeItem> _targetCollection;
 
     private readonly DispatcherTimer _statusTimer;
+    private bool _isClosing;
 
     public CollaboratorArgs CollabArgs;
    
@@ -1103,46 +1104,50 @@ public class ShellViewModel : ObservableRecipient
     /// <param name="statusMessage"></param>
     private void StatusMessageReceived(StatusChangedMessage statusMessage)
     {
-        // Ignore inside tests
-        if (State.Headless) return;
+        // Bypass if in headless mode or if the app is closing
+        if (State.Headless || _isClosing) return;
 
-        // Ensure we are on the UI Thread.
-        var dq = Window.GlobalDispatcher;
-        if (dq is { HasThreadAccess: false })
+        try
         {
-            dq.TryEnqueue(() => StatusMessageReceived(statusMessage));
-            return;
+            // Ensure we are on the UI thread
+            var dq = Window.GlobalDispatcher;
+            if (dq is { HasThreadAccess: false })
+            {
+                dq.TryEnqueue(() => StatusMessageReceived(statusMessage));
+                return;
+            }
+
+            if (_statusTimer.IsEnabled)
+                _statusTimer.Stop();
+
+            StatusMessage = statusMessage.Value.Status;
+            switch (statusMessage.Value.Level)
+            {
+                case LogLevel.Info:
+                    StatusColor = Window.SecondaryColor;
+                    _statusTimer.Interval = TimeSpan.FromSeconds(15);
+                    _statusTimer.Start();
+                    break;
+                case LogLevel.Warn:
+                    StatusColor = new SolidColorBrush(Colors.Yellow);
+                    _statusTimer.Interval = TimeSpan.FromSeconds(30);
+                    _statusTimer.Start();
+                    break;
+                case LogLevel.Error:
+                    StatusColor = new SolidColorBrush(Colors.Red);
+                    break;
+                case LogLevel.Fatal:
+                    StatusColor = new SolidColorBrush(Colors.DarkRed);
+                    break;
+            }
+
+            Logger.Log(statusMessage.Value.Level, StatusMessage);
         }
-
-        if (_statusTimer.IsEnabled)
-            _statusTimer.Stop();
-
-        StatusMessage = statusMessage.Value.Status;
-
-        switch (statusMessage.Value.Level)
+        catch (Exception ex)
         {
-            //Timer ticks for these, and will auto clear.
-            case LogLevel.Info:
-                StatusColor = Window.SecondaryColor;
-                _statusTimer.Interval = TimeSpan.FromSeconds(15);
-                _statusTimer.Start();
-                break;
-            case LogLevel.Warn:
-                StatusColor = new SolidColorBrush(Colors.Yellow);
-                _statusTimer.Interval = TimeSpan.FromSeconds(30);
-                _statusTimer.Start();
-                break;
-
-            //Time won't tick for these
-            case LogLevel.Error:
-                StatusColor = new SolidColorBrush(Colors.Red);
-                break;
-            case LogLevel.Fatal:
-                StatusColor = new SolidColorBrush(Colors.DarkRed);
-                break;
+            // Log or handle the exception safely
+            Logger.LogException(LogLevel.Warn, ex, "StatusMessageReceived failed during shutdown.");
         }
-
-        Logger.Log(statusMessage.Value.Level, statusMessage.Value.Status);
     }
 
 
@@ -1447,6 +1452,8 @@ public class ShellViewModel : ObservableRecipient
 
     public ShellViewModel()
     {
+        // Track when the application is shutting down
+        Application.Current.Exit += (s, e) => _isClosing = true;
         // Resolve services via Ioc as needed
         Logger = Ioc.Default.GetRequiredService<LogService>();
         Search = Ioc.Default.GetRequiredService<SearchService>();

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -75,7 +75,7 @@ public class ShellViewModel : ObservableRecipient
     private ObservableCollection<StoryNodeItem> _targetCollection;
 
     private readonly DispatcherTimer _statusTimer;
-    private bool _isClosing;
+    public bool IsClosing;
 
     public CollaboratorArgs CollabArgs;
    
@@ -1105,7 +1105,7 @@ public class ShellViewModel : ObservableRecipient
     private void StatusMessageReceived(StatusChangedMessage statusMessage)
     {
         // Bypass if in headless mode or if the app is closing
-        if (State.Headless || _isClosing) return;
+        if (State.Headless || IsClosing) return;
 
         try
         {
@@ -1452,8 +1452,6 @@ public class ShellViewModel : ObservableRecipient
 
     public ShellViewModel()
     {
-        // Track when the application is shutting down
-        Application.Current.Exit += (s, e) => _isClosing = true;
         // Resolve services via Ioc as needed
         Logger = Ioc.Default.GetRequiredService<LogService>();
         Search = Ioc.Default.GetRequiredService<SearchService>();


### PR DESCRIPTION
## Summary
- prevent updates to the status bar after shutdown begins
- log failures in `StatusMessageReceived`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686551dbeec8833081e978cad28f0683