### PR TITLE
fix: Update SDK version and restore Windows-first target framework order

### DIFF
--- a/StoryCAD/StoryCAD.csproj
+++ b/StoryCAD/StoryCAD.csproj
@@ -15,11 +15,13 @@
     </PropertyGroup>
 
     <!-- On Windows, build both WinAppSDK and Skia Desktop -->
-    <!-- Desktop must be first per UNOB0012 - windows first breaks cross-platform debugging -->
+    <!-- Windows must be first for MSIX packaged debugging to work in VS -->
+    <!-- Suppress UNOB0012 warning about framework order - we need windows first for MSIX -->
     <PropertyGroup Condition="'$(OS)'=='Windows_NT'">
+        <NoWarn>$(NoWarn);UNOB0012</NoWarn>
         <TargetFrameworks>
-            net10.0-desktop;
-            net10.0-windows10.0.22621
+            net10.0-windows10.0.22621;
+            net10.0-desktop
         </TargetFrameworks>
     </PropertyGroup>
 

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Uno.Sdk": "6.4.53"
   },
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.102",
     "rollForward": "latestPatch",
     "allowPrerelease": false
   },


### PR DESCRIPTION
## Summary
- Update global.json SDK version from 10.0.100 to 10.0.102 (matches installed SDK)
- Restore Windows target framework to first position for MSIX packaged debugging
- Suppress UNOB0012 warning (Windows-first is required for VS2026 MSIX debugging)

## Problem
The desktop-first target framework order broke MSIX packaged debugging in VS2026 with error:
> "The project doesn't know how to run the profile with name 'StoryCAD (WinAppSDK Packaged)' and command 'MsixPackage'"

VS2026 defaults to the first target framework listed. When desktop was first, VS treated the project as a Console Application and didn't recognize the MsixPackage launch command.

## Test plan
- [x] Build succeeds with 0 warnings, 0 errors
- [x] All 653 tests pass (639 passed, 14 skipped)
- [x] MSIX packaged debugging works in VS2026
- [x] UNOB0012 warning is suppressed

Fixes #1263

🤖 Generated with [Claude Code](https://claude.com/claude-code)