### PR TITLE
DI Cleanup: Batch 5 — Infrastructure (Issue #1063)

### DIFF
--- a/StoryCADLib/Services/Backup/AutoSaveService.cs
+++ b/StoryCADLib/Services/Backup/AutoSaveService.cs
@@ -21,7 +21,7 @@ namespace StoryCAD.Services.Backup
         private readonly AppState _appState;
         private readonly PreferenceService _preferenceService;
         private readonly OutlineViewModel _outlineVM;
-        // TODO: ShellViewModel removed due to circular dependency - needs architectural fix
+        // TODO: ShellViewModel and BackupService removed due to circular dependency - needs architectural fix
 
         private BackgroundWorker autoSaveWorker;
         private System.Timers.Timer autoSaveTimer;
@@ -31,16 +31,6 @@ namespace StoryCAD.Services.Backup
         public bool IsRunning => autoSaveTimer.Enabled;
 
         #region Constructor
-
-        // Constructor for backward compatibility - will be removed later
-        public AutoSaveService() : this(
-            Ioc.Default.GetRequiredService<Windowing>(),
-            Ioc.Default.GetRequiredService<LogService>(),
-            Ioc.Default.GetRequiredService<AppState>(),
-            Ioc.Default.GetRequiredService<PreferenceService>(),
-            Ioc.Default.GetRequiredService<OutlineViewModel>())
-        {
-        }
 
         public AutoSaveService(Windowing window, LogService logger, AppState appState, PreferenceService preferenceService, OutlineViewModel outlineViewModel)
         {
@@ -123,6 +113,8 @@ namespace StoryCAD.Services.Backup
 
         private Task AutoSaveProject()
         {
+            // TODO: Circular dependency - AutoSaveService ↔ BackupService
+            // BackupService requires AutoSaveService in constructor, so we can't inject it here
             var backupService = Ioc.Default.GetRequiredService<BackupService>();
             var logService = _logger;
 

--- a/StoryCADLib/Services/Outline/OutlineService.cs
+++ b/StoryCADLib/Services/Outline/OutlineService.cs
@@ -16,6 +16,8 @@ namespace StoryCAD.Services.Outline;
 /// </summary>
 public class OutlineService
 {
+    // TODO: Circular dependency - OutlineService ↔ AutoSaveService/BackupService ↔ OutlineViewModel ↔ OutlineService
+    // These services have a complex circular dependency that needs architectural refactoring
     private LogService _log = Ioc.Default.GetRequiredService<LogService>();
 
     /// <summary>

--- a/StoryCADLib/ViewModels/CharacterViewModel.cs
+++ b/StoryCADLib/ViewModels/CharacterViewModel.cs
@@ -20,7 +20,7 @@ public class CharacterViewModel : ObservableRecipient, INavigable
     public RelationshipModel CurrentRelationship;
     private bool _changeable; // process property changes for this story element
     private bool _changed;    // this story element has changed
-    readonly Windowing Windowing = Ioc.Default.GetService<Windowing>();
+    private readonly Windowing _windowing;
     private readonly OutlineViewModel _outlineViewModel;
     private readonly ShellViewModel _shellViewModel;
     #endregion
@@ -763,7 +763,7 @@ public class CharacterViewModel : ObservableRecipient, INavigable
             Content = new NewRelationshipPage(_vm),
             MinWidth = 200
         };
-        ContentDialogResult _result = await Windowing.ShowContentDialog(_NewRelDialog);
+        ContentDialogResult _result = await _windowing.ShowContentDialog(_NewRelDialog);
 
         if (_result == ContentDialogResult.Primary) //User clicks add relationship
         {
@@ -837,7 +837,7 @@ public class CharacterViewModel : ObservableRecipient, INavigable
             PrimaryButtonText = "Copy flaw example",
             CloseButtonText = "Cancel"
         };
-        ContentDialogResult _result = await Windowing.ShowContentDialog(_flawDialog);
+        ContentDialogResult _result = await _windowing.ShowContentDialog(_flawDialog);
 
         if (_result == ContentDialogResult.Primary)   // Copy to Character Flaw  
         {
@@ -862,7 +862,7 @@ public class CharacterViewModel : ObservableRecipient, INavigable
             CloseButtonText = "Cancel",
             Content = new Traits()
         };
-        ContentDialogResult _result = await Windowing.ShowContentDialog(_traitDialog);
+        ContentDialogResult _result = await _windowing.ShowContentDialog(_traitDialog);
 
         if (_result == ContentDialogResult.Primary)   // Copy to Character Trait 
         {
@@ -918,18 +918,12 @@ public class CharacterViewModel : ObservableRecipient, INavigable
     #region Constructors
 
     // Constructor for XAML compatibility - will be removed later
-    public CharacterViewModel() : this(
-        Ioc.Default.GetRequiredService<LogService>(),
-        Ioc.Default.GetRequiredService<OutlineViewModel>(),
-        Ioc.Default.GetRequiredService<ShellViewModel>())
-    {
-    }
-
-    public CharacterViewModel(LogService logger, OutlineViewModel outlineViewModel, ShellViewModel shellViewModel)
+    public CharacterViewModel(LogService logger, OutlineViewModel outlineViewModel, ShellViewModel shellViewModel, Windowing windowing)
     {
         _logger = logger;
         _outlineViewModel = outlineViewModel;
         _shellViewModel = shellViewModel;
+        _windowing = windowing;
 
         try
         {
@@ -968,7 +962,7 @@ public class CharacterViewModel : ObservableRecipient, INavigable
         catch (Exception e)
         {
             _logger.LogException(LogLevel.Fatal, e, "Error loading lists in Problem view model");
-            Windowing.ShowResourceErrorMessage();
+            _windowing.ShowResourceErrorMessage();
         }
 
         CharacterTraits = new ObservableCollection<string>();

--- a/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
+++ b/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
@@ -30,6 +30,7 @@ public class OutlineViewModel : ObservableRecipient
     private readonly OutlineService outlineService;
     private readonly SearchService searchService;
     private readonly AppState appState;
+    private readonly BackendService _backendService;
     // The reference to ShellViewModel is temporary
     // until the ShellViewModel is refactored to fully
     // use OutlineViewModel for outline methods.
@@ -547,8 +548,7 @@ public class OutlineViewModel : ObservableRecipient
                     await outlineService.WriteModel(StoryModel, StoryModelFile);
                 }
             }
-            BackendService backend = Ioc.Default.GetRequiredService<BackendService>();
-            await backend.DeleteWorkFile();
+            await _backendService.DeleteWorkFile();
             logger.Flush();
         }
         Application.Current.Exit();  // Win32
@@ -1350,14 +1350,16 @@ public class OutlineViewModel : ObservableRecipient
     #region Constructor(s)
 
     public OutlineViewModel(LogService logService, PreferenceService preferenceService,
-        Windowing windowing, OutlineService outlineService, AppState appState)
+        Windowing windowing, OutlineService outlineService, AppState appState,
+        SearchService searchService, BackendService backendService)
     {
         logger = logService;
         preferences = preferenceService;
         window = windowing;
         this.outlineService = outlineService;
         this.appState = appState;
-        searchService = Ioc.Default.GetRequiredService<SearchService>();
+        this.searchService = searchService;
+        _backendService = backendService;
     }
 
     #endregion

--- a/StoryCADLib/ViewModels/Tools/InitVM.cs
+++ b/StoryCADLib/ViewModels/Tools/InitVM.cs
@@ -12,7 +12,8 @@ namespace StoryCAD.ViewModels.Tools;
 /// </summary>
 public class InitVM : ObservableRecipient
 {
-    private readonly PreferenceService preference = Ioc.Default.GetService<PreferenceService>();
+    private readonly PreferenceService preference;
+    private readonly BackendService _backendService;
 
 
     /// <summary>
@@ -23,8 +24,10 @@ public class InitVM : ObservableRecipient
     /// For example this would give the following path for me
     /// C:\Users\Jake\Documents\StoryCAD\Projects
     /// </summary>
-    public InitVM()
+    public InitVM(PreferenceService preferenceService, BackendService backendService)
     {
+        preference = preferenceService;
+        _backendService = backendService;
         ProjectDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "StoryCAD", "Projects");
         BackupDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "StoryCAD", "Backups");
 
@@ -81,7 +84,6 @@ public class InitVM : ObservableRecipient
         PreferencesIo _prfIo = new();
         await _prfIo.WritePreferences(Preferences);
         await _prfIo.ReadPreferences();
-        BackendService _backend = Ioc.Default.GetRequiredService<BackendService>();
-        if (preference.Model.RecordPreferencesStatus) { await _backend.PostPreferences(preference.Model); }
+        if (preference.Model.RecordPreferencesStatus) { await _backendService.PostPreferences(preference.Model); }
     }
 }

