### PR TITLE
Remove legacy print and clean up print code

### DIFF
--- a/StoryCADLib/Assets/Install/reports/List of Characters.txt
+++ b/StoryCADLib/Assets/Install/reports/List of Characters.txt
@@ -1,4 +1,0 @@
-                        StoryCAD - List of Characters
-
-                        @Description
-

--- a/StoryCADLib/Assets/Install/reports/List of Problems.txt
+++ b/StoryCADLib/Assets/Install/reports/List of Problems.txt
@@ -1,4 +1,0 @@
-                        StoryCAD - List of Problems
-
-                        @Description
-

--- a/StoryCADLib/Assets/Install/reports/List of Scenes.txt
+++ b/StoryCADLib/Assets/Install/reports/List of Scenes.txt
@@ -1,4 +1,0 @@
-                        StoryCAD - List of Plot Points
-
-                        @Description
-

--- a/StoryCADLib/Assets/Install/reports/List of Settings.txt
+++ b/StoryCADLib/Assets/Install/reports/List of Settings.txt
@@ -1,4 +1,0 @@
-                        StoryCAD - List of Settings
-
-                        @Description
-

--- a/StoryCADLib/Assets/Install/reports/List of Websites.txt
+++ b/StoryCADLib/Assets/Install/reports/List of Websites.txt
@@ -1,4 +1,0 @@
-                        StoryCAD - List of Websites
-
-                        @Description
-

--- a/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml
@@ -7,8 +7,6 @@
     mc:Ignorable="d" Width="600">
 
     <StackPanel HorizontalAlignment="Center">
-        <InfoBar IsOpen="False" Name="OldW10Warning" Severity="Warning" 
-                 Message="You are using an outdated version of Windows 10, please upgrade to Windows 10 22H2 or Windows 11 for a better printing experience."/>
         <Grid HorizontalAlignment="Center" Margin="0,15">
 			<Grid.RowDefinitions>
 				<RowDefinition Height="Auto"/>

--- a/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml.cs
@@ -29,9 +29,6 @@ public sealed partial class PrintReportsDialog
         PrintVM.SceneList = false;
         PrintVM.WebList = false;
 
-        //Warn user if they are on win10 as print manager can't be used.
-        if (Environment.OSVersion.Version.Build <= 19045) { OldW10Warning.IsOpen = true; }
-
         //Gets all nodes that aren't deleted
         try
         {
@@ -47,10 +44,9 @@ public sealed partial class PrintReportsDialog
     }
 
     /// <summary>
-    /// You can't bind selected items so when the values change this function is ran which updates the values in the VM accordingly
+    /// You can't bind selected items so when the values change 
+    /// this function is ran which updates the values in the VM accordingly
     /// </summary>
