### PR TITLE
fix(build): Eliminate all build warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -179,3 +179,8 @@ dotnet_diagnostic.CS0105.severity = warning  # Using directive appeared previous
 
 # Code Quality - Obsolete API Usage (Issue #1134)
 dotnet_diagnostic.CS0618.severity = warning  # Member is obsolete
+
+# MSTest Analyzer - Suppress style suggestions (MSTEST0037)
+# These are suggestions to use "better" Assert methods but the existing
+# patterns like Assert.IsTrue(collection.Contains(x)) work correctly
+dotnet_diagnostic.MSTEST0037.severity = none

--- a/StoryCADLib/StoryCADLib.csproj
+++ b/StoryCADLib/StoryCADLib.csproj
@@ -41,7 +41,7 @@
 
     <!-- on Windows, build both desktop + WinUI -->
     <PropertyGroup Condition="'$(OS)'=='Windows_NT'">
-        <TargetFrameworks>net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
+        <TargetFrameworks>net10.0-desktop;net10.0-windows10.0.22621</TargetFrameworks>
     </PropertyGroup>
 
     <!-- on non-Windows, only build desktop -->

--- a/StoryCADTests/Models/StoryModelTests.cs
+++ b/StoryCADTests/Models/StoryModelTests.cs
@@ -390,7 +390,7 @@ public class StoryModelTests
         //    - Move to trash: Use context menu "Delete" command
         //    - Restore from trash: Use context menu "Restore" command
 
-        Assert.IsTrue(true, "Drag-and-drop constraints are enforced through XAML properties");
+        // Test documents expected XAML constraints - passes if comment is accurate
     }
 
     #endregion

--- a/StoryCADTests/Services/API/SemanticKernelAPITests.cs
+++ b/StoryCADTests/Services/API/SemanticKernelAPITests.cs
@@ -246,7 +246,7 @@ public class SemanticKernelApiTests
 
         // Assert
         Assert.IsTrue(addResult.IsSuccess, "AddElement should succeed with a valid parent.");
-        Assert.IsNotNull(addResult.Payload, "The payload should not be null for a successfully added element.");
+        Assert.AreNotEqual(Guid.Empty, addResult.Payload, "The payload should not be empty for a successfully added element.");
 
         // Optionally verify that the added element's type is Section.
         var newElement = _api.CurrentModel.StoryElements.StoryElementGuids[addResult.Payload];

--- a/StoryCADTests/Services/Collaborator/PluginLoadContextTests.cs
+++ b/StoryCADTests/Services/Collaborator/PluginLoadContextTests.cs
@@ -286,8 +286,7 @@ public class PluginLoadContextTests
             Assert.IsNotNull(type.Assembly, $"Type {type.Name} should have a valid assembly reference");
         }
 
-        // Final assertion - no regression
-        Assert.IsTrue(true, "No ReflectionTypeLoadException thrown - regression prevented");
+        // Test passes if no ReflectionTypeLoadException thrown - regression prevented
     }
 
     #region Helper Methods

--- a/StoryCADTests/Services/Outline/FileOpenServiceTests.cs
+++ b/StoryCADTests/Services/Outline/FileOpenServiceTests.cs
@@ -104,10 +104,8 @@ public class FileOpenServiceTests
         // Act
         await _fileOpenService.OpenFile(nonExistentPath);
 
-        // Assert
-        // The method should complete without throwing an exception
+        // Assert - test passes if no exception thrown
         // In production, this would show a file picker to the user
-        Assert.IsTrue(true); // Method completed successfully
 
         // Cleanup
         WeakReferenceMessenger.Default.UnregisterAll(this);
@@ -221,7 +219,6 @@ public class FileOpenServiceTests
         // In headless mode, file picker returns null and method returns early
         await _fileOpenService.OpenFile(Path.Combine(Path.GetTempPath(), "test", "somefile.stbx"));
 
-        // If we get here without exception, the test passes
-        Assert.IsTrue(true);
+        // Test passes if no exception thrown
     }
 }

--- a/StoryCADTests/Services/Search/SearchServiceTests.cs
+++ b/StoryCADTests/Services/Search/SearchServiceTests.cs
@@ -96,9 +96,8 @@ public class SearchServiceTests
             _searchService.SearchString(heroNode, "test", _testModel);
         }
 
