### PR TITLE
Remove blank textboxes

### DIFF
--- a/StoryCAD/Views/CharacterPage.xaml
+++ b/StoryCAD/Views/CharacterPage.xaml
@@ -46,9 +46,8 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <TextBox Header="Age" Grid.Column="0" MinWidth="100"
+                        <TextBox Header="Age" Grid.Column="0" MinWidth="100" Margin="0,0,100,0"
                                  Text="{x:Bind CharVm.Age, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                        <TextBlock Grid.Column="1" MinWidth="300"/>
                         <TextBox Header="Sex" Grid.Column="2" MinWidth="100"
                                  Text="{x:Bind CharVm.Sex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     </Grid>
@@ -58,9 +57,8 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <TextBox Header="Height" Grid.Column="0" MinWidth="100"
+                        <TextBox Header="Height" Grid.Column="0" MinWidth="100" Margin="0,0,100,0"
                                  Text="{x:Bind CharVm.CharHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                        <TextBlock Grid.Column="1" MinWidth="300"/>
                         <TextBox Header="Weight" Grid.Column="2" MinWidth="100"
                                  Text="{x:Bind CharVm.Weight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     </Grid>
@@ -70,11 +68,10 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <ComboBox IsEditable="True" Header="Eye Color" Grid.Column="0" MinWidth="200"
+                        <ComboBox IsEditable="True" Header="Eye Color" Grid.Column="0" MinWidth="200" Margin="0,0,80,0"
                                   ItemsSource="{x:Bind CharVm.EyesList}"
                                   Text="{x:Bind CharVm.Eyes, Mode=TwoWay}"
                                   PlaceholderText="{x:Bind CharVm.Eyes, Mode=TwoWay}" />
-                        <TextBlock Grid.Column="1" MinWidth="100"/>
                         <ComboBox IsEditable="True" Header="Hair Color" Grid.Column="2"  MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.HairList}"
                                   Text="{x:Bind CharVm.Hair, Mode=TwoWay}" 
@@ -86,11 +83,10 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <ComboBox IsEditable="True" Header="Build" Grid.Column="0" MinWidth="200"
+                        <ComboBox IsEditable="True" Header="Build" Grid.Column="0" MinWidth="200" Margin="0,0,80,0"
                                   ItemsSource="{x:Bind CharVm.BuildList}"
                                   Text="{x:Bind CharVm.Build, Mode=TwoWay}"
                                   PlaceholderText="{x:Bind CharVm.Build, Mode=TwoWay}" />
-                        <TextBlock Grid.Column="1" MinWidth="100"/>
                         <ComboBox IsEditable="True" Header="Complexion" Grid.Column="2" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.SkinList}"
                                   Text="{x:Bind CharVm.Complexion, Mode=TwoWay}"
@@ -102,11 +98,10 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <ComboBox IsEditable="True" Header="Race" Grid.Column="0"  MinWidth="200"
+                        <ComboBox IsEditable="True" Header="Race" Grid.Column="0"  MinWidth="200" Margin="0,0,80,0"
                                   ItemsSource="{x:Bind CharVm.RaceList}"
                                   Text="{x:Bind CharVm.Race, Mode=TwoWay}"
                                   PlaceholderText="{x:Bind CharVm.Race, Mode=TwoWay}" />
-                        <TextBlock Grid.Column="1" MinWidth="100"/>
                         <ComboBox IsEditable="True" Header="Nationality" Grid.Column="2" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.NationalityList}"
                                   Text="{x:Bind CharVm.Nationality, Mode=TwoWay}"
@@ -140,8 +135,7 @@
                     </Grid.RowDefinitions>
                     <Button  Content="Flaw Builder" Grid.Row="0" HorizontalAlignment="Left" Margin="0,10,10,10" 
                              Command="{x:Bind CharVm.FlawCommand, Mode=OneWay}" />
-                    <TextBlock Width="100"  Grid.Row="1" />
-                    <usercontrols:RichEditBoxExtended Grid.Row="2" Header="Flaw"
+                    <usercontrols:RichEditBoxExtended Grid.Row="2" Margin="0,10,0,0" Header="Flaw"
                                                       RtfText="{x:Bind CharVm.Flaw, Mode=TwoWay}" AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                       ScrollViewer.VerticalScrollBarVisibility="Visible"
