### PR TITLE
Fix Warnings, Update All packages.

### DIFF
--- a/StoryCAD/StoryCAD.csproj
+++ b/StoryCAD/StoryCAD.csproj
@@ -28,10 +28,6 @@
 	<PropertyGroup>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ss:fffZ"))</SourceRevisionId>
 	</PropertyGroup>
-	<PropertyGroup>
-		<WindowsSdkPackageVersion>10.0.22621.38</WindowsSdkPackageVersion>
-		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-	</PropertyGroup>
 	<ItemGroup>
 		<Content Include="Assets\SplashScreen.scale-200.png" />
 		<Content Include="Assets\Square150x150Logo.scale-200.png" />
@@ -41,14 +37,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="dotenv.net" Version="3.2.1" />
-		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250228001" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
+		<PackageReference Include="dotenv.net" Version="4.0.0" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4654" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-		<PackageReference Include="NLog" Version="5.4.0" />
-		<PackageReference Include="NLog.Extensions.Logging" Version="5.4.0" />
-		<PackageReference Include="WinUIEx" Version="2.5.1" />
+		<PackageReference Include="NLog" Version="6.0.3" />
+		<PackageReference Include="NLog.Extensions.Logging" Version="6.0.3" />
+		<PackageReference Include="WinUIEx" Version="2.6.0" />
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 

--- a/StoryCADLib/DAL/PreferencesIO.cs
+++ b/StoryCADLib/DAL/PreferencesIO.cs
@@ -16,9 +16,6 @@ namespace StoryCAD.DAL;
 /// </summary>
 public class PreferencesIo
 {
-	//TODO: Remove this variable after June 2025.
-	private IList<string> _preferences;
-
 	private LogService _log = Ioc.Default.GetService<LogService>();
 	private AppState _state = Ioc.Default.GetService<AppState>();
 

--- a/StoryCADLib/Services/Logging/LogService.cs
+++ b/StoryCADLib/Services/Logging/LogService.cs
@@ -37,7 +37,6 @@ public class LogService : ILogService
             fileTarget.CreateDirs = true;
             fileTarget.MaxArchiveFiles = 7;
             fileTarget.ArchiveEvery = FileArchivePeriod.Day;
-            fileTarget.ConcurrentWrites = true;
             fileTarget.Layout = "${longdate} | ${level} | ${message} | ${exception:format=Message,StackTrace,Data:MaxInnerExceptionLevel=15}";
             LoggingRule fileRule = new("*", NLog.LogLevel.Off, fileTarget);
             if (Ioc.Default.GetRequiredService<PreferenceService>().Model.AdvancedLogging)

--- a/StoryCADLib/Services/Outline/OutlineService.cs
+++ b/StoryCADLib/Services/Outline/OutlineService.cs
@@ -634,7 +634,7 @@ public Task<StoryModel> CreateModel(string name, string author, int selectedTemp
         }
 
         //Get desired bind
-        StoryElement? DesiredBindElement;
+        StoryElement DesiredBindElement;
         Model.StoryElements.StoryElementGuids.TryGetValue(DesiredBind, out DesiredBindElement);
         Parent.StructureBeats[Index].Guid = DesiredBind;
 
@@ -745,7 +745,7 @@ public Task<StoryModel> CreateModel(string name, string author, int selectedTemp
             return;
         }
 
-        StoryElement? BoundElement;
+        StoryElement BoundElement;
         Model.StoryElements.StoryElementGuids.TryGetValue(Parent.StructureBeats[Index].Guid, out BoundElement);
         
         //An element is bound that doesn't exist

--- a/StoryCADLib/Services/Reports/PrintReports.cs
+++ b/StoryCADLib/Services/Reports/PrintReports.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text;
 ﻿using System.Drawing;
 using System.Drawing.Printing;
-using System.Text;
 using StoryCAD.Services.Outline;
 using StoryCAD.ViewModels.Tools;
 

--- a/StoryCADLib/StoryCADLib.csproj
+++ b/StoryCADLib/StoryCADLib.csproj
@@ -11,6 +11,7 @@
 	  <Version>3.2.1.0</Version>
 	  <FileVersion>3.2.1.0</FileVersion>
 	  <AssemblyVersion>3.2.1.0</AssemblyVersion>
+	  <PackageVersion>3.2.1-preview</PackageVersion>
 	  <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
@@ -92,15 +93,11 @@
     <PRIResource Remove="Services\Preferences\**" />
     <PRIResource Remove="Services\Theming\**" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="Collaborator\ViewModels\IWizardStepViewModel.cs" />
-    <Compile Remove="Collaborator\ViewModels\IWizardViewModel.cs" />
-    <Compile Remove="Controls\ProblemName.cs" />
-  </ItemGroup>
-
-	<PropertyGroup>
-		<WindowsSdkPackageVersion>10.0.22621.38</WindowsSdkPackageVersion>
-	</PropertyGroup>
+	<ItemGroup>
+		<Compile Remove="Collaborator\ViewModels\IWizardStepViewModel.cs" />
+		<Compile Remove="Collaborator\ViewModels\IWizardViewModel.cs" />
+		<Compile Remove="Controls\ProblemName.cs" />
+	</ItemGroup>
 
 	<ItemGroup>
 	  <AppxManifest Include="Package.appxmanifest">
@@ -110,20 +107,22 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="dotenv.net" Version="3.2.1" />
+    <PackageReference Include="dotenv.net" Version="4.0.0" />
     <PackageReference Include="Elmah.Io.NLog" Version="5.3.55" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
-    <PackageReference Include="MySql.Data" Version="9.2.0" /> 
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250228001" />
-	<PackageReference Include="NLog" Version="5.4.0" />
-	<PackageReference Include="NLog.Extensions.Logging" Version="5.4.0" />
-	<PackageReference Include="NRTFTree-Async" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
+    <PackageReference Include="MySql.Data" Version="9.4.0" /> 
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
+	<PackageReference Include="NLog" Version="6.0.3" />
+	<PackageReference Include="NLog.Extensions.Logging" Version="6.0.3" />
+	<PackageReference Include="NRTFTree-Async" Version="1.0.1" />
 	<PackageReference Include="Octokit" Version="14.0.0" />
-    <PackageReference Include="WinUIEx" Version="2.5.1" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.41.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.41.0" />
+    <PackageReference Include="WinUIEx" Version="2.6.0" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4654" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.61.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.61.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Planners.OpenAI" Version="1.16.0-preview" />
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.8" />
+    <PackageReference Include="System.Reflection.Metadata" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>
@@ -135,8 +134,6 @@
   </ItemGroup>
   
 	<PropertyGroup>
-		<WindowsSdkPackageVersion>10.0.22621.38</WindowsSdkPackageVersion>
-		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<IncludeSymbols>True</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/StoryCADLib/ViewModels/ProblemViewModel.cs
+++ b/StoryCADLib/ViewModels/ProblemViewModel.cs
@@ -891,7 +891,7 @@ public class ProblemViewModel : ObservableRecipient, INavigable
             Ioc.Default.GetService<OutlineService>()
                 .SaveBeatsheet(FilePath.Path, StructureDescription, StructureBeats.ToList());
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             Ioc.Default.GetService<ShellViewModel>().ShowMessage(LogLevel.Error,"Failed to save Beatsheet", false);
 
@@ -907,7 +907,7 @@ public class ProblemViewModel : ObservableRecipient, INavigable
             StructureDescription = model.Description;
             StructureBeats = new ObservableCollection<StructureBeatViewModel>(model.Beats);
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             Ioc.Default.GetService<ShellViewModel>().ShowMessage(LogLevel.Error, "Failed to Load Beatsheet", false);
 

--- a/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
+++ b/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
@@ -696,7 +696,7 @@ public class OutlineViewModel : ObservableRecipient
         }
     }
 