-        // Assert - If this completes quickly, the cache is working
+        // Assert - test passes if multiple searches complete efficiently
         // (In a real scenario, you might measure execution time)
-        Assert.IsTrue(true, "Multiple searches should complete efficiently using cache");
     }
 
     #endregion

--- a/StoryCADTests/Services/WindowingTests.cs
+++ b/StoryCADTests/Services/WindowingTests.cs
@@ -43,8 +43,7 @@ namespace StoryCADTests.Services
             // Act - should return early without throwing
             _windowing.SetWindowSize(window!, 1200.0, 800.0);
 
-            // Assert - if we get here without exception, test passes
-            Assert.IsTrue(true, "SetWindowSize handled null window correctly on all platforms");
+            // Assert - test passes if no exception thrown
         }
 
         [TestMethod]
@@ -113,16 +112,10 @@ namespace StoryCADTests.Services
                 "TryGetScaleFactor should accept Window parameter, not use MainWindow directly");
 
             // Platform-specific expectations for Skia desktop
-            if (OperatingSystem.IsWindows())
-            {
-                // Windows Skia desktop uses DisplayInformation or environment variable
-                Assert.IsTrue(true, "Windows Skia desktop should attempt DisplayInformation for DPI");
-            }
-            else if (OperatingSystem.IsMacOS())
-            {
-                // macOS Skia desktop uses DisplayInformation or defaults
-                Assert.IsTrue(true, "macOS Skia desktop should attempt DisplayInformation for DPI");
-            }
+            // Platform verification:
+            // - Windows Skia desktop uses DisplayInformation or environment variable for DPI
+            // - macOS Skia desktop uses DisplayInformation or defaults for DPI
+            // Test passes if we reach this point
 #endif
         }
 
@@ -222,7 +215,7 @@ namespace StoryCADTests.Services
             // - Windows automatically handles the DPI scaling for WorkArea
 
             // This is why the old GetLogicalScreenWidth/Height methods are not needed
-            Assert.IsTrue(true, "DisplayArea.WorkArea provides logical dimensions automatically");
+            // Test documents expected behavior - passes if comment is accurate
         }
 
 //        [TestMethod]

--- a/StoryCADTests/StoryCADTests.csproj
+++ b/StoryCADTests/StoryCADTests.csproj
@@ -4,14 +4,18 @@
         <UnoSingleProject>true</UnoSingleProject>
         <LangVersion>latest</LangVersion>
         <RootNamespace>StoryCADTests</RootNamespace>
+        <DefaultLanguage>en-us</DefaultLanguage>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
         <IsTestProject>true</IsTestProject>
         <TestProjectType>UnitTest</TestProjectType>
         <EnableMSTestRunner>true</EnableMSTestRunner>
+        <GenerateUnoMain>false</GenerateUnoMain>
         <GenerateLibraryLayout>true</GenerateLibraryLayout>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>UNO0001</WarningsAsErrors>
+        <!-- Suppress CS8892: MSTest and Uno both generate Main entry points, this is expected -->
+        <NoWarn>$(NoWarn);CS8892</NoWarn>
 
         <!-- Test features -->
         <UnoFeatures>
@@ -21,7 +25,7 @@
 
     <!-- Target frameworks based on OS -->
     <PropertyGroup Condition="'$(OS)'=='Windows_NT'">
-        <TargetFrameworks>net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
+        <TargetFrameworks>net10.0-desktop;net10.0-windows10.0.22621</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
@@ -36,6 +40,8 @@
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <Platforms>x86;x64;arm64</Platforms>
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+        <!-- Disable Uno-generated Program.cs to avoid conflict with MSTest entry point -->
+        <GenerateProgramFile>false</GenerateProgramFile>
     </PropertyGroup>
 
     <!-- Desktop-specific settings -->

--- a/StoryCADTests/TestSetup.cs
+++ b/StoryCADTests/TestSetup.cs
@@ -1,8 +1,11 @@
 using CommunityToolkit.Mvvm.DependencyInjection;
 using dotenv.net;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StoryCADLib.Services;
 using StoryCADLib.Services.Backup;
 using StoryCADLib.Services.IoC;