@@ -199,11 +193,10 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <ComboBox IsEditable="True" Header="Intelligence"  Grid.Column="0" Width="200"
+                        <ComboBox IsEditable="True" Header="Intelligence"  Grid.Column="0" Width="200" Margin="0,0,80,0"
                                   ItemsSource="{x:Bind CharVm.IntelligenceList}"
                                   Text="{x:Bind CharVm.Intelligence, Mode=TwoWay}"
                                   PlaceholderText="{x:Bind CharVm.Intelligence, Mode=TwoWay}"/>
-                        <TextBlock Width="100"  Grid.Column="1" />
                         <ComboBox IsEditable="True" Header="Values"  Grid.Column="2"  Width="200"
                                   ItemsSource="{x:Bind CharVm.ValuesList}"
                                   Text="{x:Bind CharVm.Values, Mode=TwoWay}" 
@@ -215,11 +208,10 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <ComboBox IsEditable="True" Header="Focus"  Grid.Column="0" Width="200"
+                        <ComboBox IsEditable="True" Header="Focus"  Grid.Column="0" Width="200" Margin="0,0,80,0"
                                   ItemsSource="{x:Bind CharVm.FocusList}"
                                   Text="{x:Bind CharVm.Focus, Mode=TwoWay}"
                                   PlaceholderText="{x:Bind CharVm.Focus, Mode=TwoWay}"/>
-                        <TextBlock Width="100"  Grid.Column="1" />
                         <ComboBox IsEditable="True" Header="Abnormality"  Grid.Column="2"  Width="200"
                                   ItemsSource="{x:Bind CharVm.AbnormalityList}"
                                   Text="{x:Bind CharVm.Abnormality, Mode=TwoWay}"
@@ -266,11 +258,10 @@
                                   ItemsSource="{x:Bind CharVm.SensitivityList}"
                                   Text="{x:Bind CharVm.Sensitivity, Mode=TwoWay}"
                                   PlaceholderText="{x:Bind CharVm.Sensitivity, Mode=TwoWay}" />
-                    <ComboBox IsEditable="True" Header="Sociability" Grid.Column="0" Grid.Row="5" MinWidth="200"
+                    <ComboBox IsEditable="True" Header="Sociability" Grid.Column="0" Grid.Row="5" MinWidth="200" Margin="0,0,80,0"
                                   ItemsSource="{x:Bind CharVm.SociabilityList}"
                                   Text="{x:Bind CharVm.Sociability, Mode=TwoWay}" 
                                   PlaceholderText="{x:Bind CharVm.Sociability, Mode=TwoWay}" />
-                    <TextBlock Grid.Column="1" Grid.Row="0" MinWidth="100"/>
                     <ComboBox IsEditable="True" Header="Aggression" Grid.Column="2" Grid.Row="0" MinWidth="200"
                                   ItemsSource="{x:Bind CharVm.AggressionList}"
                                   Text="{x:Bind CharVm.Aggression, Mode=TwoWay}" 
@@ -318,14 +309,12 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <TextBox Header="Other Trait:" Grid.Column="0" MinWidth="300" Text="{x:Bind CharVm.NewTrait, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                        <TextBlock Grid.Column="1" Width="10" />
-                        <Button Grid.Column="2" FontFamily="Segoe MDL2 Assets" Content="&#xE710;"  Command="{x:Bind CharVm.AddTraitCommand, Mode=OneWay}" >
+                        <TextBox Header="Other Trait:" Grid.Column="0" MinWidth="300" Margin="0,0,10,0" Text="{x:Bind CharVm.NewTrait, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <Button Grid.Column="2" FontFamily="Segoe MDL2 Assets" Content="&#xE710;" Margin="0,0,10,0" Command="{x:Bind CharVm.AddTraitCommand, Mode=OneWay}" >
                             <ToolTipService.ToolTip>
                                 <ToolTip Content="Add Trait" />
                             </ToolTipService.ToolTip>
                         </Button>