-    /// <param name="sender"></param>
-    /// <param name="e"></param>
     private void UpdateSelection(object sender, SelectionChangedEventArgs e)
     {
         PrintVM.SelectedNodes.Clear();

--- a/StoryCADLib/Services/Outline/OutlineService.cs
+++ b/StoryCADLib/Services/Outline/OutlineService.cs
@@ -244,7 +244,7 @@ public Task<StoryModel> CreateModel(string name, string author, int selectedTemp
             throw new ArgumentNullException(nameof(model));
         }
 
-        if (StoryNodeItem.RootNodeType(parent) == StoryItemType.TrashCan)
+            if (StoryNodeItem.RootNodeType(parent) == StoryItemType.TrashCan)
         {
             throw new InvalidOperationException("Cannot add a new node to the Trash Can.");
         }

--- a/StoryCADLib/Services/Reports/PrintReports.cs
+++ b/StoryCADLib/Services/Reports/PrintReports.cs
@@ -9,6 +9,7 @@ public class PrintReports
     private StoryModel _model;
     private ReportFormatter _formatter;
     private string _documentText;
+    private LogService logger = Ioc.Default.GetRequiredService<LogService>();
 
     public async Task<string> Generate()
     {
@@ -18,7 +19,7 @@ public class PrintReports
         //Process single selection (non-Pivot) reports
         if (_vm.CreateOverview)
         {
-            rtf = _formatter.FormatStoryOverviewReport(Overview());
+            rtf = _formatter.FormatStoryOverviewReport();
             _documentText += FormatText(rtf);
         }
         if (_vm.CreateSummary)
@@ -35,32 +36,27 @@ public class PrintReports
 
 		if (_vm.ProblemList)
         {
-            rtf = _formatter.FormatProblemListReport();
+            rtf = _formatter.FormatListReport(StoryItemType.Problem);
             _documentText += FormatText(rtf);
         }
         if (_vm.CharacterList)
         {
-            rtf = _formatter.FormatCharacterListReport();
+            rtf = _formatter.FormatListReport(StoryItemType.Character);
             _documentText += FormatText(rtf);
         }
         if (_vm.SettingList)
         {
-            rtf = _formatter.FormatSettingListReport();
+            rtf = _formatter.FormatListReport(StoryItemType.Setting);
             _documentText += FormatText(rtf);
         }
         if (_vm.SceneList)
         {
-            rtf = _formatter.FormatSceneListReport();
-            _documentText += FormatText(rtf);
-        }
-        if (_vm.SceneList)
-        {
-            rtf = _formatter.FormatSceneListReport();
+            rtf = _formatter.FormatListReport(StoryItemType.Scene);
             _documentText += FormatText(rtf);
         }
         if (_vm.WebList)
         {
-            rtf = _formatter.FormatWebListReport();
+            rtf = _formatter.FormatListReport(StoryItemType.Web);
             _documentText += FormatText(rtf);
         }
 
@@ -95,15 +91,10 @@ public class PrintReports
 
         if (string.IsNullOrEmpty(_documentText))
         {
-            Ioc.Default.GetRequiredService<LogService>().Log(LogLevel.Warn, "No nodes selected for report generation");
+            logger.Log(LogLevel.Warn, "No nodes selected for report generation");
             return "";
         }
         return _documentText;
-    }
-
-    private StoryElement Overview()
-    {
-        return _model.StoryElements.FirstOrDefault(element => element.ElementType == StoryItemType.StoryOverview);
     }
 
     /// <summary>
@@ -114,36 +105,59 @@ public class PrintReports
     /// <param name="summaryMode"></param>
     private string FormatText(string rtfInput, bool summaryMode = false)
     {
+        const int MaxLineLength = 72;
+        
         string text = _formatter.GetText(rtfInput, false);
         string[] lines = text.Split('\n');
         StringBuilder sb = new();
 
-        //TODO: rewrite this for readability and maintainability
-        foreach (string t in lines)
+        foreach (string inputLine in lines)
         {
-            string line = t.TrimEnd();
+            string line = inputLine.TrimEnd();
             if (line.Equals("\r"))
                 continue;
-            while (line.Length > 72)
-            {
-                string temp = line[..72];
-                if (!temp.Contains(" ")) { temp += " "; } //wrapping fix
-                int j = temp.LastIndexOf(' ');
-                temp = temp[..j];
-                sb.Append(temp);
-                sb.Append(Environment.NewLine);
-                line = line[j..];
-                line = line.TrimStart();
-            }
-            sb.Append(line + Environment.NewLine);
+
+            WrapAndAppendLine(sb, line, MaxLineLength);
         }
+
         if (summaryMode)
         {
             sb.Replace("[", "\r\n[");
             sb.Replace("]", "]\r\n");
         }
+        
         sb.Append("\n\\PageBreak\n");
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Wraps a line to the specified maximum length and appends to StringBuilder
+    /// </summary>
+    /// <param name="sb">StringBuilder to append to</param>
+    /// <param name="line">Line to wrap</param>
+    /// <param name="maxLength">Maximum line length</param>
+    private void WrapAndAppendLine(StringBuilder sb, string line, int maxLength)
+    {
+        while (line.Length > maxLength)
+        {
+            string segment = line[..maxLength];
+            
+            // Ensure we have a space for wrapping
+            if (!segment.Contains(" "))
+            {
+                segment += " ";
+            }
+            
+            int lastSpaceIndex = segment.LastIndexOf(' ');
+            string wrappedPortion = segment[..lastSpaceIndex];
+            
+            sb.Append(wrappedPortion);
+            sb.Append(Environment.NewLine);
+            
+            line = line[lastSpaceIndex..].TrimStart();
+        }
+        
+        sb.Append(line + Environment.NewLine);
     }
 
     #region Constructor

--- a/StoryCADLib/Services/Reports/ReportFormatter.cs
+++ b/StoryCADLib/Services/Reports/ReportFormatter.cs
@@ -710,12 +710,14 @@ public class ReportFormatter
 
     public string FormatListReport(StoryItemType elementType)
     {
+        //Get element (override web for websites.)
+        string name = elementType == StoryItemType.Web ? "Websites" : elementType + "s";
+
         string[] lines = [
-        "                        StoryCAD - List of Websites",
+        $"                        StoryCAD - List of {name}",
         "",
         "                        @Description"];
         RtfDocument doc = new(string.Empty);
-        doc.AddText($"StoryCAD - List of {elementType}s");
 
         // Parse and write the report
         foreach (string line in lines)

--- a/StoryCADLib/Services/Reports/ReportFormatter.cs
+++ b/StoryCADLib/Services/Reports/ReportFormatter.cs
@@ -1,7 +1,5 @@
-﻿using System.Drawing;
-using System.Text;
+﻿using System.Text;
 using NRtfTree.Util;
-using StoryCAD.DAL;
 using System.Reflection;
 using StoryCAD.ViewModels.SubViewModels;
 using StoryCAD.ViewModels.Tools;
@@ -15,10 +13,11 @@ public class ReportFormatter
 
     #region Public methods
 
-    public string FormatStoryOverviewReport(StoryElement element)
+    public string FormatStoryOverviewReport()
     {
-        OverviewModel overview = (OverviewModel)element;
-        string[] lines = _templates["Story Overview"];  
+        OverviewModel overview = (OverviewModel)_model.StoryElements.
+            FirstOrDefault(element => element.ElementType == StoryItemType.StoryOverview);
+        string[] lines = _templates["Story Overview"]; 
         RtfDocument doc = new(string.Empty);
 
         string vpName = StoryElement.GetByGuid(overview.ViewpointCharacter).Name;
@@ -59,35 +58,6 @@ public class ReportFormatter
             sb.Replace("@Notes", GetText(overview.Notes));
             doc.AddText(sb.ToString());
             doc.AddNewLine();
-        }
-        return doc.GetRtf();
-    }
-
-    public string FormatProblemListReport()
-    {
-        string[] lines = _templates["List of Problems"];
-        RtfDocument doc = new(string.Empty);
-
-        // Parse and write the report
-        foreach (string line in lines)
-        {
-            if (line.Contains("@Description"))
-            {
-                foreach (StoryElement element in _model.StoryElements)
-                    if (element.ElementType == StoryItemType.Problem)
-                    {
-                        ProblemModel chr = (ProblemModel)element;
-                        StringBuilder sb = new(line);
-                        sb.Replace("@Description", chr.Name);
-                        doc.AddText(sb.ToString());
-                        doc.AddNewLine();
-                    }
-            }
-            else
-            {
-                doc.AddText(line);
-                doc.AddNewLine();
-            }
         }
         return doc.GetRtf();
     }
@@ -282,7 +252,6 @@ public class ReportFormatter
             }
         }
     }
