### PR TITLE
Fix NuGet packaging workflow

### DIFF
--- a/.github/workflows/AutoBuilder.yml
+++ b/.github/workflows/AutoBuilder.yml
@@ -122,12 +122,6 @@ jobs:
         ${{ github.workspace }}\.github\workflows\MSIX.ps1 -TargetDirectory "${{ github.workspace }}\StoryCAD\Packages"
       shell: pwsh
 
-    - name: Move StoryCADLib Nuget Package to Packages Directory
-      run: |
-        Get-ChildItem -Path "${{ github.workspace }}\StoryCADLib\bin\x64\*" -Include *.nupkg,*.snupkg -File |
-          Move-Item -Destination "${{ github.workspace }}\StoryCAD\Packages\" -Force
-
-
     - name: Write help file
       run: |
         $LastVer = "${{ steps.testtag.outputs.tag }}"
@@ -175,6 +169,13 @@ jobs:
 
         # 6. Cleanup
         Remove-Item -Recurse -Force $tempDir
+
+    - name: Move repacked StoryCADLib to Packages
+      if: ${{ matrix.configuration == 'Release' && matrix.platform == 'x64' }}
+      shell: pwsh
+      run: |
+        Get-ChildItem -Path "${{ github.workspace }}\StoryCADLib\bin\Release" -Filter "StoryCADLib*.nupkg" |
+          Move-Item -Destination "${{ github.workspace }}\StoryCAD\Packages" -Force
 
     - name: Zip the packages folder
       run: |

--- a/.github/workflows/ReleaseBuilder.yml
+++ b/.github/workflows/ReleaseBuilder.yml
@@ -113,13 +113,6 @@ jobs:
         -TargetDirectory "${{ github.workspace }}\StoryCAD\Packages"
 
     # ─── NuGet repack ───────────────────────────────────────────────────────────
-    - name: Move StoryCADLib package into Packages/
-      shell: pwsh
-      run: |
-        Get-ChildItem -Path "${{ github.workspace }}\StoryCADLib\bin\x64\*" `
-          -Include *.nupkg,*.snupkg -File -Recurse |
-          Move-Item -Destination "${{ github.workspace }}\StoryCAD\Packages" -Force
-
     - name: Repack StoryCADLib with runtime binaries & Assets
       shell: pwsh
       run: |
@@ -133,6 +126,12 @@ jobs:
         Copy-Item "${{ github.workspace }}\StoryCADLib\Assets\*" (Join-Path $lib StoryCADLib) -Recurse -Force
         Compress-Archive -Path (Join-Path $tmp '*') -DestinationPath $pkg.FullName -Force
         Remove-Item $tmp -Recurse -Force
+
+    - name: Move repacked StoryCADLib to Packages
+      shell: pwsh
+      run: |
+        Get-ChildItem -Path "${{ github.workspace }}\StoryCADLib\bin\Release" -Filter "StoryCADLib*.nupkg" |
+          Move-Item -Destination "${{ github.workspace }}\StoryCAD\Packages" -Force
 
     # ─── Help file & zipping ───────────────────────────────────────────────────
     - name: Write install instructions


### PR DESCRIPTION
## Summary
- fix AutoBuilder to put the repacked StoryCADLib package in `Packages/`
- fix ReleaseBuilder to only package the final repacked StoryCADLib

## Testing
- `dotnet test StoryCAD.sln` *(fails: NETSDK1100)*

------
https://chatgpt.com/codex/tasks/task_b_6866947e05e88330ac6479a28ea3fc36