-                        <TextBlock Grid.Column="3" Width="10" />
                         <Button Grid.Column="4" FontFamily="Segoe MDL2 Assets" Content="&#xE738;" Command="{x:Bind CharVm.RemoveTraitCommand, Mode=OneWay}">
                             <ToolTipService.ToolTip>
                                 <ToolTip Content="Remove Trait" />

--- a/StoryCAD/Views/OverviewPage.xaml
+++ b/StoryCAD/Views/OverviewPage.xaml
@@ -26,9 +26,8 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <TextBox Header="Date Created" Grid.Column="0"
+                        <TextBox Header="Date Created" Grid.Column="0" Margin="0,0,100,0"
                                  Text="{x:Bind OverviewVm.DateCreated, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                        <TextBlock Grid.Column="1" MinWidth="100"/>
                         <TextBox Header="Last Changed" Grid.Column="2"
                                  Text="{x:Bind OverviewVm.DateModified, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     </Grid>
@@ -56,8 +55,7 @@
                               DisplayMemberPath="Name"
                               SelectedItem="{x:Bind OverviewVm.SelectedProblem, Mode=TwoWay}"
                               ItemsSource="{x:Bind OverviewVm.Problems, Mode=OneWay}" />
-                    <TextBlock Grid.Row="1" Text=" "/>
-                    <usercontrols:RichEditBoxExtended Header="Premise" Grid.Row="2" 
+                    <usercontrols:RichEditBoxExtended Header="Premise" Grid.Row="2" Margin="0,10,0,0"
                                     RtfText="{x:Bind OverviewVm.Premise, Mode=TwoWay}" AcceptsReturn="True"
                                     IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                     ScrollViewer.VerticalScrollBarVisibility="Visible"
@@ -80,10 +78,9 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <ComboBox Header="Type" Grid.Column="0" IsEditable="False" MinWidth="200"
+                        <ComboBox Header="Type" Grid.Column="0" IsEditable="False" MinWidth="200" Margin="0,0,20,0"
                                   ItemsSource="{x:Bind OverviewVm.StoryTypeList}"
                                   SelectedItem="{x:Bind OverviewVm.StoryType, Mode=TwoWay}" />
-                        <TextBlock Grid.Column="1" MinWidth="100"/>
                         <ComboBox Header="Genre" Grid.Column="2" IsEditable="False" MinWidth="200"
                                   ItemsSource="{x:Bind OverviewVm.GenreList}"
                                   SelectedItem="{x:Bind OverviewVm.StoryGenre, Mode=TwoWay}" />
@@ -94,10 +91,9 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <ComboBox Header="Viewpoint" Grid.Column="0" IsEditable="False" MinWidth="200" 
+                        <ComboBox Header="Viewpoint" Grid.Column="0" IsEditable="False" MinWidth="200" Margin="0,0,20,0" 
                                   ItemsSource="{x:Bind OverviewVm.ViewpointList}"
                                   SelectedItem="{x:Bind OverviewVm.Viewpoint, Mode=TwoWay}" BorderThickness="1" />
-                        <TextBlock Grid.Column="1" MinWidth="100"/>
                         <ComboBox Header="Literary Technique" IsEditable="False" Grid.Column="2" MinWidth="200" 
                                   ItemsSource="{x:Bind OverviewVm.LiteraryTechniqueList}"
                                   SelectedItem="{x:Bind OverviewVm.LiteraryTechnique, Mode=TwoWay}" />
@@ -112,10 +108,9 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <ComboBox Header="Voice" Grid.Column="0" IsEditable="False" MinWidth="200" 
+                        <ComboBox Header="Voice" Grid.Column="0" IsEditable="False" MinWidth="200" Margin="0,0,20,0" 
                                   ItemsSource="{x:Bind OverviewVm.VoiceList}"
                                   SelectedItem="{x:Bind OverviewVm.Voice, Mode=TwoWay}" />
-                        <TextBlock Grid.Column="1" MinWidth="100"/>
                         <ComboBox Header="Tense" Grid.Column="2" IsEditable="False" MinWidth="200" 
                                   ItemsSource="{x:Bind OverviewVm.TenseList}"
                                   SelectedItem="{x:Bind OverviewVm.Tense, Mode=TwoWay}" />