-    public async Task PrintCurrentNodeAsync()
+    public Task PrintCurrentNodeAsync()
     {
         using (var serializationLock = new SerializationLock(autoSaveService, backupService, logger))
         {
@@ -704,10 +704,11 @@ public class OutlineViewModel : ObservableRecipient
             {
                 Messenger.Send(new StatusChangedMessage(new("Right tap a node to print", LogLevel.Warn)));
                 logger.Log(LogLevel.Info, "Print node failed as no node is selected");
-                return;
+                return Task.CompletedTask;
             }
             Ioc.Default.GetRequiredService<PrintReportDialogVM>().PrintSingleNode(shellVm.RightTappedNode);
         }
+        return Task.CompletedTask;
     }
 
     public async Task KeyQuestionsTool()

--- a/StoryCADTests/FileTests.cs
+++ b/StoryCADTests/FileTests.cs
@@ -491,9 +491,9 @@ public class FileTests
     /// https://github.com/storybuilder-org/StoryCAD/pull/971
     /// </summary>
     [TestMethod]
+    [Ignore("Test temporarily disabled")]
     public void TestOpenWithNoRecentIndex()
     {
-        return;
         FileOpenVM fileOpenVM = Ioc.Default.GetRequiredService<FileOpenVM>();
         fileOpenVM.SelectedRecentIndex = -1;
         fileOpenVM.ConfirmClicked();

--- a/StoryCADTests/OutlineServiceTests.cs
+++ b/StoryCADTests/OutlineServiceTests.cs
@@ -707,7 +707,7 @@ namespace StoryCADTests
         /// Tests that GetAllStoryElements returns empty list for empty model
         /// </summary>
         [TestMethod]
-        public async Task GetAllStoryElements_EmptyModel_ReturnsEmptyList()
+        public void GetAllStoryElements_EmptyModel_ReturnsEmptyList()
         {
             // Arrange
             var model = new StoryModel();

--- a/StoryCADTests/StoryCADTests.csproj
+++ b/StoryCADTests/StoryCADTests.csproj
@@ -92,22 +92,18 @@
 	<ItemGroup>
 		<ProjectCapability Include="TestContainer" />
 	</ItemGroup>
-    <PropertyGroup>
-        <WindowsSdkPackageVersion>10.0.22621.38</WindowsSdkPackageVersion>
-    </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250228001" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4654" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="MSTest.TestAdapter">
-			<Version>3.8.2</Version>
+			<Version>3.10.1</Version>
 		</PackageReference>
 		<PackageReference Include="MSTest.TestFramework">
-			<Version>3.8.2</Version>
+			<Version>3.10.1</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.TestPlatform.TestHost">
-			<Version>17.13.0</Version>
+			<Version>17.14.1</Version>
 			<ExcludeAssets>build</ExcludeAssets>
 		</PackageReference>
 		<Manifest Include="$(ApplicationManifest)" />


### PR DESCRIPTION
This PR does the following:
- Fix all known warnings.
- Upgrade all packages

This PR makes changes to remove some workarounds previously needed to fix WebView2 packages higher than the 1.27xxx package we previously used.

This removes the windows sdk package version and the unsafe blocks, this does not affect how storycad functions, is packages or anything else and was added as a workaround for some old issue with winui.