### PR TITLE
Fix tree binding for root collection

### DIFF
--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -360,7 +360,7 @@
                    FontFamily="Segoe UI">
             <!-- Nav tree -->
             <SplitView.Pane>
-                <ItemsRepeater ItemsSource="{x:Bind ShellVm.DataSource, Mode=TwoWay}" x:Name="NavigationTree"
+                <ItemsRepeater ItemsSource="{x:Bind ShellVm.DataSource[0].Children, Mode=TwoWay}" x:Name="NavigationTree"
                                ContextFlyout="{StaticResource AddStoryElementFlyout}" 
                                ContextRequested="AddButton_ContextRequested" >
 


### PR DESCRIPTION
## Summary
- show navigation tree by binding directly to Overview's children

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: NETSDK1100)*

------
https://chatgpt.com/codex/tasks/task_b_687cf1e0de80832da88efb3cf4666386