### PR TITLE
Fix change indicator going red when navigating between nodes.

### DIFF
--- a/.claude/docs/architecture/StoryCAD_architecture_notes.md
+++ b/.claude/docs/architecture/StoryCAD_architecture_notes.md
@@ -186,17 +186,6 @@ ManualTest/docs/
 
 **Note**: StoryCAD has a public API (SemanticKernelAPI) that external tools can use
 
----
-
-#### 7. storybuilder-miscellaneous
-- **GitHub**: [github.com/storybuilder-org/storybuilder-miscellaneous](https://github.com/storybuilder-org/storybuilder-miscellaneous)
-- **Local Path**: `/mnt/d/dev/src/storybuilder-miscellaneous/`
-- **Visibility**: Private
-- **Purpose**: Private repository for sysadmin material, secrets, archived docs
-- **Content**: Confidential/administrative material
-- **Usage**: Archive location for closed issue documentation from `devdocs/`
-
----
 
 ### Repository Relationships
 
@@ -247,7 +236,7 @@ API-Samples
 2. Build CollaboratorLib.dll
 3. Set `STORYCAD_PLUGIN_DIR` environment variable
 4. StoryCAD loads plugin at runtime
-
+[StoryCAD.2025-11-18.log](../../../../../../Downloads/StoryCAD.2025-11-18.log)
 #### Writing Documentation
 **For End Users**:
 - Repository: `ManualTest`
@@ -297,7 +286,6 @@ API-Samples
 | StoryCAD-Legacy-STBX-Conversion-Tool | https://github.com/storybuilder-org/StoryCAD-Legacy-STBX-Conversion-Tool | Public |
 | NRTFTree-Async | https://github.com/storybuilder-org/NRTFTree-Async | Public |
 | API-Samples | https://github.com/storybuilder-org/API-Samples | Private |
-| storybuilder-miscellaneous | https://github.com/storybuilder-org/storybuilder-miscellaneous | Private |
 
 ---
 

--- a/.claude/repos.md
+++ b/.claude/repos.md
@@ -68,11 +68,6 @@ This document maps the repositories in the development environment. Each reposit
 
 ## Other Repositories
 
-### storybuilder-miscellaneous
-- **Path**: `/mnt/d/dev/src/storybuilder-miscellaneous/`
-- **README**: [README.md](/mnt/d/dev/src/storybuilder-miscellaneous/README.md)
-- **Summary**: Private repo with sysadmin material for StoryBuilder (confidential)
-
 ### openai
 - **Path**: `/mnt/d/dev/src/openai/`
 - **README**: [README.md](/mnt/d/dev/src/openai/README.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,3 +448,4 @@ git commit -m "message"
 - Watch for circular dependencies when adding constructor parameters
 - If encountered, document with TODO and leave specific Ioc.Default calls rather than forcing bad design
 - Example: Windowing ↔ OutlineViewModel (documented in /home/tcox/.claude/memory/architecture.md)
+- Do not memorise or document any information about Storybuilder-miscellaneous in the StoryCAD Repo.

--- a/StoryCAD.sln.DotSettings
+++ b/StoryCAD.sln.DotSettings
@@ -2,6 +2,8 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IOC/@EntryIndexedValue">IOC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=VM/@EntryIndexedValue">VM</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=antag/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=beatsheet/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=evergreenbootstrapper/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Masterplots/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=prefs/@EntryIndexedValue">True</s:Boolean>

--- a/StoryCADLib/ViewModels/CharacterViewModel.cs
+++ b/StoryCADLib/ViewModels/CharacterViewModel.cs
@@ -516,6 +516,8 @@ public class CharacterViewModel : ObservableRecipient, INavigable, ISaveable
 
     public void Activate(object parameter)
     {
+        _changeable = false;  // Disable change tracking before setting Model
+        _changed = false;
         Model = (CharacterModel)parameter;
         LoadModel(); // Load the ViewModel from the Story
     }
@@ -543,6 +545,10 @@ public class CharacterViewModel : ObservableRecipient, INavigable, ISaveable
 
     private void OnPropertyChanged(object sender, PropertyChangedEventArgs args)
     {
+        // Ignore Model property changes - these happen during navigation, not user edits
+        if (args.PropertyName == nameof(Model))
+            return;
+
         if (_changeable)
         {
             if (!_changed)

--- a/StoryCADLib/ViewModels/FolderViewModel.cs
+++ b/StoryCADLib/ViewModels/FolderViewModel.cs
@@ -89,6 +89,8 @@ public class FolderViewModel : ObservableRecipient, INavigable, ISaveable
 
     public void Activate(object parameter)
     {
+        _changeable = false;  // Disable change tracking before setting Model
+        _changed = false;
         Model = (FolderModel)parameter;
         LoadModel(); // Load the ViewModel from the Story
     }
@@ -100,6 +102,10 @@ public class FolderViewModel : ObservableRecipient, INavigable, ISaveable
 
     private void OnPropertyChanged(object sender, PropertyChangedEventArgs args)
     {
+        // Ignore Model property changes - these happen during navigation, not user edits
+        if (args.PropertyName == nameof(Model))
+            return;
+
         if (_changeable)
         {
             if (!_changed)

--- a/StoryCADLib/ViewModels/OverviewViewModel.cs
+++ b/StoryCADLib/ViewModels/OverviewViewModel.cs
@@ -289,6 +289,8 @@ public class OverviewViewModel : ObservableRecipient, INavigable, ISaveable
 
     public void Activate(object parameter)
     {
+        _changeable = false;  // Disable change tracking before setting Model
+        _changed = false;
         Model = (OverviewModel)parameter;
         LoadModel();
     }
@@ -300,6 +302,10 @@ public class OverviewViewModel : ObservableRecipient, INavigable, ISaveable
 
     private void OnPropertyChanged(object sender, PropertyChangedEventArgs args)
     {
+        // Ignore Model property changes - these happen during navigation, not user edits
+        if (args.PropertyName == nameof(Model))
+            return;
+
         if (_changeable)
         {
             if (!_changed)
@@ -330,7 +336,6 @@ public class OverviewViewModel : ObservableRecipient, INavigable, ISaveable
         StoryGenre = Model.StoryGenre;
         Viewpoint = Model.Viewpoint;
         ViewpointCharacter = Model.ViewpointCharacter;
-        SelectedViewpointCharacter = Characters.FirstOrDefault(p => p.Uuid == ViewpointCharacter);
         Voice = Model.Voice;
         LiteraryTechnique = Model.LiteraryDevice;
         Tense = Model.Tense;
@@ -338,8 +343,6 @@ public class OverviewViewModel : ObservableRecipient, INavigable, ISaveable
         Tone = Model.Tone;
         Style = Model.Style;
         StoryProblem = Model.StoryProblem;
-        // Set SelectedProblem based on StoryProblem GUID
-        SelectedProblem = Problems.FirstOrDefault(p => p.Uuid == StoryProblem);
         Description = Model.Description;
         Concept = Model.Concept;
         Premise = Model.Premise;
@@ -347,6 +350,14 @@ public class OverviewViewModel : ObservableRecipient, INavigable, ISaveable
         Notes = Model.Notes;
 
         _changeable = true;
+
+        // Set UI-bound selection properties after enabling change tracking
+        // These can trigger property cascades from UI binding updates
+        var wasChangeable = _changeable;
+        _changeable = false;
+        SelectedViewpointCharacter = Characters.FirstOrDefault(p => p.Uuid == ViewpointCharacter);
+        SelectedProblem = Problems.FirstOrDefault(p => p.Uuid == StoryProblem);
+        _changeable = wasChangeable;
     }
 
     public void SaveModel()

--- a/StoryCADLib/ViewModels/ProblemViewModel.cs
+++ b/StoryCADLib/ViewModels/ProblemViewModel.cs
@@ -75,7 +75,7 @@ public class ProblemViewModel : ObservableRecipient, INavigable, ISaveable
     #endregion
 
     /// <summary>
-    ///     Creates a new story beat.
+    /// Creates a new story beat.
     /// </summary>
     public void CreateBeat(object sender, RoutedEventArgs e)
     {
@@ -83,7 +83,7 @@ public class ProblemViewModel : ObservableRecipient, INavigable, ISaveable
     }
 
     /// <summary>
-    ///     Deletes this beat
+    /// Deletes this beat
     /// </summary>
     public void DeleteBeat(object sender, RoutedEventArgs e)
     {
@@ -700,6 +700,8 @@ public class ProblemViewModel : ObservableRecipient, INavigable, ISaveable
 
     public void Activate(object parameter)
     {
+        _changeable = false;  // Disable change tracking before setting Model
+        _changed = false;
         Model = (ProblemModel)parameter;
         LoadModel();
     }
@@ -715,6 +717,10 @@ public class ProblemViewModel : ObservableRecipient, INavigable, ISaveable
 
     public void OnPropertyChanged(object sender, PropertyChangedEventArgs args)
     {
+        // Ignore Model property changes - these happen during navigation, not user edits
+        if (args.PropertyName == nameof(Model))
+            return;
+
         if (_changeable)
         {
             if (!_changed)
@@ -746,12 +752,10 @@ public class ProblemViewModel : ObservableRecipient, INavigable, ISaveable
         Description = Model.Description;
         ProblemSource = Model.ProblemSource;
         Protagonist = Model.Protagonist;
-        SelectedProtagonist = Characters.FirstOrDefault(p => p.Uuid == Protagonist);
         ProtGoal = Model.ProtGoal;
         ProtMotive = Model.ProtMotive;
         ProtConflict = Model.ProtConflict;
         Antagonist = Model.Antagonist;
-        SelectedAntagonist = Characters.FirstOrDefault(p => p.Uuid == Antagonist);
         AntagGoal = Model.AntagGoal;
         AntagMotive = Model.AntagMotive;
         AntagConflict = Model.AntagConflict;
@@ -798,6 +802,14 @@ public class ProblemViewModel : ObservableRecipient, INavigable, ISaveable
         }
 
         _changeable = true;
+
+        // Set UI-bound selection properties after enabling change tracking
+        // These can trigger property cascades from UI binding updates
+        var wasChangeable = _changeable;
+        _changeable = false;
+        SelectedProtagonist = Characters.FirstOrDefault(p => p.Uuid == Protagonist);
+        SelectedAntagonist = Characters.FirstOrDefault(p => p.Uuid == Antagonist);
+        _changeable = wasChangeable;
     }
 
     public void SaveModel()

--- a/StoryCADLib/ViewModels/SettingViewModel.cs
+++ b/StoryCADLib/ViewModels/SettingViewModel.cs
@@ -184,6 +184,8 @@ public class SettingViewModel : ObservableRecipient, INavigable, ISaveable
 
     public void Activate(object parameter)
     {
+        _changeable = false;  // Disable change tracking before setting Model
+        _changed = false;
         Model = (SettingModel)parameter;
         LoadModel();
     }
@@ -195,6 +197,10 @@ public class SettingViewModel : ObservableRecipient, INavigable, ISaveable
 
     private void OnPropertyChanged(object sender, PropertyChangedEventArgs args)
     {
+        // Ignore Model property changes - these happen during navigation, not user edits
+        if (args.PropertyName == nameof(Model))
+            return;
+
         if (_changeable)
         {
             if (!_changed)

--- a/StoryCADLib/ViewModels/WebViewModel.cs
+++ b/StoryCADLib/ViewModels/WebViewModel.cs
@@ -43,6 +43,8 @@ public class WebViewModel : ObservableRecipient, INavigable, ISaveable
 
     public void Activate(object parameter)
     {
+        _changeable = false;  // Disable change tracking before setting Model
+        _changed = false;
         Model = (WebModel)parameter;
         LoadModel();
     }
@@ -69,6 +71,10 @@ public class WebViewModel : ObservableRecipient, INavigable, ISaveable
 
     private void OnPropertyChanged(object sender, PropertyChangedEventArgs args)
     {
+        // Ignore Model property changes - these happen during navigation, not user edits
+        if (args.PropertyName == nameof(Model))
+            return;
+
         if (_changeable)
         {
             if (!_changed)


### PR DESCRIPTION
This PR blocks the change flag from being updated between navigation and from being fired by the model property in a VM.