### PR TITLE
refactor visibility

### DIFF
--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -15,56 +15,56 @@
 
             <CommandBarFlyout x:Key="AddStoryElementFlyout" Placement="Right" x:Name="AddStoryElementCommandBarFlyout" >
                 <CommandBarFlyout.SecondaryCommands>
-                    <AppBarButton Icon="Add" Label="Add Elements" >
+                    <AppBarButton Icon="Add" Label="Add Elements" Visibility="{x:Bind ShellVm.AddButtonVisibility, Mode=OneWay}">
                         <AppBarButton.Flyout>
                             <MenuFlyout>
-                                <MenuFlyoutItem Icon="Folder" Text="Add Folder         Alt+F"  Command="{x:Bind ShellVm.AddFolderCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.AddFolderVisibility, Mode=TwoWay}" />
-                                <MenuFlyoutItem Icon="Folder" Text="Add Section        Alt+A"  Command="{x:Bind ShellVm.AddSectionCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.AddSectionVisibility, Mode=TwoWay}" />
-                                <MenuFlyoutItem Icon="Help"   Text="Add Problem      Alt+P"  Command="{x:Bind ShellVm.AddProblemCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.AddProblemVisibility, Mode=TwoWay}" />
-                                <MenuFlyoutItem Icon="Contact" Text="Add Character    Alt+C"  Command="{x:Bind ShellVm.AddCharacterCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.AddCharacterVisibility, Mode=TwoWay}" />
-                                <MenuFlyoutItem Icon="Globe" Text="Add Setting        Alt+L"  Command="{x:Bind ShellVm.AddSettingCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.AddSettingVisibility, Mode=TwoWay}" />
-                                <MenuFlyoutItem Icon="AllApps" Text="Add Scene          Alt+S"  Command="{x:Bind ShellVm.AddSceneCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.AddSceneVisibility, Mode=TwoWay}" />
-                                <MenuFlyoutItem Icon="TwoPage" Text="Add Notes          Alt+N"  Command="{x:Bind ShellVm.AddNotesCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.AddFolderVisibility, Mode=TwoWay}" />
-                                <MenuFlyoutItem Icon="PreviewLink" Text="Add Website      Alt+W"  Command="{x:Bind ShellVm.AddWebCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.AddFolderVisibility, Mode=TwoWay}" />
+                                <MenuFlyoutItem Icon="Folder" Text="Add Folder         Alt+F"  Command="{x:Bind ShellVm.AddFolderCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" />
+                                <MenuFlyoutItem Icon="Folder" Text="Add Section        Alt+A"  Command="{x:Bind ShellVm.AddSectionCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.NarratorVisibility, Mode=TwoWay}" />
+                                <MenuFlyoutItem Icon="Help"   Text="Add Problem      Alt+P"  Command="{x:Bind ShellVm.AddProblemCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" />
+                                <MenuFlyoutItem Icon="Contact" Text="Add Character    Alt+C"  Command="{x:Bind ShellVm.AddCharacterCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" />
+                                <MenuFlyoutItem Icon="Globe" Text="Add Setting        Alt+L"  Command="{x:Bind ShellVm.AddSettingCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" />
+                                <MenuFlyoutItem Icon="AllApps" Text="Add Scene          Alt+S"  Command="{x:Bind ShellVm.AddSceneCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" />
+                                <MenuFlyoutItem Icon="TwoPage" Text="Add Notes          Alt+N"  Command="{x:Bind ShellVm.AddNotesCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" />
+                                <MenuFlyoutItem Icon="PreviewLink" Text="Add Website      Alt+W"  Command="{x:Bind ShellVm.AddWebCommand, Mode=OneWay}" Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" />
                             </MenuFlyout>
                         </AppBarButton.Flyout>
                     </AppBarButton>
                     <AppBarSeparator />
                     <AppBarButton Icon="Delete" Label="Delete element"  Command="{x:Bind ShellVm.RemoveStoryElementCommand, Mode=OneWay}" 
-                          Visibility="{x:Bind ShellVm.RemoveStoryElementVisibility, Mode=TwoWay}" >
+                          Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" >
                         <ToolTipService.ToolTip>
                             <ToolTip Content="Move Story Element to Trashcan" />
                         </ToolTipService.ToolTip>
                     </AppBarButton>
                     <AppBarButton Icon="Refresh" Label="Restore Element" Command="{x:Bind ShellVm.RestoreStoryElementCommand, Mode=OneWay}" 
