### PR TITLE
Add Draft mode to Build/Release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,6 +19,11 @@ on:
         description: 'Tag / version (e.g. v4.0.0)'
         required: true
         type: string
+      skip_release:
+        description: 'Skip creating a release (build only)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -252,7 +257,7 @@ jobs:
 
   release:
     needs: build
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && !inputs.skip_release
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This PR adds a way to invoke the build pipeline without actually creating a release for point testing.