--- a/StoryCADLib/ViewModels/Tools/PreferencesViewModel.cs
+++ b/StoryCADLib/ViewModels/Tools/PreferencesViewModel.cs
@@ -24,7 +24,12 @@ namespace StoryCAD.ViewModels.Tools;
 /// </summary>
 public class PreferencesViewModel : ObservableValidator
 {
-    public PreferencesModel CurrentModel = Ioc.Default.GetRequiredService<StoryCAD.Services.PreferenceService>().Model;
+    private readonly PreferenceService _preferenceService;
+    private readonly BackendService _backendService;
+    private readonly RatingService _ratingService;
+    private readonly Windowing _windowing;
+    
+    public PreferencesModel CurrentModel;
     public string Errors => string.Join(Environment.NewLine, from ValidationResult e in GetErrors(null) select e.ErrorMessage);
 
     #region Fields
@@ -261,8 +266,8 @@ public class PreferencesViewModel : ObservableValidator
 
         if (CurrentModel.ThemePreference != PreferedTheme)
         {
-            Ioc.Default.GetService<Windowing>().RequestedTheme = CurrentModel.ThemePreference;
-            Ioc.Default.GetService<Windowing>().UpdateUIToTheme();
+            _windowing.RequestedTheme = CurrentModel.ThemePreference;
+            _windowing.UpdateUIToTheme();
         }
         CurrentModel.ThemePreference = PreferedTheme;
         CurrentModel.ShowStartupDialog = ShowStartupPage;
@@ -276,13 +281,10 @@ public class PreferencesViewModel : ObservableValidator
         PreferencesIo _prfIo = new();
         await _prfIo.WritePreferences(CurrentModel);
         await _prfIo.ReadPreferences();
-        PreferenceService Prefs = Ioc.Default.GetService<PreferenceService>();
+        _preferenceService.Model = CurrentModel;
 
-		Prefs.Model = CurrentModel;
-
-        BackendService _backend = Ioc.Default.GetRequiredService<BackendService>();
-        Prefs.Model.RecordPreferencesStatus = false;  // indicate need to update
-        await _backend.PostPreferences(Prefs.Model);
+        _preferenceService.Model.RecordPreferencesStatus = false;  // indicate need to update
+        await _backendService.PostPreferences(_preferenceService.Model);
     }
 
     private void OnPropertyChanged(object sender, PropertyChangedEventArgs args)
