### PR TITLE
Fix/report formatter null reference

### DIFF
--- a/StoryCADLib/Services/Reports/ReportFormatter.cs
+++ b/StoryCADLib/Services/Reports/ReportFormatter.cs
@@ -1,7 +1,5 @@
-﻿using System.Drawing;
-using System.Text;
+﻿using System.Text;
 using NRtfTree.Util;
-using StoryCAD.DAL;
 using System.Reflection;
 using StoryCAD.ViewModels.SubViewModels;
 using StoryCAD.ViewModels.Tools;
@@ -28,7 +26,7 @@ public class ReportFormatter
         {
             ProblemModel problem = (ProblemModel)_model.StoryElements.StoryElementGuids[overview.StoryProblem];
             problemName = problem.Name;
-            premise = problem?.Premise;
+            premise = problem.Premise;
         }
 
         // Parse and write the report
@@ -199,7 +197,7 @@ public class ReportFormatter
 
 		// Retrieve the ShellViewModel once
 		var outlineViewModel = Ioc.Default.GetRequiredService<OutlineViewModel>();
-		if (outlineViewModel?.StoryModel?.StoryElements == null)
+		if (outlineViewModel.StoryModel?.StoryElements == null)
 		{
 			// StoryElements not available
 			return string.Empty;
@@ -642,7 +640,7 @@ public class ReportFormatter
         RtfDocument doc = new(string.Empty);
         StringBuilder sb = new();
         WebModel model = element as WebModel;
-        sb.AppendLine(model.Name);
+        sb.AppendLine(model!.Name);
         sb.AppendLine(model.URL.ToString());
         doc.AddText(sb.ToString());
         doc.AddNewLine();
@@ -800,7 +798,7 @@ public class ReportFormatter
             {
                 //Read from manifest stream
                 await using Stream streams = Assembly.GetExecutingAssembly().GetManifestResourceStream(FileName);
-                using StreamReader reader = new(streams);
+                using StreamReader reader = new(streams!);
 
                 //Gets the stream, then formats it into line by line.
                 string[] lines = (await reader.ReadToEndAsync())
@@ -812,7 +810,7 @@ public class ReportFormatter
         }
         catch (Exception ex)
         {
-            Ioc.Default.GetService<LogService>().LogException(LogLevel.Error, ex, "Error loading report templates.");
+            Ioc.Default.GetService<LogService>()!.LogException(LogLevel.Error, ex, "Error loading report templates.");
         }
     }
 
@@ -821,7 +819,7 @@ public class ReportFormatter
     #region Private methods
 
     /// <summary>
-    /// A RichEditBox property is an a wrapper for an RTF 
+    /// A RichEditBox property is a wrapper for an RTF 
     /// document, with its header, font table, color table, etc.,
     /// and which can be read or written. This causes format problems
     /// when it's a cell on a StoryCAD report.  This function
@@ -850,10 +848,10 @@ public class ReportFormatter
 
     #region Constructor
 
-    public ReportFormatter() 
+    public ReportFormatter()
     {
         OutlineViewModel outlineVM = Ioc.Default.GetService<OutlineViewModel>();
-        _model = outlineVM.StoryModel;
+        if (outlineVM != null) _model = outlineVM.StoryModel;
     }
 
     #endregion

--- a/StoryCADLib/Services/Reports/ReportFormatter.cs
+++ b/StoryCADLib/Services/Reports/ReportFormatter.cs
@@ -831,7 +831,7 @@ public class ReportFormatter
     public string GetText(string rtfInput, bool formatNewLines = true)
     {
         string text = rtfInput ?? string.Empty;
-        if (rtfInput!.Equals(string.Empty))
+        if (text.Equals(string.Empty))
             return string.Empty;
         RichTextStripper rts = new();
         text =  rts.StripRichTextFormat(text);


### PR DESCRIPTION
Users were experiencing a crash when generating Story Overview reports. The exception occurred in
  `ReportFormatter.GetText()` when processing Story Overview elements with null RTF content.
  
**Root Cause**: Line 834 was using the null-forgiving operator (`!`) on `rtfInput` parameter after already
  null-coalescing it to the `text` variable on line 833.

Also cleaned up other null-related warnings.