-
 	private string FormatStructureBeatsElements(ProblemModel problem)
     {
 	    StringBuilder beats = new();
@@ -341,35 +310,6 @@ public class ReportFormatter
             doc.AddNewLine();
         }
 
-        return doc.GetRtf();
-    }
-
-    public string FormatCharacterListReport()
-    {
-        string[] lines = _templates["List of Characters"];
-        RtfDocument doc = new(string.Empty);
-
-        // Parse and write the report
-        foreach (string line in lines)
-        {
-            if (line.Contains("@Description"))
-            {
-                foreach (StoryElement element in _model.StoryElements)
-                    if (element.ElementType == StoryItemType.Character)
-                    {
-                        CharacterModel chr = (CharacterModel)element;
-                        StringBuilder sb = new(line);
-                        sb.Replace("@Description", chr.Name);
-                        doc.AddText(sb.ToString());
-                        doc.AddNewLine();
-                    }
-            }
-            else
-            {
-                doc.AddText(line);
-                doc.AddNewLine();
-            }
-        }
         return doc.GetRtf();
     }
 
@@ -457,35 +397,6 @@ public class ReportFormatter
         return doc.GetRtf();
     }
 
-    public string FormatSettingListReport()
-    {
-        string[] lines = _templates["List of Settings"];
-        RtfDocument doc = new(string.Empty);
-
-        // Parse and write the report
-        foreach (string line in lines)
-        {
-            if (line.Contains("@Description"))
-            {
-                foreach (StoryElement element in _model.StoryElements)
-                    if (element.ElementType == StoryItemType.Setting)
-                    {
-                        SettingModel setting = (SettingModel)element;
-                        StringBuilder sb = new(line);
-                        sb.Replace("@Description", setting.Name);
-                        doc.AddText(sb.ToString());
-                        doc.AddNewLine();
-                    }
-            }
-            else
-            {
-                doc.AddText(line);
-                doc.AddNewLine();
-            }
-        }
-        return doc.GetRtf();
-    }
-
     public string FormatSettingReport(StoryElement element)
     {
         SettingModel setting = (SettingModel)element;
@@ -514,35 +425,6 @@ public class ReportFormatter
             doc.AddNewLine();
         }
         return doc.GetRtf();
