### PR TITLE
Fix issue with printing and narrative editor

### DIFF
--- a/StoryCADLib/Services/Reports/PrintReports.cs
+++ b/StoryCADLib/Services/Reports/PrintReports.cs
@@ -20,10 +20,11 @@ public class PrintReports
 
     #region Constructor
 
-    public PrintReports(PrintReportDialogVM vm, AppState appState)
+    public PrintReports(PrintReportDialogVM vm, AppState appState, ILogService logger)
     {
         _vm = vm;
         _appState = appState;
+        _logger = logger;
         _model = appState.CurrentDocument!.Model;
         _formatter = new ReportFormatter(appState);
     }

--- a/StoryCADLib/ViewModels/Tools/NarrativeToolVM.cs
+++ b/StoryCADLib/ViewModels/Tools/NarrativeToolVM.cs
@@ -120,12 +120,16 @@ public class NarrativeToolVM : ObservableRecipient
                 if (SelectedNode.Type == StoryItemType.TrashCan || SelectedNode.IsRoot)
                 {
                     Message = "You can't delete this node!";
+                    return;
                 }
 
                 if (IsNarratorSelected)
                 {
+                    var deletedName = SelectedNode.Name;
                     SelectedNode.Delete(StoryViewType.NarratorView);
-                    Message = $"Deleted {SelectedNode}";
+                    Message = $"Deleted {deletedName}";
+                    SelectedNode = null;
+                    IsNarratorSelected = false;
                 }
                 else
                 {

--- a/StoryCADLib/ViewModels/Tools/PrintReportDialogVM.cs
+++ b/StoryCADLib/ViewModels/Tools/PrintReportDialogVM.cs
@@ -255,7 +255,7 @@ public partial class PrintReportDialogVM : ObservableRecipient
 
     private async Task<IReadOnlyList<IReadOnlyList<string>>> BuildReportPagesAsync(int? linesPerPageOverride = null)
     {
-        var report = await new PrintReports(this, _appState).Generate();
+        var report = await new PrintReports(this, _appState, _logService).Generate();
         return BuildReportPages(report, linesPerPageOverride);
     }
 
@@ -415,7 +415,7 @@ public partial class PrintReportDialogVM : ObservableRecipient
                 document.Close();
             }
 
-            await FileIO.WriteBytesAsync(exportFile, memoryStream.ToArray());
+            await File.WriteAllBytesAsync(exportFile.Path, memoryStream.ToArray());
             Messenger.Send(new StatusChangedMessage(new StatusMessage($"Reports exported to PDF: {exportFile.Path}",
                 LogLevel.Info)));
         }

--- a/StoryCADTests/ViewModels/Tools/NarrativeToolVMTests.cs
+++ b/StoryCADTests/ViewModels/Tools/NarrativeToolVMTests.cs
@@ -1,6 +1,10 @@
+using CommunityToolkit.Mvvm.DependencyInjection;
 using StoryCADLib.Models;
+using StoryCADLib.Services;
 using StoryCADLib.Services.Dialogs;
 using StoryCADLib.Services.Logging;
+using StoryCADLib.Services.Outline;
+using StoryCADLib.ViewModels;
 using StoryCADLib.ViewModels.Tools;
 
 namespace StoryCADTests.ViewModels.Tools;
@@ -83,4 +87,96 @@ public class NarrativeToolVMTests
         Assert.IsTrue(hasShellViewModelDependency,
             "NarrativeToolVM still has ShellViewModel dependency (needs refactoring to extract VerifyToolUse to a service)");
     }