-                          Visibility="{x:Bind ShellVm.RestoreStoryElementVisibility, Mode=TwoWay}" >
+                          Visibility="{x:Bind ShellVm.TrashButtonVisibility, Mode=TwoWay}" >
                         <ToolTipService.ToolTip>
                             <ToolTip Content="Restore Story Element from Trashcan" />
                         </ToolTipService.ToolTip>
                     </AppBarButton>
                     <AppBarButton Icon="Switch" Label="Add to Narrative" Command="{x:Bind ShellVm.AddToNarrativeCommand, Mode=OneWay}" 
-                          Visibility="{x:Bind ShellVm.AddToNarrativeVisibility, Mode=TwoWay}" >
+                          Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" >
                         <ToolTipService.ToolTip>
                             <ToolTip Content="Add Scene to Narrative" />
                         </ToolTipService.ToolTip>
                     </AppBarButton>
                     <AppBarButton Icon="Switch" Label="Remove from narrative" Command="{x:Bind ShellVm.RemoveFromNarrativeCommand, Mode=OneWay}"
-                          Visibility="{x:Bind ShellVm.RemoveFromNarrativeVisibility, Mode=TwoWay}" >
+                          Visibility="{x:Bind ShellVm.NarratorVisibility, Mode=TwoWay}" >
                         <ToolTipService.ToolTip>
                             <ToolTip Content="Remove Scene from Narrative" />
                         </ToolTipService.ToolTip>
                     </AppBarButton>
                     <AppBarButton Icon="Switch" Label="Convert to Scene" Command="{x:Bind ShellVm.ConvertToSceneCommand, Mode=OneWay}"
-                          Visibility="{x:Bind ShellVm.ConvertToSceneVisibility, Mode=TwoWay}" />
+                          Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" />
                     <AppBarButton Icon="Switch" Label="Convert to Problem" Command="{x:Bind ShellVm.ConvertToProblemCommand, Mode=OneWay}"
-                          Visibility="{x:Bind ShellVm.ConvertToProblemVisibility, Mode=TwoWay}" />
+                          Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" />
                     <AppBarButton Icon="Print" Label="Print node" Command="{x:Bind ShellVm.PrintNodeCommand, Mode=OneWay}"
                           Visibility="{x:Bind ShellVm.PrintNodeVisibility, Mode=TwoWay}" >
                         <ToolTipService.ToolTip>
                             <ToolTip Content="Print selected node"/>
                         </ToolTipService.ToolTip>
                     </AppBarButton>
-                    <AppBarButton Icon="Cancel" Label="Empty Trash" Visibility="{x:Bind ShellVm.EmptyTrashVisibility, Mode=TwoWay}" >
+                    <AppBarButton Icon="Cancel" Label="Empty Trash" Visibility="{x:Bind ShellVm.TrashButtonVisibility, Mode=TwoWay}" >
                         <ToolTipService.ToolTip>
                             <ToolTip Content="Empty trash"/>
                         </ToolTipService.ToolTip>
@@ -168,37 +168,37 @@
                     </AppBarButton.Icon>
                     <AppBarButton.Flyout>
                         <MenuFlyout>
-                            <MenuFlyoutItem  Visibility="{x:Bind ShellVm.AddFolderVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddFolderCommand, Mode=OneWay}" Icon="Folder" Text="Add folder">
+                            <MenuFlyoutItem  Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddFolderCommand, Mode=OneWay}" Icon="Folder" Text="Add folder">
                                 <MenuFlyoutItem.KeyboardAccelerators>
                                     <KeyboardAccelerator Key="F" Modifiers="Menu"/>
                                 </MenuFlyoutItem.KeyboardAccelerators>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.AddSectionVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddSectionCommand,Mode=OneWay}" Icon="Folder" Text="Add section">
+                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.NarratorVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddSectionCommand,Mode=OneWay}" Icon="Folder" Text="Add section">
                                 <MenuFlyoutItem.KeyboardAccelerators>
                                     <KeyboardAccelerator Key="A" Modifiers="Menu"/>
                                 </MenuFlyoutItem.KeyboardAccelerators>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.AddProblemVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddProblemCommand ,Mode=OneWay}" Icon="Help" Text="Add problem">
+                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddProblemCommand ,Mode=OneWay}" Icon="Help" Text="Add problem">
                                 <MenuFlyoutItem.KeyboardAccelerators>
                                     <KeyboardAccelerator Key="P" Modifiers="Menu"/>
                                 </MenuFlyoutItem.KeyboardAccelerators>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.AddCharacterVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddCharacterCommand,Mode=OneWay}" Icon="Contact" Text="Add character">