-    }
-
-    public string FormatSceneListReport()
-    {
-        string[] lines = _templates["List of Scenes"];
-        RtfDocument doc = new(string.Empty);
-
-        // Parse and write the report
-        foreach (string line in lines)
-        {
-            if (line.Contains("@Description"))
-            {
-                foreach (StoryElement element in _model.StoryElements)
-                    if (element.ElementType == StoryItemType.Scene)
-                    {
-                        SceneModel scene = (SceneModel)element;
-                        StringBuilder sb = new(line);
-                        sb.Replace("@Description", scene.Name);
-                        doc.AddText(sb.ToString());
-                        doc.AddNewLine();
-                    }
-            }
-            else
-            {
-                doc.AddText(line);
-                doc.AddNewLine();
-            }
-        }
-        return doc.GetRtf(); 
     }
 
     public string FormatSceneReport(StoryElement element)
@@ -676,38 +558,6 @@ public class ReportFormatter
         doc.AddImage(imgfile.Path, 1920, 1080);
         */
 
-    }
-
-    public string FormatWebListReport()
-    {
-        string[] lines = _templates["List of Websites"];
-        RtfDocument doc = new(string.Empty);
-
-        // Parse and write the report
-        foreach (string line in lines)
-        {
-            if (line.Contains("@Description"))
-            {
-                foreach (StoryElement element in _model.StoryElements)
-                {
-                    if (element.ElementType == StoryItemType.Web)
-                    {
-                        WebModel scene = (WebModel)element;
-                        StringBuilder sb = new(line);
-                        sb.Replace("@Description", scene.Name);
-                        doc.AddText(sb.ToString());
-                        doc.AddNewLine();
-                    }
-                }
-
-            }
-            else
-            {
-                doc.AddText(line);
-                doc.AddNewLine();
-            }
-        }
-        return doc.GetRtf();
     }
 
     public string FormatFolderReport(StoryElement element)
@@ -857,4 +707,36 @@ public class ReportFormatter
     }
 
     #endregion
+
+    public string FormatListReport(StoryItemType elementType)
+    {
+        string[] lines = [
+        "                        StoryCAD - List of Websites",
+        "",
+        "                        @Description"];
+        RtfDocument doc = new(string.Empty);
+        doc.AddText($"StoryCAD - List of {elementType}s");
+
+        // Parse and write the report
+        foreach (string line in lines)
+        {
+            if (line.Contains("@Description"))
+            {
+                var elements = _model.StoryElements.Where(e => e.ElementType == elementType);
+                foreach (StoryElement element in elements)
+                {
+                    StringBuilder sb = new(line);
+                    sb.Replace("@Description", element.Name);
+                    doc.AddText(sb.ToString());
+                    doc.AddNewLine();
+                }
+            }
+            else
+            {
+                doc.AddText(line);
+                doc.AddNewLine();
+            }
+        }
+        return doc.GetRtf();
+    }
 }