+
+    #region Delete Tests
+
+    [TestMethod]
+    public async Task Delete_WhenNodeDeleted_ClearsSelectedNode()
+    {
+        // Arrange - This tests the fix for deleted elements remaining highlighted
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var shellVM = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var windowing = Ioc.Default.GetRequiredService<Windowing>();
+        var toolValidation = Ioc.Default.GetRequiredService<ToolValidationService>();
+        var logger = Ioc.Default.GetRequiredService<ILogService>();
+        var outlineService = Ioc.Default.GetRequiredService<OutlineService>();
+
+        // Create test model with narrator view
+        var model = await outlineService.CreateModel("Test Story", "Test Author", 0);
+        appState.CurrentDocument = new StoryDocument(model, "test.stbx");
+
+        // Create a scene and add it to narrator view via its node
+        var scene = new SceneModel("Test Scene", model, model.ExplorerView[0]);
+        scene.Node.CopyToNarratorView(model);
+        var narratorScene = model.NarratorView[0].Children.FirstOrDefault(c => c.Name == "Test Scene");
+
+        var vm = new NarrativeToolVM(shellVM, appState, windowing, toolValidation, logger);
+        vm.SelectedNode = narratorScene;
+        vm.IsNarratorSelected = true;
+
+        // Act
+        vm.Delete();
+
+        // Assert
+        Assert.IsNull(vm.SelectedNode, "SelectedNode should be null after deletion");
+        Assert.IsFalse(vm.IsNarratorSelected, "IsNarratorSelected should be false after deletion");
+    }
+
+    [TestMethod]
+    public async Task Delete_WhenNotNarratorSelected_DoesNotClearSelection()
+    {
+        // Arrange
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var shellVM = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var windowing = Ioc.Default.GetRequiredService<Windowing>();
+        var toolValidation = Ioc.Default.GetRequiredService<ToolValidationService>();
+        var logger = Ioc.Default.GetRequiredService<ILogService>();
+        var outlineService = Ioc.Default.GetRequiredService<OutlineService>();
+
+        // Create model with a scene
+        var model = await outlineService.CreateModel("Test Story", "Test Author", 0);
+        appState.CurrentDocument = new StoryDocument(model, "test.stbx");
+        var scene = new SceneModel("Test Scene", model, model.ExplorerView[0]);
+
+        var vm = new NarrativeToolVM(shellVM, appState, windowing, toolValidation, logger);
+        vm.SelectedNode = scene.Node;
+        vm.IsNarratorSelected = false; // Explorer view selected, not narrator
+
+        // Act
+        vm.Delete();
+
+        // Assert - Selection should NOT be cleared since we can't delete from explorer in this context
+        Assert.AreEqual(scene.Node, vm.SelectedNode, "SelectedNode should remain unchanged when not deleting from narrator");
+        Assert.AreEqual("You can't delete from here!", vm.Message, "Should show appropriate message");
+    }
+
+    [TestMethod]
+    public async Task Delete_WhenTrashCanSelected_ReturnsEarlyWithMessage()
+    {
+        // Arrange
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var shellVM = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var windowing = Ioc.Default.GetRequiredService<Windowing>();
+        var toolValidation = Ioc.Default.GetRequiredService<ToolValidationService>();
+        var logger = Ioc.Default.GetRequiredService<ILogService>();
+        var outlineService = Ioc.Default.GetRequiredService<OutlineService>();
+
+        // Create model to get access to trash node
+        var model = await outlineService.CreateModel("Test Story", "Test Author", 0);
+        appState.CurrentDocument = new StoryDocument(model, "test.stbx");
+        var trashNode = model.TrashView.FirstOrDefault();
+
+        var vm = new NarrativeToolVM(shellVM, appState, windowing, toolValidation, logger);
+        vm.SelectedNode = trashNode;
+        vm.IsNarratorSelected = true;
+
+        // Act
+        vm.Delete();
+
+        // Assert - Should return early without attempting deletion
+        Assert.AreEqual("You can't delete this node!", vm.Message, "Should show cannot delete message");
+        Assert.AreEqual(trashNode, vm.SelectedNode, "SelectedNode should remain unchanged for protected nodes");
+    }
+
+    #endregion
 }

--- a/StoryCADTests/ViewModels/Tools/PrintReportDialogVMTests.cs
+++ b/StoryCADTests/ViewModels/Tools/PrintReportDialogVMTests.cs
@@ -79,6 +79,68 @@ public class PrintReportDialogVMTests
     #region Report Generation Tests
 
     [TestMethod]
+    public void BuildReportPages_WithEmptyContent_ReturnsEmptyReportPage()
+    {
+        // Arrange - This tests the fix for the NullReferenceException crash
+        // when no content is selected for printing
+        var report = "";
+        var linesPerPage = 70;
+
+        // Act - Using reflection since BuildReportPages is private static
+        var method = typeof(PrintReportDialogVM).GetMethod(
+            "BuildReportPages",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        var pages = (IReadOnlyList<IReadOnlyList<string>>)method.Invoke(
+            null,
+            new object[] { report, linesPerPage });
+
+        // Assert
+        Assert.AreEqual(1, pages.Count, "Should return one page for empty report");
+        Assert.AreEqual(1, pages[0].Count, "Page should have one line");
+        Assert.AreEqual("(Empty report)", pages[0][0], "Should show empty report message");
+    }
+
+    [TestMethod]
+    public void BuildReportPages_WithNullContent_ReturnsEmptyReportPage()
+    {
+        // Arrange - Edge case: null report string
+        string report = null;
+        var linesPerPage = 70;
+
+        // Act
+        var method = typeof(PrintReportDialogVM).GetMethod(
+            "BuildReportPages",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        var pages = (IReadOnlyList<IReadOnlyList<string>>)method.Invoke(
+            null,
+            new object[] { report, linesPerPage });
+
+        // Assert
+        Assert.AreEqual(1, pages.Count, "Should return one page for null report");
+        Assert.AreEqual("(Empty report)", pages[0][0], "Should show empty report message");
+    }
+
+    [TestMethod]
+    public void BuildReportPages_WithWhitespaceOnlyContent_ReturnsEmptyReportPage()
+    {
+        // Arrange - Edge case: whitespace-only report
+        var report = "   \n\t\n   ";
+        var linesPerPage = 70;
+
+        // Act
+        var method = typeof(PrintReportDialogVM).GetMethod(
+            "BuildReportPages",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        var pages = (IReadOnlyList<IReadOnlyList<string>>)method.Invoke(
+            null,
+            new object[] { report, linesPerPage });
+
+        // Assert
+        Assert.AreEqual(1, pages.Count, "Should return one page for whitespace-only report");
+        Assert.AreEqual("(Empty report)", pages[0][0], "Should show empty report message");
+    }
+
+    [TestMethod]
     public void BuildReportPages_WithShortContent_CreatesSinglePage()
     {
         // Arrange


### PR DESCRIPTION
This PR fixes two issues encounted during the 3.4 testing process 
#1226 a crash in the print reports menu with nothing selected
#1227 A crash in the narrative editor when deleting nodes and not updating selection