+                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddCharacterCommand,Mode=OneWay}" Icon="Contact" Text="Add character">
                                 <MenuFlyoutItem.KeyboardAccelerators>
                                     <KeyboardAccelerator Key="C" Modifiers="Menu"/>
                                 </MenuFlyoutItem.KeyboardAccelerators>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.AddSettingVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddSettingCommand,Mode=OneWay}" Icon="Globe" Text="Add setting">
+                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddSettingCommand,Mode=OneWay}" Icon="Globe" Text="Add setting">
                                 <MenuFlyoutItem.KeyboardAccelerators>
                                     <KeyboardAccelerator Key="L" Modifiers="Menu"/>
                                 </MenuFlyoutItem.KeyboardAccelerators>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.AddSceneVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddSceneCommand,Mode=OneWay}" Icon="AllApps" Text="Add scene">
+                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddSceneCommand,Mode=OneWay}" Icon="AllApps" Text="Add scene">
                                 <MenuFlyoutItem.KeyboardAccelerators>
                                     <KeyboardAccelerator Key="S" Modifiers="Menu"/>
                                 </MenuFlyoutItem.KeyboardAccelerators>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Text="Add Web node" Visibility="{x:Bind ShellVm.AddSceneVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddWebCommand,Mode=OneWay}">
+                            <MenuFlyoutItem Text="Add Web node" Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddWebCommand,Mode=OneWay}">
                                 <MenuFlyoutItem.Icon>
                                     <SymbolIcon Symbol="PreviewLink"/>
                                 </MenuFlyoutItem.Icon>
@@ -206,7 +206,7 @@
                                     <KeyboardAccelerator Key="W" Modifiers="Menu"/>
                                 </MenuFlyoutItem.KeyboardAccelerators>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Text="Add Notes node" Visibility="{x:Bind ShellVm.AddSceneVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddNotesCommand,Mode=OneWay}">
+                            <MenuFlyoutItem Text="Add Notes node" Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddNotesCommand,Mode=OneWay}">
                                 <MenuFlyoutItem.Icon>
                                     <SymbolIcon Symbol="TwoPage"/>
                                 </MenuFlyoutItem.Icon>
@@ -215,16 +215,16 @@
                                 </MenuFlyoutItem.KeyboardAccelerators>
                             </MenuFlyoutItem>
                             <MenuFlyoutSeparator/>
-                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.RemoveStoryElementVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.RemoveStoryElementCommand,Mode=OneWay}" Icon="Delete" Text="Delete story element">
+                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.RemoveStoryElementCommand,Mode=OneWay}" Icon="Delete" Text="Delete story element">
                                 <MenuFlyoutItem.KeyboardAccelerators>
                                     <KeyboardAccelerator Key="Delete"/>
                                 </MenuFlyoutItem.KeyboardAccelerators>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.RestoreStoryElementVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.RestoreStoryElementCommand,Mode=OneWay}" Icon="Refresh" Text="Restore Story element"/>
-                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.AddToNarrativeVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddToNarrativeCommand,Mode=OneWay}" Icon="Switch" Text="Add To Narrative"/>
-                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.RemoveFromNarrativeVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.RemoveFromNarrativeCommand,Mode=OneWay}" Icon="Switch" Text="Remove from Narrative"/>
-                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.ConvertToSceneVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.ConvertToSceneCommand,Mode=OneWay}" Icon="Switch" Text="Convert to Scene"/>
-                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.ConvertToProblemVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.ConvertToProblemCommand,Mode=OneWay}" Icon="Switch" Text="Convert to Problem"/>
+                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.TrashButtonVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.RestoreStoryElementCommand,Mode=OneWay}" Icon="Refresh" Text="Restore Story element"/>
+                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddToNarrativeCommand,Mode=OneWay}" Icon="Switch" Text="Add To Narrative"/>
+                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.NarratorVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.RemoveFromNarrativeCommand,Mode=OneWay}" Icon="Switch" Text="Remove from Narrative"/>
+                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.ConvertToSceneCommand,Mode=OneWay}" Icon="Switch" Text="Convert to Scene"/>
+                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.ConvertToProblemCommand,Mode=OneWay}" Icon="Switch" Text="Convert to Problem"/>
                         </MenuFlyout>
                     </AppBarButton.Flyout>
                 </AppBarButton>

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -173,89 +173,42 @@ public class ShellViewModel : ObservableRecipient
         set => SetProperty(ref _isPaneOpen, value);
     }
 
