### PR TITLE
Refactor Report loading to happen as needed instead of startup

### DIFF
--- a/StoryCADLib/Services/Reports/PrintReports.cs
+++ b/StoryCADLib/Services/Reports/PrintReports.cs
@@ -34,18 +34,17 @@ public class PrintReports
     public async Task<string> Generate()
     {
         var rtf = string.Empty;
-        await _formatter.LoadReportTemplates(); // Load text report templates
 
         //Process single selection (non-Pivot) reports
         if (_vm.CreateOverview)
         {
-            rtf = _formatter.FormatStoryOverviewReport();
+            rtf = await _formatter.FormatStoryOverviewReport();
             _documentText += FormatText(rtf);
         }
 
         if (_vm.CreateSummary)
         {
-            rtf = _formatter.FormatSynopsisReport();
+            rtf = await _formatter.FormatSynopsisReport();
             _documentText += FormatText(rtf, true);
         }
 
@@ -103,16 +102,16 @@ public class PrintReports
                 switch (node.Type)
                 {
                     case StoryItemType.Problem:
-                        rtf = _formatter.FormatProblemReport(element);
+                        rtf = await _formatter.FormatProblemReport(element);
                         break;
                     case StoryItemType.Character:
-                        rtf = _formatter.FormatCharacterReport(element);
+                        rtf = await _formatter.FormatCharacterReport(element);
                         break;
                     case StoryItemType.Setting:
-                        rtf = _formatter.FormatSettingReport(element);
+                        rtf = await _formatter.FormatSettingReport(element);
                         break;
                     case StoryItemType.Scene:
-                        rtf = _formatter.FormatSceneReport(element);
+                        rtf = await _formatter.FormatSceneReport(element);
                         break;
                     case StoryItemType.Web:
                         rtf = _formatter.FormatWebReport(element);

--- a/StoryCADLib/Services/Reports/ReportFormatter.cs
+++ b/StoryCADLib/Services/Reports/ReportFormatter.cs
@@ -11,6 +11,20 @@ public class ReportFormatter
 {
     private readonly StoryModel _storyModel;
     private readonly Dictionary<string, string[]> _templates = new();
+    private bool _templatesLoaded;
+
+    /// <summary>
+    /// Ensures report templates are loaded before use.
+    /// This method is idempotent - calling it multiple times has no effect after first load.
+    /// </summary>
+    private async Task EnsureTemplatesLoadedAsync()
+    {
+        if (!_templatesLoaded)
+        {
+            await LoadReportTemplates();
+            _templatesLoaded = true;
+        }
+    }
 
     public string FormatListReport(StoryItemType elementType)
     {
@@ -51,8 +65,9 @@ public class ReportFormatter
 
     #region Public methods
 
-    public string FormatStoryOverviewReport()
+    public async Task<string> FormatStoryOverviewReport()
     {
+        await EnsureTemplatesLoadedAsync();
         var overview =
             (OverviewModel)_storyModel.StoryElements.FirstOrDefault(element =>
                 element.ElementType == StoryItemType.StoryOverview);
@@ -103,8 +118,9 @@ public class ReportFormatter
         return doc.GetRtf();
     }
 
-    public string FormatProblemReport(StoryElement element)
+    public async Task<string> FormatProblemReport(StoryElement element)
     {
+        await EnsureTemplatesLoadedAsync();
         var problem = (ProblemModel)element;
         var lines = _templates["Problem Description"];
         RtfDocument doc = new(string.Empty);
@@ -461,8 +477,9 @@ public class ReportFormatter
         return beats.ToString();
     }
 
-    public string FormatCharacterRelationshipReport(StoryElement element)
+    public async Task<string> FormatCharacterRelationshipReport(StoryElement element)
     {
+        await EnsureTemplatesLoadedAsync();
         var character = (CharacterModel)element;
         RtfDocument doc = new(string.Empty);
         foreach (var rel in character.RelationshipList)
@@ -502,8 +519,9 @@ public class ReportFormatter
         return doc.GetRtf();
     }
 
-    public string FormatCharacterReport(StoryElement element)
+    public async Task<string> FormatCharacterReport(StoryElement element)
     {
+        await EnsureTemplatesLoadedAsync();
         var character = (CharacterModel)element;
         var lines = _templates["Character Description"];
         RtfDocument doc = new(string.Empty);
@@ -537,7 +555,7 @@ public class ReportFormatter
             //Relationships section
             if (sb.ToString() == "@Relationships" && character.RelationshipList.Count > 0)
             {
-                sb.Replace("@Relationships", FormatCharacterRelationshipReport(element));
+                sb.Replace("@Relationships", await FormatCharacterRelationshipReport(element));
             }
 
             //Flaw section
@@ -587,8 +605,9 @@ public class ReportFormatter
         return doc.GetRtf();
     }
 
-    public string FormatSettingReport(StoryElement element)
+    public async Task<string> FormatSettingReport(StoryElement element)
     {
+        await EnsureTemplatesLoadedAsync();
         var setting = (SettingModel)element;
         var lines = _templates["Setting Description"];
         RtfDocument doc = new(string.Empty);
@@ -618,8 +637,9 @@ public class ReportFormatter
         return doc.GetRtf();
     }
 
-    public string FormatSceneReport(StoryElement element)
+    public async Task<string> FormatSceneReport(StoryElement element)
     {
+        await EnsureTemplatesLoadedAsync();
         var scene = (SceneModel)element;
         var lines = _templates["Scene Description"];
         RtfDocument doc = new(string.Empty);
@@ -759,8 +779,9 @@ public class ReportFormatter
         */
     }
 
-    public string FormatFolderReport(StoryElement element)
+    public async Task<string> FormatFolderReport(StoryElement element)
     {
+        await EnsureTemplatesLoadedAsync();
         var folder = (FolderModel)element;
         var lines = _templates["Folder Description"];
         RtfDocument doc = new(string.Empty);
@@ -777,8 +798,9 @@ public class ReportFormatter
         return doc.GetRtf();
     }
 
-    public string FormatSectionReport(StoryElement element)
+    public async Task<string> FormatSectionReport(StoryElement element)
     {
+        await EnsureTemplatesLoadedAsync();
         var section = (FolderModel)element;
         var lines = _templates["Section Description"];
         RtfDocument doc = new(string.Empty);
@@ -796,8 +818,9 @@ public class ReportFormatter
         return doc.GetRtf();
     }
 
-    public string FormatSynopsisReport()
+    public async Task<string> FormatSynopsisReport()
     {
+        await EnsureTemplatesLoadedAsync();
         var lines = _templates["Story Synopsis"];
         RtfDocument doc = new(string.Empty);
 

--- a/StoryCADLib/Services/Reports/ScrivenerReports.cs
+++ b/StoryCADLib/Services/Reports/ScrivenerReports.cs
@@ -50,7 +50,6 @@ public class ScrivenerReports
     public async Task GenerateReports()
     {
         await _scrivener.LoadScrivenerProject(); // Load the Scrivener project
-        await _formatter.LoadReportTemplates(); // Load text report templates
         _binderNode = _scrivener.BuildBinderItemTree(); // Build a BinderItem model
         UpdateStoryCADOutline(); // Replace or add StoryCAD BinderItems to model
 
@@ -483,7 +482,7 @@ public class ScrivenerReports
         var di = await _scrivener.GetSubFolder(node.Uuid); // Get subfolder path
         var contents = await di.CreateFileAsync("content.rtf", CreationCollisionOption.ReplaceExisting);
 
-        var rtf = _formatter.FormatStoryOverviewReport();
+        var rtf = await _formatter.FormatStoryOverviewReport();
 
         // Write the report
         await FileIO.WriteTextAsync(contents, rtf);
@@ -505,7 +504,7 @@ public class ScrivenerReports
         var di = await _scrivener.GetSubFolder(node.Uuid); // Get subfolder path
         var contents = await di.CreateFileAsync("content.rtf", CreationCollisionOption.ReplaceExisting);
 
-        var rtf = _formatter.FormatProblemReport(element);
+        var rtf = await _formatter.FormatProblemReport(element);
 
         // Write the report
         await FileIO.WriteTextAsync(contents, rtf);
@@ -527,7 +526,7 @@ public class ScrivenerReports
         var di = await _scrivener.GetSubFolder(node.Uuid); // Get subfolder path
         var contents = await di.CreateFileAsync("content.rtf", CreationCollisionOption.ReplaceExisting);
 
-        var rtf = _formatter.FormatCharacterReport(element);
+        var rtf = await _formatter.FormatCharacterReport(element);
 
         // Write the report
         await FileIO.WriteTextAsync(contents, rtf);
@@ -551,7 +550,7 @@ public class ScrivenerReports
         var di = await _scrivener.GetSubFolder(node.Uuid); // Get subfolder path
         var contents = await di.CreateFileAsync("content.rtf", CreationCollisionOption.ReplaceExisting);
 
-        var rtf = _formatter.FormatSettingReport(element);
+        var rtf = await _formatter.FormatSettingReport(element);
 
         // Write the report
         await FileIO.WriteTextAsync(contents, rtf);
@@ -575,7 +574,7 @@ public class ScrivenerReports
         var di = await _scrivener.GetSubFolder(node.Uuid); // Get subfolder path
         var contents = await di.CreateFileAsync("content.rtf", CreationCollisionOption.ReplaceExisting);
 
-        var rtf = _formatter.FormatSceneReport(element);
+        var rtf = await _formatter.FormatSceneReport(element);
 
         // Write the report
         await FileIO.WriteTextAsync(contents, rtf);
@@ -587,7 +586,7 @@ public class ScrivenerReports
         var di = await _scrivener.GetSubFolder(node.Uuid); // Get subfolder path
         var contents = await di.CreateFileAsync("content.rtf", CreationCollisionOption.ReplaceExisting);
 
-        var rtf = _formatter.FormatFolderReport(element);
+        var rtf = await _formatter.FormatFolderReport(element);
 
         // Write the report
         await FileIO.WriteTextAsync(contents, rtf);
@@ -599,7 +598,7 @@ public class ScrivenerReports
         var di = await _scrivener.GetSubFolder(node.Uuid); // Get subfolder path
         var contents = await di.CreateFileAsync("content.rtf", CreationCollisionOption.ReplaceExisting);
 
-        var rtf = _formatter.FormatSectionReport(element);
+        var rtf = await _formatter.FormatSectionReport(element);
 
         // Write the report
         await FileIO.WriteTextAsync(contents, rtf);
@@ -611,7 +610,7 @@ public class ScrivenerReports
         var di = await _scrivener.GetSubFolder(node.Uuid);
         var contents = await di.CreateFileAsync("content.rtf", CreationCollisionOption.ReplaceExisting);
 
-        var rtf = _formatter.FormatSynopsisReport();
+        var rtf = await _formatter.FormatSynopsisReport();
 
         // Write the report
         await FileIO.WriteTextAsync(contents, rtf);

--- a/StoryCADTests/Services/Reports/ReportFormatterTests.cs
+++ b/StoryCADTests/Services/Reports/ReportFormatterTests.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.DependencyInjection;
 using StoryCADLib.Models;
+using StoryCADLib.Services.Outline;
 using StoryCADLib.Services.Reports;
 
 namespace StoryCADTests.Services.Reports;
@@ -21,5 +22,128 @@ public class ReportFormatterTests
 
         // Assert
         Assert.AreEqual(string.Empty, result);
+    }
+
+    [TestMethod]
+    public void GetText_WithoutTemplates_WorksCorrectly()
+    {
+        // Arrange - GetText should work without templates being loaded (lazy loading)
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var storyModel = new StoryModel();
+        appState.CurrentDocument = new StoryDocument(storyModel);
+
+        // Act - GetText doesn't use templates, so it should work immediately
+        var formatter = new ReportFormatter(appState);
+        var result = formatter.GetText("plain text");
+
+        // Assert
+        Assert.AreEqual("plain text", result);
+    }
+
+    [TestMethod]
+    public async Task FormatListReport_WithValidModel_LoadsTemplatesLazily()
+    {
+        // Arrange
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var outlineService = Ioc.Default.GetRequiredService<OutlineService>();
+        var model = await outlineService.CreateModel("Test Story", "Test Author", 0);
+        appState.CurrentDocument = new StoryDocument(model, "test.stbx");
+
+        // Act - FormatListReport doesn't use templates (inline template)
+        // but this verifies the formatter works without explicit LoadReportTemplates()
+        var formatter = new ReportFormatter(appState);
+        var result = formatter.FormatListReport(StoryItemType.Character);
+
+        // Assert - Should return RTF content
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.StartsWith("{\\rtf"), "Result should be valid RTF");
+    }
+
+    [TestMethod]
+    public async Task FormatProblemReport_WithValidElement_LoadsTemplatesLazily()
+    {
+        // Arrange
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var outlineService = Ioc.Default.GetRequiredService<OutlineService>();
+        var model = await outlineService.CreateModel("Test Story", "Test Author", 0);
+        appState.CurrentDocument = new StoryDocument(model, "test.stbx");
+
+        var problem = new ProblemModel("Test Problem", model, null);
+
+        // Act - This format method requires templates, should load them lazily
+        var formatter = new ReportFormatter(appState);
+        var result = await formatter.FormatProblemReport(problem);
+
+        // Assert - Should return RTF content with problem data
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.StartsWith("{\\rtf"), "Result should be valid RTF");
+    }
+
+    [TestMethod]
+    public async Task FormatCharacterReport_WithValidElement_LoadsTemplatesLazily()
+    {
+        // Arrange
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var outlineService = Ioc.Default.GetRequiredService<OutlineService>();
+        var model = await outlineService.CreateModel("Test Story", "Test Author", 0);
+        appState.CurrentDocument = new StoryDocument(model, "test.stbx");
+
+        var character = new CharacterModel("Test Character", model, null)
+        {
+            Role = "Protagonist"
+        };
+
+        // Act - This format method requires templates, should load them lazily
+        var formatter = new ReportFormatter(appState);
+        var result = await formatter.FormatCharacterReport(character);
+
+        // Assert - Should return RTF content with character data
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.StartsWith("{\\rtf"), "Result should be valid RTF");
+    }
+
+    [TestMethod]
+    public async Task FormatStoryOverviewReport_WithValidModel_LoadsTemplatesLazily()
+    {
+        // Arrange
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var outlineService = Ioc.Default.GetRequiredService<OutlineService>();
+        var model = await outlineService.CreateModel("Test Story", "Test Author", 0);
+        appState.CurrentDocument = new StoryDocument(model, "test.stbx");
+
+        // Act - This format method requires templates, should load them lazily
+        var formatter = new ReportFormatter(appState);
+        var result = await formatter.FormatStoryOverviewReport();
+
+        // Assert - Should return RTF content
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.StartsWith("{\\rtf"), "Result should be valid RTF");
+    }
+
+    [TestMethod]
+    public async Task MultipleFormatCalls_LoadsTemplatesOnlyOnce()
+    {
+        // Arrange
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var outlineService = Ioc.Default.GetRequiredService<OutlineService>();
+        var model = await outlineService.CreateModel("Test Story", "Test Author", 0);
+        appState.CurrentDocument = new StoryDocument(model, "test.stbx");
+
+        var problem1 = new ProblemModel("Problem 1", model, null);
+        var problem2 = new ProblemModel("Problem 2", model, null);
+
+        // Act - Call multiple format methods
+        var formatter = new ReportFormatter(appState);
+        var result1 = await formatter.FormatProblemReport(problem1);
+        var result2 = await formatter.FormatProblemReport(problem2);
+        var result3 = await formatter.FormatStoryOverviewReport();
+
+        // Assert - All should succeed and return valid RTF
+        Assert.IsNotNull(result1);
+        Assert.IsNotNull(result2);
+        Assert.IsNotNull(result3);
+        Assert.IsTrue(result1.StartsWith("{\\rtf"), "Result 1 should be valid RTF");
+        Assert.IsTrue(result2.StartsWith("{\\rtf"), "Result 2 should be valid RTF");
+        Assert.IsTrue(result3.StartsWith("{\\rtf"), "Result 3 should be valid RTF");
     }
 }


### PR DESCRIPTION
This PR updates Report loading to happen when a report is needed instead of being loaded at start up as set out in #1145 