--- a/StoryCADLib/Services/Reports/ScrivenerReports.cs
+++ b/StoryCADLib/Services/Reports/ScrivenerReports.cs
@@ -416,7 +416,7 @@ namespace StoryCAD.Services.Reports
             StorageFolder di = await _scrivener.GetSubFolder(node.Uuid); // Get subfolder path
             StorageFile contents = await di.CreateFileAsync("content.rtf", CreationCollisionOption.ReplaceExisting);
  
-            string rtf = _formatter.FormatStoryOverviewReport(overview);
+            string rtf = _formatter.FormatStoryOverviewReport();
             
             // Write the report
             await FileIO.WriteTextAsync(contents, rtf);
@@ -427,7 +427,7 @@ namespace StoryCAD.Services.Reports
             // Locate and open the output content.rtf report
             StorageFolder di = await _scrivener.GetSubFolder(node.Uuid); // Get subfolder path
             StorageFile contents = await di.CreateFileAsync("content.rtf", CreationCollisionOption.ReplaceExisting);
-            string rtf =  _formatter.FormatProblemListReport();
+            string rtf =  _formatter.FormatListReport(StoryItemType.Problem);
             // Write the report
             await FileIO.WriteTextAsync(contents, rtf);
         }
@@ -449,7 +449,7 @@ namespace StoryCAD.Services.Reports
             // Locate and open the output content.rtf report
             StorageFolder di = await _scrivener.GetSubFolder(node.Uuid); // Get subfolder path
             StorageFile contents = await di.CreateFileAsync("content.rtf", CreationCollisionOption.ReplaceExisting);
-            string rtf = _formatter.FormatCharacterListReport();
+            string rtf = _formatter.FormatListReport(StoryItemType.Character);
             // Write the report
             await FileIO.WriteTextAsync(contents, rtf);
         }
@@ -472,7 +472,7 @@ namespace StoryCAD.Services.Reports
             StorageFolder di = await _scrivener.GetSubFolder(node.Uuid); // Get subfolder path
             StorageFile contents = await di.CreateFileAsync("content.rtf", CreationCollisionOption.ReplaceExisting);
 
-            string rtf = _formatter.FormatSettingListReport();
+            string rtf = _formatter.FormatListReport(StoryItemType.Setting);
             
             // Write the report
             await FileIO.WriteTextAsync(contents, rtf);
@@ -496,7 +496,7 @@ namespace StoryCAD.Services.Reports
             StorageFolder di = await _scrivener.GetSubFolder(node.Uuid); // Get subfolder path
             StorageFile contents = await di.CreateFileAsync("content.rtf", CreationCollisionOption.ReplaceExisting);
 
-            string rtf = _formatter.FormatSceneListReport();
+            string rtf = _formatter.FormatListReport(StoryItemType.Scene);
             
             // Write the report
             await FileIO.WriteTextAsync(contents, rtf);

--- a/StoryCADLib/StoryCADLib.csproj
+++ b/StoryCADLib/StoryCADLib.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <Content Remove="Assets\Install\Lists.ini" />
     <Content Remove="Assets\Install\reports\Character Relationship Description.txt" />
-    <Content Remove="Assets\Install\reports\List of Websites.txt" />
     <Content Remove="Assets\Install\reports\Structure Beats.txt" />
     <Content Remove="Assets\Install\samples\A Doll's House.stbx" />
     <Content Remove="Assets\Install\samples\Danger Calls.stbx" />
@@ -42,11 +41,7 @@
     <None Remove="Assets\Install\reports\Character Description.txt" />
     <None Remove="Assets\Install\reports\Character Relationship Description.txt" />
     <None Remove="Assets\Install\reports\Folder Description.txt" />
-    <None Remove="Assets\Install\reports\List of Characters.txt" /> 
-    <None Remove="Assets\Install\reports\List of Problems.txt" />
     <None Remove="Assets\Install\reports\List of Scene.txt" />