-    // CommandBar Flyout AppBarButton properties
-    private Visibility _addFolderVisibility;
-    public Visibility AddFolderVisibility
+
+    private Visibility _explorerVisibility;
+    /// <summary>
+    /// Controls visibility for elements that should only be shown in the Explorer view.
+    /// </summary>
+    public Visibility ExplorerVisibility
     {
-        get => _addFolderVisibility;
-        set => SetProperty(ref _addFolderVisibility, value);
+        get => _explorerVisibility;
+        set => SetProperty(ref _explorerVisibility, value);
     }
 
-    private Visibility _addSectionVisibility;
-    public Visibility AddSectionVisibility
+    private Visibility _narratorVisibility;
+    /// <summary>
+    /// Controls visibility for elements that should only be shown in the Narrator view.
+    /// </summary>
+    public Visibility NarratorVisibility
     {
-        get => _addSectionVisibility;
-        set => SetProperty(ref _addSectionVisibility, value);
+        get => _narratorVisibility;
+        set => SetProperty(ref _narratorVisibility, value);
     }
 
-    private Visibility _addProblemVisibility;
-    public Visibility AddProblemVisibility
+    private Visibility _trashButtonVisibility;
+    /// <summary>
+    /// Controls visibility for elements that should only be shown in the Trash view.
+    /// </summary
+    public Visibility TrashButtonVisibility
     {
-        get => _addProblemVisibility;
-        set => SetProperty(ref _addProblemVisibility, value);
+        get => _trashButtonVisibility;
+        set => SetProperty(ref _trashButtonVisibility, value);
     }
 
-    private Visibility _addCharacterVisibility;
-    public Visibility AddCharacterVisibility
+    private Visibility _addButtonVisibility;
+    public Visibility AddButtonVisibility
     {
-        get => _addCharacterVisibility;
-        set => SetProperty(ref _addCharacterVisibility, value);
-    }
-
-    private Visibility _addSettingVisibility;
-    public Visibility AddSettingVisibility
-    {
-        get => _addSettingVisibility;
-        set => SetProperty(ref _addSettingVisibility, value);
-    }
-
-    private Visibility _addSceneVisibility;
-    public Visibility AddSceneVisibility
-    {
-        get => _addSceneVisibility;
-        set => SetProperty(ref _addSceneVisibility, value);
-    }
-
-    private Visibility _convertToSceneVisibility;
-    public Visibility ConvertToSceneVisibility
-    {
-        get => _convertToSceneVisibility;
-        set => SetProperty(ref _convertToSceneVisibility, value);
-    }
-
-    private Visibility _convertToProblemVisibility;
-    public Visibility ConvertToProblemVisibility
-    {
-        get => _convertToProblemVisibility;
-        set => SetProperty(ref _convertToProblemVisibility, value);
-    }
-
-    private Visibility _removeStoryElementVisibility;
-    public Visibility RemoveStoryElementVisibility
-    {
-        get => _removeStoryElementVisibility;
-        set => SetProperty(ref _removeStoryElementVisibility, value);
-    }
-
-    private Visibility _restoreStoryElementVisibility;
-    public Visibility RestoreStoryElementVisibility
-    {
-        get => _restoreStoryElementVisibility;
-        set => SetProperty(ref _restoreStoryElementVisibility, value);
-    }
-
-    private Visibility _addToNarrativeVisibility;
-    public Visibility AddToNarrativeVisibility
-    {
-        get => _addToNarrativeVisibility;
-        set => SetProperty(ref _addToNarrativeVisibility, value);
-    }
-
-    private Visibility _removeFromNarrativeVisibility;
-    public Visibility RemoveFromNarrativeVisibility
-    {
-        get => _removeFromNarrativeVisibility;
-        set => SetProperty(ref _removeFromNarrativeVisibility, value);
+        get => _addButtonVisibility;
+        set => SetProperty(ref _addButtonVisibility, value);
     }
 
     private Visibility _printNodeVisibility;
@@ -263,13 +216,6 @@ public class ShellViewModel : ObservableRecipient
     {
         get => _printNodeVisibility;
         set => SetProperty(ref _printNodeVisibility, value);
-    }
-
-    private Visibility _emptyTrashVisibility;
-    public Visibility EmptyTrashVisibility
-    {
-        get => _emptyTrashVisibility;
-        set => SetProperty(ref _emptyTrashVisibility, value);
     }
 
     // Status Bar properties
