### PR TITLE
Flyout fix

### DIFF
--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -20,41 +20,42 @@
 
             <CommandBarFlyout x:Key="AddStoryElementFlyout" Placement="Right">
                 <CommandBarFlyout.SecondaryCommands>
-                    <AppBarButton Icon="Add" Label="Add Elements">
+                    <AppBarButton Icon="Add" Label="Add Elements"
+                                  Visibility="{x:Bind ShellVm.AddButtonVisibility, Mode=OneWay}">
                         <AppBarButton.Flyout>
                             <MenuFlyout>
                                 <MenuFlyoutItem Icon="Folder"
                                                 Command="{x:Bind ShellVm.AddFolderCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
-                                                Text="Add Folder         Alt+F" />
+                                                win:Text="Add Folder         Alt+F" skia:Text="Add Folder         ⌥F" />
                                 <MenuFlyoutItem Icon="Folder"
                                                 Command="{x:Bind ShellVm.AddSectionCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.NarratorVisibility, Mode=OneWay}"
-                                                Text="Add Section        Alt+A" />
+                                                win:Text="Add Section        Alt+A" skia:Text="Add Section        ⌥A" />
                                 <MenuFlyoutItem Icon="Help"
                                                 Command="{x:Bind ShellVm.AddProblemCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
-                                                Text="Add Problem      Alt+P" />
+                                                win:Text="Add Problem      Alt+P" skia:Text="Add Problem      ⌥P" />
                                 <MenuFlyoutItem Icon="Contact"
                                                 Command="{x:Bind ShellVm.AddCharacterCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
-                                                Text="Add Character    Alt+C" />
+                                                win:Text="Add Character    Alt+C" skia:Text="Add Character    ⌥C" />
                                 <MenuFlyoutItem Icon="Globe"
                                                 Command="{x:Bind ShellVm.AddSettingCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
-                                                Text="Add Setting        Alt+L" />
+                                                win:Text="Add Setting        Alt+L" skia:Text="Add Setting        ⌥L" />
                                 <MenuFlyoutItem Icon="AllApps"
                                                 Command="{x:Bind ShellVm.AddSceneCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
-                                                Text="Add Scene          Alt+S" />
+                                                win:Text="Add Scene          Alt+S" skia:Text="Add Scene          ⌥S" />
                                 <MenuFlyoutItem Icon="TwoPage"
                                                 Command="{x:Bind ShellVm.AddNotesCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
-                                                Text="Add Notes          Alt+N" />
+                                                win:Text="Add Notes          Alt+N" skia:Text="Add Notes          ⌥N" />
                                 <MenuFlyoutItem Icon="PreviewLink"
                                                 Command="{x:Bind ShellVm.AddWebCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
-                                                Text="Add Website      Alt+W" />
+                                                win:Text="Add Website      Alt+W" skia:Text="Add Website      ⌥W" />
                             </MenuFlyout>
                         </AppBarButton.Flyout>
                     </AppBarButton>
@@ -159,22 +160,22 @@
                               Width="50">
                     <AppBarButton.Flyout>
                         <MenuFlyout>
-                            <MenuFlyoutItem Text="Open/Create file                Ctrl+O" Command="{x:Bind ShellVm.OpenFileOpenMenuCommand}">
+                            <MenuFlyoutItem win:Text="Open/Create file                Ctrl+O" skia:Text="Open/Create file                ⌘O" Command="{x:Bind ShellVm.OpenFileOpenMenuCommand}">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8F4;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Text="Save Story                      Ctrl+S" Command="{x:Bind ShellVm.SaveFileCommand, Mode=OneWay}">
+                            <MenuFlyoutItem win:Text="Save Story                      Ctrl+S" skia:Text="Save Story                      ⌘S" Command="{x:Bind ShellVm.SaveFileCommand, Mode=OneWay}">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE74E;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Text="Save Story As                   Ctrl+Shift+S" Command="{x:Bind ShellVm.SaveAsCommand, Mode=OneWay}">
+                            <MenuFlyoutItem win:Text="Save Story As                   Ctrl+Shift+S" skia:Text="Save Story As                   ⇧⌘S" Command="{x:Bind ShellVm.SaveAsCommand, Mode=OneWay}">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE792;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Text="Create Backup                   Ctrl+B"
+                            <MenuFlyoutItem win:Text="Create Backup                   Ctrl+B" skia:Text="Create Backup                   ⌘B"
                                             Command="{x:Bind ShellVm.CreateBackupCommand, Mode=OneWay}">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xe838;" />
@@ -185,7 +186,7 @@
                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE127;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Text="Exit                     Ctrl+Q" Command="{x:Bind ShellVm.ExitCommand, Mode=OneWay}">
