### PR TITLE
Catch situation model being empty

### DIFF
--- a/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
+++ b/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
@@ -11,6 +11,7 @@ using CommunityToolkit.Mvvm.Messaging;
 using StoryCAD.DAL;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
+using NLog;
 using StoryCAD.Services.Backend;
 using StoryCAD.Services.Dialogs;
 using StoryCAD.Services.Dialogs.Tools;
@@ -19,6 +20,7 @@ using StoryCAD.Models.Tools;
 using StoryCAD.Services.Reports;
 using StoryCAD.Services.Search;
 using StoryCAD.Services.Locking;
+using LogLevel = StoryCAD.Services.Logging.LogLevel;
 
 namespace StoryCAD.ViewModels.SubViewModels;
 
@@ -846,6 +848,11 @@ public class OutlineViewModel : ObservableRecipient
 
                 if (result == ContentDialogResult.Primary)
                 {
+                    if (situationModel == null)
+                    {
+                        logger.Log(LogLevel.Warn, "No Situation selected.");
+                        return;
+                    }
                     ProblemModel problem = new(situationModel.SituationName, appState.CurrentDocument.Model, shellVm.RightTappedNode)
                     {
                         Description = "See Notes.",
@@ -858,6 +865,11 @@ public class OutlineViewModel : ObservableRecipient
                 }
                 else if (result == ContentDialogResult.Secondary)
                 {
+                    if (situationModel == null)
+                    {
+                        logger.Log(LogLevel.Warn, "No Situation selected.");
+                        return;
+                    }
                     SceneModel sceneVar = new(situationModel.SituationName, appState.CurrentDocument.Model, shellVm.RightTappedNode)
                     {
                         Description = "See Notes.",

--- a/StoryCADTests/OutlineViewModelTests.cs
+++ b/StoryCADTests/OutlineViewModelTests.cs
@@ -357,6 +357,26 @@ namespace StoryCADTests
         }
 
         [TestMethod]
+        public async Task DramaticSituationsTool_WithNullSituation_DoesNotCreateElements()
+        {
+            var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+            var appState = Ioc.Default.GetRequiredService<AppState>();
+            var model = await outlineService.CreateModel("NullSituation", "StoryBuilder", 0);
+            appState.CurrentDocument = new StoryDocument(model, null);
+            outlineService.SetCurrentView(appState.CurrentDocument.Model, StoryViewType.ExplorerView);
+            shell.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
+            
+            var vm = Ioc.Default.GetRequiredService<DramaticSituationsViewModel>();
+            vm.Situation = null;  // Set Situation directly to null, not SituationName
+            
+            int countBefore = appState.CurrentDocument.Model.StoryElements.Count;
+            await outlineVM.DramaticSituationsTool();
+            int countAfter = appState.CurrentDocument.Model.StoryElements.Count;
+            
+            Assert.AreEqual(countBefore, countAfter, "No elements should be created when situation is null");
+        }
+
+        [TestMethod]
         public async Task TestStockScenesTool()
         {
             //Create outline


### PR DESCRIPTION
This PR fixes an issue where stock scenes is null would crash.