@@ -300,15 +302,21 @@ public class PreferencesViewModel : ObservableValidator
 	/// </summary>
     public void ShowRatingPrompt(object sender, RoutedEventArgs e)
     {
-	    Ioc.Default.GetService<RatingService>().OpenRatingPrompt();
+	    _ratingService.OpenRatingPrompt();
     }
 
 	#endregion
 
 	#region Constructor
 
-	public PreferencesViewModel()
+	public PreferencesViewModel(PreferenceService preferenceService, BackendService backendService,
+        RatingService ratingService, Windowing windowing)
     {
+        _preferenceService = preferenceService;
+        _backendService = backendService;
+        _ratingService = ratingService;
+        _windowing = windowing;
+        CurrentModel = _preferenceService.Model;
         this.ErrorsChanged += Preferences_ErrorsChanged;
     }
 


### PR DESCRIPTION
## Summary
- Apply the IOC → Constructor Injection Playbook to: BackendService, Windowing (partial), AutoSaveService, BackupService
- No lifetime changes (Singletons). No behavior changes.

## Changes
- **BackendService**: Fully converted in non-App.xaml.cs files
  - OutlineViewModel: Added BackendService via constructor injection
  - InitVM: Added BackendService and PreferenceService via constructor injection
  - PreferencesViewModel: Added BackendService, PreferenceService, RatingService, and Windowing via constructor injection
  
- **AutoSaveService & BackupService**: 
  - Removed obsolete parameterless constructors (DI container handles resolution)
  - Added Windowing injection to BackupService
  - Documented circular dependencies with TODOs

- **Windowing** (partial conversion):
  - CharacterViewModel: Converted from service locator to constructor injection
  - BackupService: Added Windowing for GlobalDispatcher access
  - Many files remain for future batches (33 non-View files)

## Circular Dependencies Documented
- AutoSaveService ↔ BackupService (via SerializationLock)
- OutlineService ↔ AutoSaveService/BackupService ↔ OutlineViewModel
- These require architectural refactoring (interface extraction, messaging, etc.) tracked for future work

## Verification
- Build: Successful (only nullable warnings)
- Tests: 340 passed, 5 skipped, 0 failed
- Smoke test: Passed
- Grep gates: BackendService fully clean (excluding App.xaml.cs and tests)

## Notes
- App.xaml.cs unchanged (application entry point, needs service locator)
- View files (Views/*.xaml.cs) skipped per playbook
- Full Windowing conversion incomplete due to extensive usage - needs future batches

**Link:** #1063