### PR TITLE
Correct duplicate node restore

### DIFF
--- a/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
+++ b/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using StoryCAD.Services.Backup;
 using StoryCAD.Services.Messages;
@@ -1140,7 +1141,7 @@ public class OutlineViewModel : ObservableRecipient
         }
 
         ObservableCollection<StoryNodeItem> _target = shellVm.DataSource[0].Children;
-        shellVm.DataSource[1].Children.Remove(shellVm.RightTappedNode);
+        shellVm.RightTappedNode.Parent.Children.Remove(shellVm.RightTappedNode);
         _target.Add(shellVm.RightTappedNode);
         shellVm.RightTappedNode.Parent = shellVm.DataSource[0];
         Messenger.Send(new StatusChangedMessage(new(


### PR DESCRIPTION
The previous code contained the following actual delete:
     shellVm.DataSource[1].Children.Remove(shellVm.RightTappedNode)
which is trying to remove the "Child" node from the root level of the trash, but the "Child" node isn't necessarily a direct child of the trash root. The correct code should be:
      shellVm.RightTappedNode.Parent.Children.Remove(shellVm.RightTappedNode);
      
Since the delete failed to remove the child node from the trash, the subsequent restore of the parent node resulted in the second restore of the child node also.