+                            <MenuFlyoutItem win:Text="Exit                            Ctrl+Q" skia:Text="Quit                            ⌘Q" Command="{x:Bind ShellVm.ExitCommand, Mode=OneWay}">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE106;" />
                                 </MenuFlyoutItem.Icon>
@@ -202,38 +203,38 @@
                         <MenuFlyout>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddFolderCommand, Mode=OneWay}" Icon="Folder"
-                                            Text="Add folder         Alt+F">
+                                            win:Text="Add folder         Alt+F" skia:Text="Add folder         ⌥F">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.NarratorVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddSectionCommand, Mode=OneWay}" Icon="Folder"
-                                            Text="Add section        Alt+A">
+                                            win:Text="Add section        Alt+A" skia:Text="Add section        ⌥A">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddProblemCommand, Mode=OneWay}" Icon="Help"
-                                            Text="Add problem      Alt+P">
+                                            win:Text="Add problem      Alt+P" skia:Text="Add problem      ⌥P">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddCharacterCommand, Mode=OneWay}" Icon="Contact"
-                                            Text="Add character    Alt+C">
+                                            win:Text="Add character    Alt+C" skia:Text="Add character    ⌥C">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddSettingCommand, Mode=OneWay}" Icon="Globe"
-                                            Text="Add setting        Alt+L">
+                                            win:Text="Add setting        Alt+L" skia:Text="Add setting        ⌥L">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddSceneCommand, Mode=OneWay}" Icon="AllApps"
-                                            Text="Add scene          Alt+S">
+                                            win:Text="Add scene          Alt+S" skia:Text="Add scene          ⌥S">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddWebCommand, Mode=OneWay}"
-                                            Text="Add Web node     Alt+W">
+                                            win:Text="Add Web node     Alt+W" skia:Text="Add Web node     ⌥W">
                                 <MenuFlyoutItem.Icon>
                                     <SymbolIcon Symbol="PreviewLink" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddNotesCommand,Mode=OneWay}"
-                                            Text="Add Notes node   Alt+N">
+                                            win:Text="Add Notes node   Alt+N" skia:Text="Add Notes node   ⌥N">
                                 <MenuFlyoutItem.Icon>
                                     <SymbolIcon Symbol="TwoPage" />
                                 </MenuFlyoutItem.Icon>
@@ -312,7 +313,7 @@
                     </AppBarButton.Icon>
                     <AppBarButton.Flyout>
                         <MenuFlyout>
-                            <MenuFlyoutItem Text="Open Narrative Editor         Ctrl+N"
+                            <MenuFlyoutItem win:Text="Open Narrative Editor         Ctrl+N" skia:Text="Open Narrative Editor         ⌘N"
                                             Command="{x:Bind ShellVm.NarrativeToolCommand, Mode=OneWay}"
                                             muxc:ToolTipService.ToolTip="Opens the narrative editor to build your story as its told">
                             </MenuFlyoutItem>
@@ -322,13 +323,13 @@
                             <MenuFlyoutItem Text="Topic Information"
                                             Command="{x:Bind ShellVm.TopicsCommand, Mode=OneWay}" />
                             <MenuFlyoutSubItem Text="Plotting Aids">
-                                <MenuFlyoutItem Text="Master Plots                Ctrl+M"
+                                <MenuFlyoutItem win:Text="Master Plots                Ctrl+M" skia:Text="Master Plots                ⌘M"
                                                 Command="{x:Bind ShellVm.MasterPlotsCommand, Mode=OneWay}">
                                 </MenuFlyoutItem>
-                                <MenuFlyoutItem Text="Dramatic Situations         Ctrl+D"
+                                <MenuFlyoutItem win:Text="Dramatic Situations         Ctrl+D" skia:Text="Dramatic Situations         ⌘D"
                                                 Command="{x:Bind ShellVm.DramaticSituationsCommand, Mode=OneWay}">
                                 </MenuFlyoutItem>
-                                <MenuFlyoutItem Text="Stock Scenes                Ctrl+L"
+                                <MenuFlyoutItem win:Text="Stock Scenes                Ctrl+L" skia:Text="Stock Scenes                ⌘L"
                                                 Command="{x:Bind ShellVm.StockScenesCommand, Mode=OneWay}">
                                 </MenuFlyoutItem>
                             </MenuFlyoutSubItem>
@@ -346,17 +347,17 @@
                                             win:Visibility="Visible" notwin:Visibility="Collapsed"
                                             skia:Visibility="Collapsed">
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Text="PDF Reports                     Ctrl+Shift+P"
+                            <MenuFlyoutItem win:Text="PDF Reports                     Ctrl+Shift+P" skia:Text="PDF Reports                     ⇧⌘P"
                                             Command="{x:Bind ShellVm.ExportReportsToPdfCommand, Mode=OneWay}">
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Text="Scrivener Reports               Ctrl+R"
+                            <MenuFlyoutItem win:Text="Scrivener Reports               Ctrl+R" skia:Text="Scrivener Reports               ⌘R"
                                             Command="{x:Bind ShellVm.ScrivenerReportsCommand, Mode=OneWay}">
                             </MenuFlyoutItem>
 
                         </MenuFlyout>
                     </AppBarButton.Flyout>
                 </AppBarButton>