+
+[assembly: DoNotParallelize]
 
 namespace StoryCADTests;
 

--- a/StoryCADTests/ViewModels/ShellViewModelTests.cs
+++ b/StoryCADTests/ViewModels/ShellViewModelTests.cs
@@ -55,8 +55,7 @@ public class ShellViewModelTests
         // Act - should not throw
         shell.SaveModel();
 
-        // Assert - we get here without exception
-        Assert.IsTrue(true);
+        // Assert - test passes if no exception thrown
     }
 
     /// <summary>
@@ -72,8 +71,7 @@ public class ShellViewModelTests
         // Act - should not throw, HomePage has no data to save
         shell.SaveModel();
 
-        // Assert - we get here without exception
-        Assert.IsTrue(true);
+        // Assert - test passes if no exception thrown
     }
 
     /// <summary>
@@ -89,8 +87,7 @@ public class ShellViewModelTests
         // Act - should not throw but log error
         shell.SaveModel();
 
-        // Assert - we get here without exception
-        Assert.IsTrue(true);
+        // Assert - test passes if no exception thrown
     }
 
     /// <summary>
@@ -759,7 +756,7 @@ public class ShellViewModelTests
         shell.ShowFlyoutButtons();
 
         // Assert - method should complete without throwing
-        Assert.IsTrue(true, "Method completed without throwing");
+        // Test passes if no exception thrown
     }
 
     #endregion
@@ -837,7 +834,7 @@ public class ShellViewModelTests
         shell.MoveLeftCommand.Execute(null);
 
         // Assert - method should complete without throwing
-        Assert.IsTrue(true, "Method completed without throwing");
+        // Test passes if no exception thrown
     }
 
     /// <summary>
@@ -913,7 +910,7 @@ public class ShellViewModelTests
         shell.MoveRightCommand.Execute(null);
 
         // Assert - method should complete without throwing
-        Assert.IsTrue(true, "Method completed without throwing");
+        // Test passes if no exception thrown
     }
 
     /// <summary>
@@ -1020,7 +1017,7 @@ public class ShellViewModelTests
         shell.MoveUpCommand.Execute(null);
 
         // Assert - method should complete without throwing
-        Assert.IsTrue(true, "Method completed without throwing");
+        // Test passes if no exception thrown
     }
 
     /// <summary>
@@ -1158,7 +1155,7 @@ public class ShellViewModelTests
         shell.MoveDownCommand.Execute(null);
 
         // Assert - method should complete without throwing
-        Assert.IsTrue(true, "Method completed without throwing");
+        // Test passes if no exception thrown
     }
 
     /// <summary>
@@ -1300,7 +1297,7 @@ public class ShellViewModelTests
 
         // Assert
         // Method should complete without throwing (CollaboratorService.DestroyCollaborator is called)
-        Assert.IsTrue(true, "Method should complete without throwing");
+        // Test passes if no exception thrown
     }
 
     [TestMethod]
@@ -1333,7 +1330,7 @@ public class ShellViewModelTests
         try
         {
             await shellViewModel.OnApplicationClosing();
-            Assert.IsTrue(true, "Method should complete without throwing");
+            // Test passes if no exception thrown
         }
         catch (Exception ex)
         {

--- a/StoryCADTests/ViewModels/Tools/NarrativeToolVMTests.cs
+++ b/StoryCADTests/ViewModels/Tools/NarrativeToolVMTests.cs
@@ -198,8 +198,7 @@ public class NarrativeToolVMTests
         try
         {
             vm.Delete();
-            // Test passes if we get here without exception
-            Assert.IsTrue(true, "Delete() should handle null SelectedNode without throwing");
+            // Test passes if no exception thrown
         }
         catch (NullReferenceException ex)
         {


### PR DESCRIPTION
## Summary
- Fix UNOB0012: Reorder TargetFrameworks (desktop before windows)
- Fix MSTEST0001: Add test parallelization config
- Fix MSTEST0032: Remove always-true assertions
- Suppress MSTEST0037 style warnings in .editorconfig
- Suppress CS8892 MSTest/Uno entry point conflict
- Fix PRI257: Set DefaultLanguage for resource localization

## Test plan
- [x] Build succeeds with 0 warnings
- [ ] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)