### PR TITLE
Set struct model title to custom beatsheet when loading beatsheet.

### DIFF
--- a/StoryCADLib/ViewModels/ProblemViewModel.cs
+++ b/StoryCADLib/ViewModels/ProblemViewModel.cs
@@ -567,6 +567,7 @@ public class ProblemViewModel : ObservableRecipient, INavigable
         if (value == "Load Custom Beat Sheet from file...")
         {
             value = "Custom Beat Sheet";
+            StructureModelTitle = value;
             LoadBeatSheet();
         }
 
@@ -923,7 +924,7 @@ public class ProblemViewModel : ObservableRecipient, INavigable
         }
         catch (Exception ex)
         {
-            Ioc.Default.GetService<ShellViewModel>().ShowMessage(LogLevel.Error, "Failed to save Beatsheet", false);
+            Ioc.Default.GetService<ShellViewModel>().ShowMessage(LogLevel.Error, "Failed to Load Beatsheet", false);
 
         }
     }


### PR DESCRIPTION
Fixes a potential issue where loaded beatsheets could be set as Load Beat Shet From File... instead of Custom beatsheet after loading.