### PR TITLE
feat(api): Add GetElementsByType method to API (#1249)

### DIFF
--- a/StoryCADLib/Services/API/SemanticKernelAPI.cs
+++ b/StoryCADLib/Services/API/SemanticKernelAPI.cs
@@ -137,6 +137,37 @@ public class SemanticKernelApi(OutlineService outlineService, ListData listData,
         }
     }
 
+    [KernelFunction]
+    [Description("""
+                 Gets all story elements of a specific type from the current model.
+                 Use this to find all Characters, Scenes, Settings, Problems, etc.
+                 Valid types: Problem, Character, Setting, Scene, Folder, Section, Web, Notes.
+                 Note: StoryOverview and TrashCan types exist but are singleton elements.
+                 Returns a list of matching elements with their GUIDs and properties.
+                 """)]
+    public OperationResult<List<StoryElement>> GetElementsByType(StoryItemType elementType)
+    {
+        if (CurrentModel == null)
+        {
+            return OperationResult<List<StoryElement>>.Failure(
+                "No StoryModel available. Create a model first.");
+        }
+
+        try
+        {
+            var filtered = CurrentModel.StoryElements
+                .Where(e => e.ElementType == elementType)
+                .ToList();
+
+            return OperationResult<List<StoryElement>>.Success(filtered);
+        }
+        catch (Exception ex)
+        {
+            return OperationResult<List<StoryElement>>.Failure(
+                $"Error retrieving elements by type: {ex.Message}");
+        }
+    }
+
     /// <summary>
     ///     Updates a story model element.
     /// </summary>

--- a/StoryCADLib/Services/Collaborator/Contracts/IStoryCADAPI.cs
+++ b/StoryCADLib/Services/Collaborator/Contracts/IStoryCADAPI.cs
@@ -36,6 +36,13 @@ public interface IStoryCADAPI
     OperationResult<ObservableCollection<StoryElement>> GetAllElements();
 
     /// <summary>
+    ///     Gets all story elements of a specific type
+    /// </summary>
+    /// <param name="elementType">The type of elements to retrieve</param>
+    /// <returns>OperationResult containing a list of matching story elements</returns>
+    OperationResult<List<StoryElement>> GetElementsByType(StoryItemType elementType);
+
+    /// <summary>
     ///     Updates a story element
     /// </summary>
     /// <param name="newElement">The updated element</param>

--- a/docs/For Developers/Using_the_API.md
+++ b/docs/For Developers/Using_the_API.md
@@ -42,10 +42,13 @@ The API exposes several core functions, including:
 - **AddElement(StoryItemType typeToAdd, string parentGUID):**  
   Creates a new StoryElement under a specified parent element (usually the StoryOverview).
 
-- **AddCastMember(Guid scene, Guid character):**  
-  Adds a character as part of a scene’s cast.
+- **AddCastMember(Guid scene, Guid character):**
+  Adds a character as part of a scene's cast.
 
-- **Additional Functions:**  
+- **GetElementsByType(StoryItemType elementType):**
+  Returns all story elements of a specific type (Character, Scene, Setting, Problem, etc.).
+
+- **Additional Functions:**
   The API also includes functions for deleting elements, retrieving element details, and creating relationships between characters.
 
 The API is designed for both direct user interaction (through desktop or console apps) and for AI-powered processing where detailed human-like guidelines are embedded into prompts for automated execution.


### PR DESCRIPTION
## Summary
Add convenience method to retrieve story elements filtered by type, eliminating the need for callers to fetch all elements and filter client-side.

## Changes
- Add `GetElementsByType(StoryItemType)` to `IStoryCADAPI` interface
- Implement method in `SemanticKernelApi` with `[KernelFunction]` for Semantic Kernel integration
- Add 3 unit tests following TDD (no model, valid type, empty results)
- Update API documentation

## Test Plan
- [x] `GetElementsByType_WithNoModel_ReturnsFailure` - Verifies null model guard
- [x] `GetElementsByType_WithValidType_ReturnsFilteredElements` - Verifies filtering works
- [x] `GetElementsByType_WithNoMatchingElements_ReturnsEmptyList` - Verifies empty result handling

All tests passing locally.

Closes #1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)