@@ -947,61 +893,33 @@ public class ShellViewModel : ObservableRecipient
             //Trash Can - View Hide all buttons except Empty Trash.
             if (StoryNodeItem.RootNodeType(RightTappedNode) == StoryItemType.TrashCan)
             {
-                AddFolderVisibility = Visibility.Collapsed;
-                AddSectionVisibility = Visibility.Collapsed;
-                AddProblemVisibility = Visibility.Collapsed;
-                AddCharacterVisibility = Visibility.Collapsed;
-                AddSettingVisibility = Visibility.Collapsed;
-                AddSceneVisibility = Visibility.Collapsed;
-                ConvertToSceneVisibility = Visibility.Collapsed;
-                ConvertToProblemVisibility = Visibility.Collapsed;
-                RemoveStoryElementVisibility = Visibility.Collapsed;
-                AddToNarrativeVisibility = Visibility.Collapsed;
-                RemoveFromNarrativeVisibility = Visibility.Collapsed;
+                ExplorerVisibility = Visibility.Collapsed;
+                NarratorVisibility = Visibility.Collapsed;
+                AddButtonVisibility = Visibility.Collapsed;
                 PrintNodeVisibility = Visibility.Collapsed;
-
-                RestoreStoryElementVisibility = Visibility.Visible;
-                EmptyTrashVisibility = Visibility.Visible;
+                AddButtonVisibility = Visibility.Collapsed;
+                TrashButtonVisibility = Visibility.Visible;
             }
             else
             {
                 //Explorer tree, show everything but empty trash and add section
                 if (SelectedView == ViewList[0])
                 {
-                    AddFolderVisibility = Visibility.Visible;
-                    AddSectionVisibility = Visibility.Collapsed;
-                    AddProblemVisibility = Visibility.Visible;
-                    AddCharacterVisibility = Visibility.Visible;
-                    AddSettingVisibility = Visibility.Visible;
-                    AddSceneVisibility = Visibility.Visible;
-                    ConvertToSceneVisibility = RightTappedNode.Type == StoryItemType.Problem ? Visibility.Visible : Visibility.Collapsed;
-                    ConvertToProblemVisibility = RightTappedNode.Type == StoryItemType.Scene ? Visibility.Visible : Visibility.Collapsed;
-                    RemoveStoryElementVisibility = Visibility.Visible;
-                    //TODO: Use correct values (bug with this)
-                    //RestoreStoryElementVisibility = Visibility.Collapsed;
-                    RestoreStoryElementVisibility = Visibility.Collapsed;
-                    AddToNarrativeVisibility = Visibility.Visible;
-                    //RemoveFromNarrativeVisibility = Visibility.Collapsed;
+                    ExplorerVisibility = Visibility.Visible;
+                    NarratorVisibility = Visibility.Collapsed;
+                    AddButtonVisibility = Visibility.Visible;
                     PrintNodeVisibility = Visibility.Visible;
-                    EmptyTrashVisibility = Visibility.Collapsed;
+                    TrashButtonVisibility = Visibility.Collapsed;
                 }
                 else //Narrator Tree, hide most things.
                 {
-                    RemoveFromNarrativeVisibility = Visibility.Visible;
-                    AddSectionVisibility = Visibility.Visible;
+                    ExplorerVisibility = Visibility.Collapsed;
+                    NarratorVisibility = Visibility.Visible;
+                    AddButtonVisibility = Visibility.Collapsed;
                     PrintNodeVisibility = Visibility.Visible;
-                    RemoveStoryElementVisibility = Visibility.Collapsed;
-                    AddFolderVisibility = Visibility.Collapsed;
-                    AddProblemVisibility = Visibility.Collapsed;
-                    AddCharacterVisibility = Visibility.Collapsed;
-                    AddSettingVisibility = Visibility.Collapsed;
-                    AddSceneVisibility = Visibility.Collapsed;
-                    ConvertToSceneVisibility = Visibility.Collapsed;
-                    ConvertToProblemVisibility = Visibility.Collapsed;
-                    RestoreStoryElementVisibility = Visibility.Collapsed;
-                    AddToNarrativeVisibility = Visibility.Collapsed;
-                    EmptyTrashVisibility = Visibility.Collapsed;
+                    TrashButtonVisibility = Visibility.Collapsed;
                 }
+                AddButtonVisibility = Visibility.Visible;
             }
         }
         catch (Exception e) //errors (is RightTappedNode null?


### PR DESCRIPTION
This PR reworks how shell item visibility works into:
- ExplorerVisibility which controls items that should be visible on the explorer tree
- Narrator visibility; same as above but for narrator tree
- Trash Visibility same as above for trash tree
- Add Button visibility, hides the add menu completely in the trash tree
- print button visibility, shown except for in trash tree.

fixes #1065 