### PR TITLE
Update change tracking.

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -121,6 +121,20 @@ jobs:
           $xml.Save($manifestPath)
           Write-Host "Updated manifest version to ${{ steps.version.outputs.version }}"
 
+      - name: Update StoryCADLib.csproj version
+        shell: pwsh
+        run: |
+          $csprojPath = Join-Path "${{ github.workspace }}" "StoryCADLib\StoryCADLib.csproj"
+          [xml]$xml = Get-Content $csprojPath
+          $versionNode = $xml.SelectSingleNode('//Version')
+          $assemblyVersionNode = $xml.SelectSingleNode('//AssemblyVersion')
+          $fileVersionNode = $xml.SelectSingleNode('//FileVersion')
+          if ($versionNode) { $versionNode.InnerText = '${{ steps.version.outputs.version }}' }
+          if ($assemblyVersionNode) { $assemblyVersionNode.InnerText = '${{ steps.version.outputs.version }}' }
+          if ($fileVersionNode) { $fileVersionNode.InnerText = '${{ steps.version.outputs.version }}' }
+          $xml.Save($csprojPath)
+          Write-Host "Updated StoryCADLib.csproj version to ${{ steps.version.outputs.version }}"
+
       - name: Decode real PFX and write .env (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh

--- a/StoryCADLib/StoryCADLib.csproj
+++ b/StoryCADLib/StoryCADLib.csproj
@@ -8,6 +8,11 @@
         <GenerateLibraryLayout>true</GenerateLibraryLayout>
         <ImplicitUsings>enable</ImplicitUsings>
         <Platforms>AnyCPU;x64</Platforms>
+
+        <!-- Version Information -->
+        <Version>4.0.0</Version>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+        <FileVersion>4.0.0.0</FileVersion>
         <!--
       UnoFeatures let's you quickly add and manage implicit package references based on the features you want to use.
       https://aka.platform.uno/singleproject-features


### PR DESCRIPTION
This PR updates version tracking.
Somewhere in development of StoryCAD UNO version tracking was switched from the APPXManifest to StoryCADLib but the version was not properly updated via autobuild, this fixes this oversight by manually specifying a version tag in StoryCADLib which can be manually updated and adding a step to the build/release action to fix this.