-    <None Remove="Assets\Install\reports\List of Settings.txt" />
-    <None Remove="Assets\Install\reports\List of Websites.txt" />
     <None Remove="Assets\Install\reports\Problem Description.txt" />
     <None Remove="Assets\Install\reports\Scene Description.txt" />
     <None Remove="Assets\Install\reports\Section Description.txt" />

--- a/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
+++ b/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
@@ -702,7 +702,7 @@ public class OutlineViewModel : ObservableRecipient
                 logger.Log(LogLevel.Info, "Print node failed as no node is selected");
                 return;
             }
-            await Ioc.Default.GetRequiredService<PrintReportDialogVM>().PrintSingleNode(shellVm.RightTappedNode);
+            Ioc.Default.GetRequiredService<PrintReportDialogVM>().PrintSingleNode(shellVm.RightTappedNode);
         }
     }
 

--- a/StoryCADLib/ViewModels/Tools/PrintReportDialogVM.cs
+++ b/StoryCADLib/ViewModels/Tools/PrintReportDialogVM.cs
@@ -24,14 +24,6 @@ public class PrintReportDialogVM : ObservableRecipient
     private OutlineViewModel OutlineVM = Ioc.Default.GetRequiredService<OutlineViewModel>();
     private List<StackPanel> _printPreviewCache; //This stores a list of pages for print preview
     #region Properties
-
-    private bool _showLoadingBar = true;
-    public bool ShowLoadingBar
-    {
-        get => _showLoadingBar;
-        set => SetProperty(ref _showLoadingBar, value);
-    }
-
     private bool _createSummary;
     public bool CreateSummary
     {
@@ -202,10 +194,17 @@ public class PrintReportDialogVM : ObservableRecipient
         GeneratePrintDocumentReport();
         PrintDocSource = Document.DocumentSource;
 
-        //Device has to support printing AND run a build of Windows above 19045 (W10 22h2)
-        //Windows 10 builds below 19045 have bug that prevent us from using the new print manager
-        //TODO: gut old print stuff after oct 2023 since only 22h2 will be offically supported.
-        if (PrintManager.IsSupported() && Environment.OSVersion.Version.Build >= 19045)
+        // Old windows build check (pre 19045 doesn't support PrintManager)
+        if (Environment.OSVersion.Version.Build <= 19045) 
+        {
+            await Window.ShowContentDialog(new ContentDialog()
+            {
+                Title = "Printing",
+                Content = "Printing is not supported on this version of Windows, please update",
+                PrimaryButtonText = "Ok"
+            });
+        }
+        if (PrintManager.IsSupported())
         {
             try
             {   // Show print UI
@@ -215,7 +214,6 @@ public class PrintReportDialogVM : ObservableRecipient
             {
                 Window.GlobalDispatcher.TryEnqueue(async () =>
                 {
-                    CloseDialog();
                     ContentDialog Dialog = new()
                     {
                         Title = "Printing error",
@@ -223,14 +221,19 @@ public class PrintReportDialogVM : ObservableRecipient
                         PrimaryButtonText = "Ok"
                     };
 
-                    await Ioc.Default.GetService<Windowing>().ShowContentDialog(Dialog);
+                    await Ioc.Default.GetService<Windowing>().ShowContentDialog(Dialog, true);
                 });
 
             }
         }
-        else //Print Manager isn't supported so we fall back to the old version of printing directly.
+        else
         {
-            ShowLoadingBar = true;
+            await Window.ShowContentDialog(new ContentDialog()
+            {
+                Title = "Printing",
+                Content = "Your device does not appear to support printing.",
+                PrimaryButtonText = "Ok"
+            });
             StartGeneratingReports();
         }
     }
@@ -264,16 +267,18 @@ public class PrintReportDialogVM : ObservableRecipient
     /// This prints a report of the node selected
     /// </summary>
     /// <param name="elementItem">Node to be printed.</param>
-    public async Task PrintSingleNode(StoryNodeItem elementItem)
+    public void PrintSingleNode(StoryNodeItem elementItem)
     {
         SelectedNodes.Clear(); //Only print single node
 
         PrintReports _rpt = new(this, OutlineVM.StoryModel);
-       
-        if (elementItem.Type == StoryItemType.StoryOverview) {CreateOverview = true; }
+
+        if (elementItem.Type == StoryItemType.StoryOverview) { CreateOverview = true; }
         else { SelectedNodes.Add(elementItem); }
 
-        _rpt.Print(await _rpt.Generate());
+        StartPrintMenu();
+        //Reset value incase dialog opened later
+        SelectedNodes.Clear();
         CreateOverview = false;
     }
 
@@ -289,13 +294,11 @@ public class PrintReportDialogVM : ObservableRecipient
     /// </summary>
     public void StartGeneratingReports()
     {
-        ShowLoadingBar = true;
         BackgroundWorker _backgroundThread = new();
         _backgroundThread.DoWork += async (_,_) =>
         {
             PrintReports _rpt = new(this, OutlineVM.StoryModel);
             _rpt.Print(await _rpt.Generate());
-            ShowLoadingBar = false;
         };
         _backgroundThread.RunWorkerAsync();
     }
@@ -372,7 +375,8 @@ public class PrintReportDialogVM : ObservableRecipient
 
     private void Paginate(object sender, PaginateEventArgs e)
     {
-        Document.SetPreviewPageCount(_printPreviewCache.Count, PreviewPageCountType.Intermediate);
+        Document.SetPreviewPageCount(_printPreviewCache.Count, 
+            PreviewPageCountType.Intermediate);
     }
 
     private void GetPreviewPage(object sender, GetPreviewPageEventArgs e)
@@ -407,8 +411,8 @@ public class PrintReportDialogVM : ObservableRecipient
         {
             //Set print job name
             PrintJobManager = args.Request.CreatePrintTask("StoryCAD - " + 
-                Path.GetFileNameWithoutExtension(Ioc.Default.GetRequiredService<OutlineViewModel>().StoryModelFile)
-                , PrintSourceRequested);
+                Path.GetFileNameWithoutExtension(OutlineVM.StoryModelFile)
+                ,PrintSourceRequested);
             PrintJobManager.Completed += PrintTaskCompleted; //Show message if job failed.
         }
         catch (Exception e)