-                <AppBarButton Width="50" IsCompact="True" Label="Preferences" ToolTipService.ToolTip="Preferences (Ctrl+P on macOS)"
+                <AppBarButton Width="50" IsCompact="True" Label="Preferences" win:ToolTipService.ToolTip="Preferences" skia:ToolTipService.ToolTip="Preferences (⌘P)"
                               Command="{x:Bind ShellVm.PreferencesCommand, Mode=OneWay}">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE713;" />
@@ -513,7 +514,7 @@
                     <SymbolIcon Symbol="Edit" Height="36"
                                 ToolTipService.ToolTip="This icon becomes red when you've made changes that haven't been saved yet.">
                         <SymbolIcon.Foreground>
-                            <SolidColorBrush Color="{x:Bind ShellVm.ChangeStatusColor, Mode=TwoWay}" />
+                            <SolidColorBrush Color="{x:Bind ShellVm.ChangeStatusColor, Mode=OneWay}" />
                         </SymbolIcon.Foreground>
                     </SymbolIcon>
                 </Button.Content>
@@ -526,7 +527,7 @@
                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE74E;" Height="36"
                               ToolTipService.ToolTip="This icon is green when AutoSave is active and working.">
                         <FontIcon.Foreground>
-                            <SolidColorBrush Color="{x:Bind ShellVm.AutosaveStatusColor, Mode=TwoWay}" />
+                            <SolidColorBrush Color="{x:Bind ShellVm.AutosaveStatusColor, Mode=OneWay}" />
                         </FontIcon.Foreground>
                     </FontIcon>
                 </Button.Content>
@@ -538,7 +539,7 @@
                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE777;" Height="36"
                               ToolTipService.ToolTip="This icon is green when you or StoryCAD has recently made a backup of your work.">
                         <FontIcon.Foreground>
-                            <SolidColorBrush Color="{x:Bind ShellVm.BackupStatusColor, Mode=TwoWay}" />
+                            <SolidColorBrush Color="{x:Bind ShellVm.BackupStatusColor, Mode=OneWay}" />
                         </FontIcon.Foreground>
                     </FontIcon>
                 </Button.Content>

--- a/StoryCAD/Views/Shell.xaml.cs
+++ b/StoryCAD/Views/Shell.xaml.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.System;
 using Windows.UI.ViewManagement;
@@ -150,9 +149,6 @@ public sealed partial class Shell : Page
             Windowing.MainWindow.AppWindow.Closing += OnMainWindowClosing;
         }
 
-        // Update keyboard hints for macOS (only updates context flyout)
-        // Done after all initialization to avoid flyout state issues
-        UpdateKeyboardHints();
     }
 
     /// <summary>
@@ -571,79 +567,4 @@ public sealed partial class Shell : Page
             Logger?.LogException(LogLevel.Error, ex, "Error handling keyboard shortcut");
         }
     }
-
-    /// <summary>
-    /// Updates keyboard hint text to use platform-specific symbols (⌘ and ⌥ on macOS, Ctrl+ and Alt+ elsewhere)
-    /// Called once during initialization.
-    /// </summary>
-    private void UpdateKeyboardHints()
-    {
-        // Only update on macOS - use runtime OS detection
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            return;
-
-        // On macOS, replace keyboard shortcuts with macOS symbols
-        // Update context flyout (used for right-click)
-        if (Resources["AddStoryElementFlyout"] is CommandBarFlyout contextFlyout)
-        {
-            UpdateMenuFlyoutItems(contextFlyout);
-        }
-
-        // Update main menu flyouts in CommandBar
-        if (Content is Grid grid && grid.Children.Count > 0 && grid.Children[0] is CommandBar commandBar)
-        {
-            foreach (var command in commandBar.PrimaryCommands.OfType<AppBarButton>())
-            {
-                if (command.Flyout is MenuFlyout menuFlyout)
-                {
-                    UpdateMenuFlyoutItems(menuFlyout);
-                }
-            }
-        }
-    }
-
-    private void UpdateMenuFlyoutItems(CommandBarFlyout flyout)
-    {
-        if (flyout?.SecondaryCommands == null) return;
-
-        foreach (var command in flyout.SecondaryCommands.OfType<AppBarButton>())
-        {
-            if (command.Flyout is MenuFlyout menuFlyout)
-            {
-                UpdateMenuFlyoutItems(menuFlyout);
-            }
-        }
-    }
-
-    private void UpdateMenuFlyoutItems(MenuFlyout menuFlyout)
-    {
-        if (menuFlyout?.Items == null) return;
-
-        foreach (var item in menuFlyout.Items.OfType<MenuFlyoutItem>())
-        {
-            if (!string.IsNullOrEmpty(item.Text))
-            {
-                // Replace keyboard shortcuts with macOS symbols
-                // Order matters: replace compound keys first
-                item.Text = item.Text.Replace("Ctrl+Shift+", "⇧+⌘+");
-                item.Text = item.Text.Replace("Ctrl+", "⌘+");
-                item.Text = item.Text.Replace("Alt+", "⌥+");
-            }
-        }
-
-        // Also check for nested MenuFlyoutSubItem
-        foreach (var subItem in menuFlyout.Items.OfType<MenuFlyoutSubItem>())
-        {
-            foreach (var item in subItem.Items.OfType<MenuFlyoutItem>())
-            {
-                if (!string.IsNullOrEmpty(item.Text))
-                {
-                    item.Text = item.Text.Replace("Ctrl+Shift+", "⇧+⌘+");
-                    item.Text = item.Text.Replace("Ctrl+", "⌘+");
-                    item.Text = item.Text.Replace("Alt+", "⌥+");
-                }
-            }
-        }
-    }
-
 }