@@ -126,10 +121,9 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="2*"/>
                     </Grid.ColumnDefinitions>
-                        <ComboBox Header="Style" Grid.Column="0" IsEditable="False" MinWidth="200" 
+                        <ComboBox Header="Style" Grid.Column="0" IsEditable="False" MinWidth="200" Margin="0,0,20,0" 
                                   ItemsSource="{x:Bind OverviewVm.StyleList}"
                                   SelectedItem="{x:Bind OverviewVm.Style, Mode=TwoWay}" />
-                        <TextBlock Grid.Column="1" MinWidth="100"/>
                         <ComboBox Header="Tone" Grid.Column="2" IsEditable="False" MinWidth="200"  
                                   ItemsSource="{x:Bind OverviewVm.ToneList}"
                                   SelectedItem="{x:Bind OverviewVm.Tone, Mode=TwoWay}" />

--- a/StoryCAD/Views/ProblemPage.xaml
+++ b/StoryCAD/Views/ProblemPage.xaml
@@ -33,8 +33,8 @@
                               ItemsSource="{x:Bind ProblemVm.ProblemTypeList}"
                               Text="{x:Bind ProblemVm.ProblemType, Mode=TwoWay}"
                               PlaceholderText="{x:Bind ProblemVm.ProblemType, Mode=TwoWay}"/>
-                        <TextBlock Grid.Column="1" Grid.Row="0" MinWidth="300"/>
                         <ComboBox Grid.Column="2" IsEditable="True" Header="Conflict Type" Grid.Row="0"  MinWidth="200"
+                                  Margin="20,0,0,0"
                                     ItemsSource="{x:Bind ProblemVm.ConflictTypeList}"
                                     Text="{x:Bind ProblemVm.ConflictType, Mode=TwoWay}"
                                     PlaceholderText="{x:Bind ProblemVm.ConflictType, Mode=TwoWay}"  />

--- a/StoryCAD/Views/SettingPage.xaml
+++ b/StoryCAD/Views/SettingPage.xaml
@@ -34,11 +34,10 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <ComboBox IsEditable="True" Header="Locale" Grid.Column="0"  MinWidth="200"
+                        <ComboBox IsEditable="True" Header="Locale" Grid.Column="0"  MinWidth="200" Margin="0,0,20,0"
                                   ItemsSource="{x:Bind SettingVm.LocaleList}"
                                   Text="{x:Bind SettingVm.Locale, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                   PlaceholderText="{x:Bind SettingVm.Locale, Mode=TwoWay}" />
-                        <TextBlock Grid.Column="1" MinWidth="100"/>
                         <ComboBox IsEditable="True" Header="Season" Grid.Column="2" MinWidth="200"
                                         ItemsSource="{x:Bind SettingVm.SeasonList}"
                                         Text="{x:Bind SettingVm.Season, Mode=TwoWay}" 
@@ -50,9 +49,8 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <TextBox Header="Period" Grid.Column="0" MinWidth="200"
+                        <TextBox Header="Period" Grid.Column="0" MinWidth="200" Margin="0,0,20,0"
                                  Text="{x:Bind SettingVm.Period, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                        <TextBlock Grid.Column="1" MinWidth="100"/>
                         <TextBox Header="Lighting" Grid.Column="2" MinWidth="200"
                                  Text="{x:Bind SettingVm.Lighting, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     </Grid>
@@ -62,9 +60,8 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-                        <TextBox Header="Weather" Grid.Column="0" MinWidth="200"
+                        <TextBox Header="Weather" Grid.Column="0" MinWidth="200" Margin="0,0,20,0"
                                  Text="{x:Bind SettingVm.Weather, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                        <TextBlock Grid.Column="1" Width="100"/>
                         <TextBox Header="Temperature" Grid.Column="2" MinWidth="200"
                                  Text="{x:Bind SettingVm.Temperature, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     </Grid>


### PR DESCRIPTION
This PR removes some blank textboxes that were in the UI for spacing during the inital development of StoryCAD; this PR removes them and relies on margin instead and the UI should look visually identical.