@@ -420,19 +424,22 @@ public class PrintReportDialogVM : ObservableRecipient
     /// <summary>
     /// Set print source
     /// </summary>
-    /// <param name="args"></param>
     private void PrintSourceRequested(PrintTaskSourceRequestedArgs args)
     {
         args.SetSource(PrintDocSource);
     }
 
+    /// <summary>
+    /// Fired when the print task is completed/failed.
+    /// </summary>
     private async void PrintTaskCompleted(PrintTask sender, PrintTaskCompletedEventArgs args)
     {
         Window.GlobalDispatcher.TryEnqueue(async () =>
         {
             if (args.Completion == PrintTaskCompletion.Failed) //Show message if print fails
             {
-                //Use an enqueue here because the sample version doesn't use it properly (i think or it doesn't work here.)
+                //Use an enqueue here because the sample version doesn't use
+                //it properly (i think or it doesn't work here.)
                 ContentDialog Dialog = new()
                 {
                     Title = "Printing error",

--- a/StoryCADTests/InstallServiceTests.cs
+++ b/StoryCADTests/InstallServiceTests.cs
@@ -16,7 +16,7 @@ public class InstallServiceTests
     [TestMethod]
     public void TestResources()
     {
-        Assert.AreEqual(28, libResources.Length);
+        Assert.AreEqual(23, libResources.Length);
 		Assert.IsTrue(libResources.Contains("StoryCAD.Assets.Install.Bibliog.txt"));
 		Assert.IsTrue(libResources.Contains("StoryCAD.Assets.Install.samples.A Doll's House.stbx"));
 		Assert.IsTrue(libResources.Contains("StoryCAD.Assets.Install.samples.The Old Man and the Sea.stbx"));


### PR DESCRIPTION
This pr focuses on cleaning the print code up and fixes #1057 
The following changes have been made:
- StoryCAD no longer has text file templates for lists
- Print Reports now has one function for creating list reports.
- StoryCAD no longer supports printing on windows 10 builds that are older than 19045
- All legacy print code has been removed.


Users who try to print on a windows 10 build older than 19045 will recieve a message saying so; users who somehow have a device that doesnt support the new printing system will recieve a message saying so.