### PR TITLE
fix locking and other small errors with drag and drop

### DIFF
--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -1364,7 +1364,7 @@ public void MoveStoryNode(StoryNodeItem source, StoryNodeItem target, DragAndDro
         }
 
         // Use async dispatch to avoid reentrancy
-        Window.GlobalDispatcher.TryEnqueue(() =>
+        Ioc.Default.GetRequiredService<Windowing>().GlobalDispatcher.TryEnqueue(() =>
         {
             lock (dragLock)
             {


### PR DESCRIPTION
This PR addresses several issues which cause drag and drop problems in StoryCAD, and particularly relating to the locking changes in 3.0. 
Unfortunately, there are still more d&d issues that can result in crashes. A rewrite which eliminates the exit code altogether is forthcoming.