### PR TITLE
Update Developer Name to StoryBuilder Foundation

### DIFF
--- a/StoryCAD/Package.appxmanifest
+++ b/StoryCAD/Package.appxmanifest
@@ -8,7 +8,7 @@
     <Identity Name="34432StoryBuilder.StoryBuilder" Publisher="CN=34A1944E-942C-4545-B217-ECE68E54ACF8" Version="4.0.0.0"/>
     <Properties>
       <DisplayName>StoryCAD</DisplayName>
-      <PublisherDisplayName>STORYBUILDER ORG</PublisherDisplayName>
+      <PublisherDisplayName>StoryBuilder Foundation</PublisherDisplayName>
       <Logo>Assets\StoreLogo.png</Logo>
     </Properties>
 


### PR DESCRIPTION
This PR updates the developer name from StoryBuilder ORG to StoryBuilder Foundation