### PR TITLE
fix: Change CopyToOutputDirectory from Always to PreserveNewest

### DIFF
--- a/StoryCAD/StoryCAD.csproj
+++ b/StoryCAD/StoryCAD.csproj
@@ -72,7 +72,7 @@
     <!-- Include .env file in output -->
     <ItemGroup>
         <None Update=".env">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>
     <ItemGroup>

--- a/StoryCADLib/StoryCADLib.csproj
+++ b/StoryCADLib/StoryCADLib.csproj
@@ -245,7 +245,7 @@
         <EmbeddedResource Include="Assets\Install\Symbols.txt" />
         <EmbeddedResource Include="Assets\Install\Tools.json" />
         <Content Update="Assets\Icon.png">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
Fixes unnecessary rebuilds on every debug run.

## Changes
| File | Change |
|------|--------|
| StoryCAD.csproj | `.env`: Always → PreserveNewest |
| StoryCADLib.csproj | `Assets\Icon.png`: Always → PreserveNewest |

## Root Cause
`CopyToOutputDirectory="Always"` copies files every build, changing timestamps, which triggers the next rebuild. `PreserveNewest` only copies when the source file is newer than the destination.

## Test plan
- [ ] Build solution
- [ ] Run debug - should not trigger another build
- [ ] Modify a source file, run debug - should build only changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)