### PR TITLE
fix(api): Handle StoryOverview in GetElementsByType

### DIFF
--- a/StoryCADLib/Services/API/SemanticKernelAPI.cs
+++ b/StoryCADLib/Services/API/SemanticKernelAPI.cs
@@ -155,6 +155,22 @@ public class SemanticKernelApi(OutlineService outlineService, ListData listData,
 
         try
         {
+            // Handle singleton types that aren't in StoryElements collection
+            if (elementType == StoryItemType.StoryOverview)
+            {
+                // StoryOverview is the first node in ExplorerView
+                if (CurrentModel.ExplorerView.Count > 0)
+                {
+                    var overviewNode = CurrentModel.ExplorerView[0];
+                    var overview = CurrentModel.StoryElements.StoryElementGuids.GetValueOrDefault(overviewNode.Uuid);
+                    if (overview != null)
+                    {
+                        return OperationResult<List<StoryElement>>.Success(new List<StoryElement> { overview });
+                    }
+                }
+                return OperationResult<List<StoryElement>>.Success(new List<StoryElement>());
+            }
+
             var filtered = CurrentModel.StoryElements
                 .Where(e => e.ElementType == elementType)
                 .ToList();


### PR DESCRIPTION
## Summary
- Fixes `GetElementsByType(StoryItemType.StoryOverview)` returning empty list
- StoryOverview is a singleton accessed via `ExplorerView[0]`, not through standard StoryElements iteration
- Discovered while migrating CollaboratorTests from mocks to real implementations

## Test plan
- [x] CollaboratorTests pass (220/220)
- [x] ElementResolverTests now correctly resolve StoryOverview elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)