### PR TITLE
Fix OutlineViewModel null dereference

### DIFF
--- a/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
+++ b/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
@@ -1039,6 +1039,11 @@ public class OutlineViewModel : ObservableRecipient
     {
         try
         {
+            if (shellVm.RightTappedNode == null)
+            {
+                Messenger.Send(new StatusChangedMessage(new("Right tap a node to delete", LogLevel.Warn)));
+                return;
+            }
             bool _delete = true;
             Guid elementToDelete = shellVm.RightTappedNode.Uuid;
             List<StoryElement> _foundElements = outlineService.FindElementReferences(StoryModel, elementToDelete);

--- a/StoryCADTests/OutlineViewModelTests.cs
+++ b/StoryCADTests/OutlineViewModelTests.cs
@@ -73,6 +73,22 @@ namespace StoryCADTests
             Assert.IsTrue(outlineVM.StoryModel.StoryElements.Characters[1].Node.Parent == outlineVM.StoryModel.ExplorerView[1]);
         }
 
+        /// <summary>
+        /// Calling Delete without selecting a node should do nothing
+        /// </summary>
+        [TestMethod]
+        public async Task DeleteNodeWithoutSelection()
+        {
+            var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+            outlineVM.StoryModel = await outlineService.CreateModel("TestNullDelete", "StoryBuilder", 0);
+            outlineVM.StoryModelFile = Path.Combine(App.ResultsDir, "NullDelete.stbx");
+
+            shell.RightTappedNode = null;
+            int before = outlineVM.StoryModel.StoryElements.Count;
+            outlineVM.RemoveStoryElement();
+            Assert.AreEqual(before, outlineVM.StoryModel.StoryElements.Count);
+        }
+
         // Test for UnifiedNewFile method
         [TestMethod]
         public async Task TestNewFileVM()


### PR DESCRIPTION
## Summary
- guard against null `RightTappedNode` before deleting
- add test for this edge case