--- a/StoryCADLib/Services/Dialogs/FileOpenMenu.xaml
+++ b/StoryCADLib/Services/Dialogs/FileOpenMenu.xaml
@@ -77,7 +77,7 @@
             <ScrollView Grid.Row="2" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Auto" BorderThickness="0" Background="Transparent">
                 <Grid Background="Transparent" BorderThickness="0">
                     <!-- Recents tab -->
-                    <Grid Visibility="{x:Bind FileOpenVM.RecentsTabContentVisibility, Mode=TwoWay}">
+                    <Grid Visibility="{x:Bind FileOpenVM.RecentsTabContentVisibility, Mode=OneWay}">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
@@ -96,7 +96,7 @@
                     </Grid>
 
                     <!-- Backups tab -->
-                    <Grid Visibility="{x:Bind FileOpenVM.BackupTabContentVisibility, Mode=TwoWay}">
+                    <Grid Visibility="{x:Bind FileOpenVM.BackupTabContentVisibility, Mode=OneWay}">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
@@ -109,7 +109,7 @@
                     </Grid>
 
                     <!-- New tab -->
-                    <Grid Visibility="{x:Bind FileOpenVM.NewTabContentVisibility, Mode=TwoWay}">
+                    <Grid Visibility="{x:Bind FileOpenVM.NewTabContentVisibility, Mode=OneWay}">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
@@ -134,7 +134,7 @@
                     </Grid>
 
                     <!-- Samples tab -->
-                    <Grid Visibility="{x:Bind FileOpenVM.SamplesTabContentVisibility, Mode=TwoWay}">
+                    <Grid Visibility="{x:Bind FileOpenVM.SamplesTabContentVisibility, Mode=OneWay}">
                         <ListView HorizontalAlignment="Stretch" VerticalAlignment="Center"
                                   ItemsSource="{x:Bind FileOpenVM.SampleNames}" CornerRadius="4"
                                   SelectedIndex="{x:Bind FileOpenVM.SelectedSampleIndex, Mode=TwoWay}" />

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -279,7 +279,6 @@ public class ShellViewModel : ObservableRecipient
                 NarratorVisibility = Visibility.Collapsed;
                 AddButtonVisibility = Visibility.Collapsed;
                 PrintNodeVisibility = Visibility.Collapsed;
-                AddButtonVisibility = Visibility.Collapsed;
                 TrashButtonVisibility = Visibility.Visible;
             }
             else
@@ -297,12 +296,10 @@ public class ShellViewModel : ObservableRecipient
                 {
                     ExplorerVisibility = Visibility.Collapsed;
                     NarratorVisibility = Visibility.Visible;
-                    AddButtonVisibility = Visibility.Collapsed;
+                    AddButtonVisibility = Visibility.Visible;
                     PrintNodeVisibility = Visibility.Visible;
                     TrashButtonVisibility = Visibility.Collapsed;
                 }
-
-                AddButtonVisibility = Visibility.Visible;
             }
         }
         catch (Exception e) //errors (is RightTappedNode null?

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.4.24"
+    "Uno.Sdk": "6.4.42"
   },
   "sdk": {
     "version": "9.0.305",


### PR DESCRIPTION
This PR resolves #1215 and makes the following changes:
- Updates how right click menu is spawned via the right tapped event
- Updates how keybinds are shown
- Note: all skia desktop versions will now show macos keybind options which is technically a bug but only MacOS desktop is supported at this time
- Updates some bindings to oneway instead of twoway.