### PR TITLE
refactor(#1146): Move navigation state from ShellViewModel to AppState

### DIFF
--- a/StoryCAD/Views/Shell.xaml.cs
+++ b/StoryCAD/Views/Shell.xaml.cs
@@ -206,7 +206,7 @@ public sealed partial class Shell : Page
         var item = (TreeViewItem)sender;
         item.Background = new SolidColorBrush(new UISettings().GetColorValue(UIColorType.Accent));
 
-        ShellVm.RightTappedNode = (StoryNodeItem)item.DataContext;
+        AppState.RightTappedNode = (StoryNodeItem)item.DataContext;
         ShellVm.LastClickedTreeviewItem = item; //We can't set the background through RightTappedNode so
         //we set a reference to the node itself to reset the background later
         ShellVm.ShowFlyoutButtons();

--- a/StoryCADLib/Models/AppState.cs
+++ b/StoryCADLib/Models/AppState.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Reflection;
 using StoryCADLib.Services;
+using StoryCADLib.ViewModels;
 
 #nullable enable
 
@@ -98,6 +99,33 @@ public class AppState
     ///     Null for pages without editable content (Home, Reports, etc.).
     /// </summary>
     public ISaveable? CurrentSaveable { get; set; }
+
+    #region Navigation State (Issue #1146)
+    // These properties were moved from ShellViewModel to enable service-layer access
+    // without ViewModel dependencies. All access must occur on the UI thread.
+
+    /// <summary>
+    ///     The current view type (Explorer or Narrator).
+    ///     Set by ShellViewModel.ViewChanged() when user switches views.
+    /// </summary>
+    public StoryViewType CurrentViewType { get; set; }
+
+    /// <summary>
+    ///     The currently selected node in the tree view.
+    ///     Set by ShellViewModel.TreeViewNodeClicked() when user clicks a node.
+    ///     Null when no node is selected.
+    /// </summary>
+    public StoryNodeItem? CurrentNode { get; set; }
+
+    /// <summary>
+    ///     The node that was right-clicked to open a context menu.
+    ///     Set by Shell.xaml.cs right-click handler.
+    ///     Used by tools that operate on the right-clicked node.
+    ///     Null when no node has been right-clicked.
+    /// </summary>
+    public StoryNodeItem? RightTappedNode { get; set; }
+
+    #endregion
 
     /// <summary>
     ///     The currently open story document, combining the model and its file path.

--- a/StoryCADLib/Services/Dialogs/ToolValidationService.cs
+++ b/StoryCADLib/Services/Dialogs/ToolValidationService.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Mvvm.Messaging;
+using StoryCADLib.Models;
 using StoryCADLib.Services.Messages;
 using static CommunityToolkit.Mvvm.Messaging.WeakReferenceMessenger;
 
@@ -6,47 +7,40 @@ namespace StoryCADLib.Services.Dialogs;
 
 /// <summary>
 ///     Service for validating tool usage prerequisites.
-///     IMPORTANT: This service is a temporary solution that still requires ShellViewModel parameters.
-///     This is part of the DI refactoring (Issue #1063) to extract validation logic from ViewModels.
-///     Issue #1146 tracks moving CurrentViewType, CurrentNode, and RightTappedNode properties
-///     from ShellViewModel to AppState to eliminate the ViewModel dependency entirely.
-///     This would require updating ~123 references across the codebase, so it's deferred to a separate task.
-///     This intermediate step allows us to:
-///     1. Extract the validation logic to a testable service
-///     2. Remove the direct dependency between NarrativeToolVM and OutlineViewModel
-///     3. Enable future incremental refactoring
+///     Reads navigation state (CurrentViewType, CurrentNode, RightTappedNode) from AppState.
+///     Issue #1146: Properties moved from ShellViewModel to AppState for service-layer access.
 /// </summary>
 public class ToolValidationService
 {
+    private readonly AppState _appState;
     private readonly ILogService _logger;
 
-    public ToolValidationService(ILogService logger)
+    public ToolValidationService(AppState appState, ILogService logger)
     {
+        _appState = appState;
         _logger = logger;
     }
 
     /// <summary>
     ///     Verifies that prerequisites are met for tool usage.
+    ///     Reads CurrentViewType, CurrentNode, and RightTappedNode from AppState.
+    ///     When nodeRequired is true and RightTappedNode is null but CurrentNode exists,
+    ///     sets RightTappedNode = CurrentNode as a fallback (side effect).
     /// </summary>
-    /// <param name="currentViewType">Current story view type from ShellViewModel</param>
-    /// <param name="currentNode">Currently selected node from ShellViewModel</param>
-    /// <param name="rightTappedNode">Right-clicked node from ShellViewModel</param>
-    /// <param name="model">Current story model from AppState</param>
     /// <param name="explorerViewOnly">If true, tool can only be used in Explorer view</param>
     /// <param name="nodeRequired">If true, a node must be selected</param>
     /// <param name="checkOutlineIsOpen">If true, checks that an outline is open</param>
     /// <returns>true if all prerequisites are met, false otherwise</returns>
     public bool VerifyToolUse(
-        StoryViewType? currentViewType,
-        StoryNodeItem currentNode,
-        StoryNodeItem rightTappedNode,
-        StoryModel model,
         bool explorerViewOnly,
         bool nodeRequired,
         bool checkOutlineIsOpen = true)
     {
         try
         {
+            var currentViewType = _appState.CurrentViewType;
+            var model = _appState.CurrentDocument?.Model;
+
             // Check if tool requires Explorer view
             if (explorerViewOnly && currentViewType != StoryViewType.ExplorerView)
             {
@@ -83,14 +77,20 @@ public class ToolValidationService
             // Check if a node is required and selected
             if (nodeRequired)
             {
-                // Use rightTappedNode if available, otherwise use currentNode
-                var nodeToUse = rightTappedNode ?? currentNode;
-
-                if (nodeToUse == null)
+                if (_appState.RightTappedNode == null)
                 {
-                    Default.Send(
-                        new StatusChangedMessage(new StatusMessage("You need to select a node first", LogLevel.Warn)));
-                    return false;
+                    if (_appState.CurrentNode != null)
+                    {
+                        // Fallback: use selected node as the target (side effect)
+                        _appState.RightTappedNode = _appState.CurrentNode;
+                    }
+                    else
+                    {
+                        // Both null - validation failure
+                        Default.Send(
+                            new StatusChangedMessage(new StatusMessage("You need to select a node first", LogLevel.Warn)));
+                        return false;
+                    }
                 }
             }
 
@@ -99,7 +99,7 @@ public class ToolValidationService
         catch (Exception ex)
         {
             _logger.LogException(LogLevel.Error, ex, "Error in ToolValidationService.VerifyToolUse()");
-            return false; // Return false to prevent any issues
+            return false;
         }
     }
 }

--- a/StoryCADLib/Services/Dialogs/Tools/NarrativeTool.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/Tools/NarrativeTool.xaml.cs
@@ -40,8 +40,8 @@ public sealed partial class NarrativeTool : Page
             return;
         }
 
-        var old = ShellVM.CurrentNode;
-        ShellVM.CurrentNode = ToolVM.SelectedNode;
+        var old = AppState.CurrentNode;
+        AppState.CurrentNode = ToolVM.SelectedNode;
         if ((sender as Button).Tag.ToString().Contains("UP"))
         {
             ShellVM.MoveUpCommand.Execute(null);
@@ -51,6 +51,6 @@ public sealed partial class NarrativeTool : Page
             ShellVM.MoveDownCommand.Execute(null);
         } //Move down
 
-        ShellVM.CurrentNode = old;
+        AppState.CurrentNode = old;
     }
 }

--- a/StoryCADLib/ViewModels/FileOpenVM.cs
+++ b/StoryCADLib/ViewModels/FileOpenVM.cs
@@ -231,7 +231,7 @@ public class FileOpenVM : ObservableRecipient
             // Reset view state to Explorer View in case we were in Narrative View
             shellVm.SelectedView = "Story Explorer View";
             shellVm.CurrentView = "Story Explorer View";
-            shellVm.CurrentViewType = StoryViewType.ExplorerView;
+            appState.CurrentViewType = StoryViewType.ExplorerView;
 
             shellVm.TreeViewNodeClicked(appState.CurrentDocument.Model.ExplorerView[0]);
         }

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -56,8 +56,6 @@ public class ShellViewModel : ObservableRecipient
     private ObservableCollection<StoryNodeItem> _targetCollection;
     private int _targetIndex;
 
-    public StoryViewType CurrentViewType;
-
     //File opened (if StoryCAD was opened via an STBX file)
     public string FilePathToLaunch;
     public bool IsClosing;
@@ -65,7 +63,6 @@ public class ShellViewModel : ObservableRecipient
 
     //List of new nodes that have a background, these are cleared on navigation
     public List<StoryNodeItem> NewNodeHighlightCache = new();
-    public StoryNodeItem RightTappedNode;
 
     // The right-hand (detail) side of ShellView
     public Frame SplitViewFrame;
@@ -231,8 +228,6 @@ public class ShellViewModel : ObservableRecipient
     // Public property for debugging PrintManager state
     public PrintReportDialogVM PrintReportDialog { get; }
 
-    // Navigation navigation landmark nodes
-    public StoryNodeItem CurrentNode { get; set; }
     public DateTime AppStartTime { get; set; } = DateTime.Now;
 
     // Track the current page type for SaveModel (testable without UI)
@@ -262,7 +257,7 @@ public class ShellViewModel : ObservableRecipient
                     break;
             }
 
-            CurrentViewType = State.CurrentDocument.Model.CurrentViewType;
+            State.CurrentViewType = State.CurrentDocument.Model.CurrentViewType;
             TreeViewNodeClicked(State.CurrentDocument.Model.CurrentView[0]);
         }
     }
@@ -279,7 +274,7 @@ public class ShellViewModel : ObservableRecipient
         try
         {
             //Trash Can - View Hide all buttons except Empty Trash.
-            if (StoryNodeItem.RootNodeType(RightTappedNode) == StoryItemType.TrashCan)
+            if (StoryNodeItem.RootNodeType(State.RightTappedNode) == StoryItemType.TrashCan)
             {
                 ExplorerVisibility = Visibility.Collapsed;
                 NarratorVisibility = Visibility.Collapsed;
@@ -311,7 +306,7 @@ public class ShellViewModel : ObservableRecipient
         catch (Exception e) //errors (is RightTappedNode null?
         {
             Logger.Log(LogLevel.Error, $"An error occurred in ShowFlyoutButtons() \n{e.Message}\n" +
-                                       $"- For reference RightTappedNode is " + RightTappedNode);
+                                       $"- For reference RightTappedNode is " + State.RightTappedNode);
         }
     }
 
@@ -651,7 +646,7 @@ public class ShellViewModel : ObservableRecipient
         {
             if (selectedItem is StoryNodeItem node)
             {
-                CurrentNode = node;
+                State.CurrentNode = node;
                 var element = outlineService.GetStoryElementByGuid(State.CurrentDocument!.Model, node.Uuid);
                 switch (element.ElementType)
                 {
@@ -701,7 +696,7 @@ public class ShellViewModel : ObservableRecipient
                         break;
                 }
 
-                CurrentNode.IsExpanded = true;
+                State.CurrentNode.IsExpanded = true;
             }
 
             //Clears background of new nodes on navigation as well as the last node.
@@ -990,7 +985,7 @@ public class ShellViewModel : ObservableRecipient
     {
         if (SerializationLock.CanExecuteCommands())
         {
-            //if (CurrentNode == null)
+            //if (State.CurrentNode == null)
             //{
             //    Messenger.Send(new StatusChangedMessage(new("Select a node to collaborate on", LogLevel.Warn, true)));
             //    return;
@@ -1032,45 +1027,45 @@ public class ShellViewModel : ObservableRecipient
             return;
         }
 
-        _sourceChildren = CurrentNode.Parent.Children;
-        _sourceIndex = _sourceChildren.IndexOf(CurrentNode);
+        _sourceChildren = State.CurrentNode.Parent.Children;
+        _sourceIndex = _sourceChildren.IndexOf(State.CurrentNode);
         _targetCollection = null;
         _targetIndex = -1;
-        var targetParent = CurrentNode.Parent.Parent;
+        var targetParent = State.CurrentNode.Parent.Parent;
         // The source must become the parent's successor
-        _targetCollection = CurrentNode.Parent.Parent.Children;
-        _targetIndex = _targetCollection.IndexOf(CurrentNode.Parent) + 1;
+        _targetCollection = State.CurrentNode.Parent.Parent.Children;
+        _targetIndex = _targetCollection.IndexOf(State.CurrentNode.Parent) + 1;
 
         _sourceChildren.RemoveAt(_sourceIndex);
         if (_targetIndex == -1)
         {
-            _targetCollection.Add(CurrentNode);
+            _targetCollection.Add(State.CurrentNode);
         }
         else
         {
-            _targetCollection.Insert(_targetIndex, CurrentNode);
+            _targetCollection.Insert(_targetIndex, State.CurrentNode);
         }
 
-        CurrentNode.Parent = targetParent;
+        State.CurrentNode.Parent = targetParent;
         ShowChange();
-        Logger.Log(LogLevel.Info, $"Moving {CurrentNode.Name} left to parent {CurrentNode.Parent.Name}");
+        Logger.Log(LogLevel.Info, $"Moving {State.CurrentNode.Name} left to parent {State.CurrentNode.Parent.Name}");
     }
 
     private bool MoveLeftIsValid()
     {
-        if (CurrentNode == null)
+        if (State.CurrentNode == null)
         {
             Messenger.Send(new StatusChangedMessage(new StatusMessage("Click or touch a node to move", LogLevel.Warn)));
             return false;
         }
 
-        if (CurrentNode.Parent != null && CurrentNode.Parent.IsRoot)
+        if (State.CurrentNode.Parent != null && State.CurrentNode.Parent.IsRoot)
         {
             Messenger.Send(new StatusChangedMessage(new StatusMessage("Cannot move further left", LogLevel.Warn)));
             return false;
         }
 
-        if (CurrentNode.Parent == null)
+        if (State.CurrentNode.Parent == null)
         {
             Messenger.Send(new StatusChangedMessage(new StatusMessage("Cannot move root node.", LogLevel.Warn)));
             return false;
@@ -1092,10 +1087,10 @@ public class ShellViewModel : ObservableRecipient
             return;
         }
 
-        if (CurrentNode.Parent != null)
+        if (State.CurrentNode.Parent != null)
         {
-            _sourceChildren = CurrentNode.Parent.Children;
-            _sourceIndex = _sourceChildren.IndexOf(CurrentNode);
+            _sourceChildren = State.CurrentNode.Parent.Children;
+            _sourceIndex = _sourceChildren.IndexOf(State.CurrentNode);
             _targetCollection = null;
             _targetIndex = -1;
         }
@@ -1106,7 +1101,7 @@ public class ShellViewModel : ObservableRecipient
         }
 
 
-        var sourceIndex = _sourceChildren.IndexOf(CurrentNode);
+        var sourceIndex = _sourceChildren.IndexOf(State.CurrentNode);
         StoryNodeItem targetParent;
         ObservableCollection<StoryNodeItem> targetCollection;
         int targetIndex;
@@ -1119,8 +1114,8 @@ public class ShellViewModel : ObservableRecipient
         }
         else
         {
-            var grandparentCollection = CurrentNode.Parent.Parent.Children;
-            var siblingIndex = grandparentCollection.IndexOf(CurrentNode.Parent) - 1;
+            var grandparentCollection = State.CurrentNode.Parent.Parent.Children;
+            var siblingIndex = grandparentCollection.IndexOf(State.CurrentNode.Parent) - 1;
 
             if (siblingIndex >= 0)
             {
@@ -1147,28 +1142,28 @@ public class ShellViewModel : ObservableRecipient
         }
 
         _sourceChildren.RemoveAt(sourceIndex);
-        targetCollection.Insert(targetIndex, CurrentNode);
-        CurrentNode.Parent = targetParent;
+        targetCollection.Insert(targetIndex, State.CurrentNode);
+        State.CurrentNode.Parent = targetParent;
         ShowChange();
-        Logger.Log(LogLevel.Info, $"Moving {CurrentNode.Name} right to parent {CurrentNode.Parent.Name}");
+        Logger.Log(LogLevel.Info, $"Moving {State.CurrentNode.Name} right to parent {State.CurrentNode.Parent.Name}");
     }
 
     private bool MoveRightIsValid()
     {
-        if (CurrentNode == null)
+        if (State.CurrentNode == null)
         {
             ShowStatusMessage("Click or touch a node to move", LogLevel.Warn);
             return false;
         }
 
-        if (CurrentNode.Parent == null)
+        if (State.CurrentNode.Parent == null)
         {
             ShowStatusMessage("Cannot move root node.", LogLevel.Warn);
             return false;
         }
 
-        if (CurrentNode.Parent.Parent == null
-            && CurrentNode.Parent.Children.IndexOf(CurrentNode) == 0)
+        if (State.CurrentNode.Parent.Parent == null
+            && State.CurrentNode.Parent.Children.IndexOf(State.CurrentNode) == 0)
         {
             ShowStatusMessage("Cannot move further right", LogLevel.Warn);
             return false;
@@ -1185,22 +1180,22 @@ public class ShellViewModel : ObservableRecipient
             return;
         }
 
-        _sourceChildren = CurrentNode.Parent.Children;
-        _sourceIndex = _sourceChildren.IndexOf(CurrentNode);
+        _sourceChildren = State.CurrentNode.Parent.Children;
+        _sourceIndex = _sourceChildren.IndexOf(State.CurrentNode);
         _targetCollection = null;
         _targetIndex = -1;
-        var targetParent = CurrentNode.Parent;
+        var targetParent = State.CurrentNode.Parent;
 
         if (_sourceIndex == 0)
         {
-            if (CurrentNode.Parent.Parent == null)
+            if (State.CurrentNode.Parent.Parent == null)
             {
                 ShowStatusMessage("Cannot move up further", LogLevel.Warn);
                 return;
             }
 
-            var grandparentCollection = CurrentNode.Parent.Parent.Children;
-            var siblingIndex = grandparentCollection.IndexOf(CurrentNode.Parent) - 1;
+            var grandparentCollection = State.CurrentNode.Parent.Parent.Children;
+            var siblingIndex = grandparentCollection.IndexOf(State.CurrentNode.Parent) - 1;
 
             if (siblingIndex >= 0)
             {
@@ -1225,27 +1220,27 @@ public class ShellViewModel : ObservableRecipient
 
         if (_targetIndex == -1)
         {
-            _targetCollection.Add(CurrentNode);
+            _targetCollection.Add(State.CurrentNode);
         }
         else
         {
-            _targetCollection.Insert(_targetIndex, CurrentNode);
+            _targetCollection.Insert(_targetIndex, State.CurrentNode);
         }
 
-        CurrentNode.Parent = targetParent;
+        State.CurrentNode.Parent = targetParent;
         ShowChange();
-        Logger.Log(LogLevel.Info, $"Moving {CurrentNode.Name} up to parent {CurrentNode.Parent.Name}");
+        Logger.Log(LogLevel.Info, $"Moving {State.CurrentNode.Name} up to parent {State.CurrentNode.Parent.Name}");
     }
 
     private bool MoveUpIsValid()
     {
-        if (CurrentNode == null)
+        if (State.CurrentNode == null)
         {
             ShowStatusMessage("Click or touch a node to move", LogLevel.Warn);
             return false;
         }
 
-        if (CurrentNode.IsRoot)
+        if (State.CurrentNode.IsRoot)
         {
             ShowStatusMessage("Cannot move up further", LogLevel.Warn);
             return false;
@@ -1262,18 +1257,18 @@ public class ShellViewModel : ObservableRecipient
             return;
         }
 
-        _sourceChildren = CurrentNode.Parent.Children;
-        _sourceIndex = _sourceChildren.IndexOf(CurrentNode);
+        _sourceChildren = State.CurrentNode.Parent.Children;
+        _sourceIndex = _sourceChildren.IndexOf(State.CurrentNode);
         _targetCollection = null;
         _targetIndex = 0;
-        var targetParent = CurrentNode.Parent;
+        var targetParent = State.CurrentNode.Parent;
 
         // If last child, must move to end parent's successor (sibling node).
         // If there are no siblings, we're at the bottom of the tree?
         if (_sourceIndex == _sourceChildren.Count - 1)
         {
             // Find the next sibling of the parent.
-            var nextParentSibling = GetNextSibling(CurrentNode.Parent);
+            var nextParentSibling = GetNextSibling(State.CurrentNode.Parent);
 
             // If there's no next sibling, then we're at the bottom of the first root's children.
             if (nextParentSibling == null)
@@ -1301,11 +1296,11 @@ public class ShellViewModel : ObservableRecipient
         }
 
         _sourceChildren.RemoveAt(_sourceIndex);
-        _targetCollection.Insert(_targetIndex, CurrentNode);
-        CurrentNode.Parent = targetParent;
+        _targetCollection.Insert(_targetIndex, State.CurrentNode);
+        State.CurrentNode.Parent = targetParent;
 
         ShowChange();
-        Logger.Log(LogLevel.Info, $"Moving {CurrentNode.Name} down up to parent {CurrentNode.Parent.Name}");
+        Logger.Log(LogLevel.Info, $"Moving {State.CurrentNode.Name} down up to parent {State.CurrentNode.Parent.Name}");
     }
 
     public StoryNodeItem GetNextSibling(StoryNodeItem node)
@@ -1328,13 +1323,13 @@ public class ShellViewModel : ObservableRecipient
 
     private bool MoveDownIsValid()
     {
-        if (CurrentNode == null)
+        if (State.CurrentNode == null)
         {
             ShowStatusMessage("Click or touch a node to move", LogLevel.Warn);
             return false;
         }
 
-        if (CurrentNode.IsRoot)
+        if (State.CurrentNode.IsRoot)
         {
             ShowStatusMessage("Cannot move a root node", LogLevel.Warn);
             return false;
@@ -1540,8 +1535,8 @@ public class ShellViewModel : ObservableRecipient
     private void NameMessageReceived(NameChangedMessage name)
     {
         var _msg = name.Value;
-        CurrentNode.Name = _msg.NewName;
-        switch (CurrentNode.Type)
+        State.CurrentNode.Name = _msg.NewName;
+        switch (State.CurrentNode.Type)
         {
             case StoryItemType.Character:
                 //int charIndex = CharacterModel.CharacterNames.IndexOf(msg.OldName);

--- a/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
+++ b/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
@@ -23,6 +23,7 @@ public class OutlineViewModel : ObservableRecipient
     private readonly BackendService _backendService;
     private readonly BackupService _backupService;
     private readonly EditFlushService _editFlushService;
+    private readonly ToolValidationService _toolValidationService;
     private readonly AppState appState;
     private readonly ILogService logger;
     private readonly OutlineService outlineService;
@@ -45,7 +46,7 @@ public class OutlineViewModel : ObservableRecipient
     public OutlineViewModel(ILogService logService, PreferenceService preferenceService,
         Windowing windowing, OutlineService outlineService, AppState appState,
         SearchService searchService, BackendService backendService, EditFlushService editFlushService,
-        AutoSaveService autoSaveService, BackupService backupService)
+        AutoSaveService autoSaveService, BackupService backupService, ToolValidationService toolValidationService)
     {
         logger = logService;
         preferences = preferenceService;
@@ -57,6 +58,7 @@ public class OutlineViewModel : ObservableRecipient
         _editFlushService = editFlushService;
         _autoSaveService = autoSaveService;
         _backupService = backupService;
+        _toolValidationService = toolValidationService;
     }
 
     #endregion
@@ -535,7 +537,7 @@ public class OutlineViewModel : ObservableRecipient
             appState.CurrentSaveable = null;
 
             shellVm.ResetModel();
-            shellVm.RightTappedNode = null; //Null right tapped node to prevent possible issues.
+            appState.RightTappedNode = null; //Null right tapped node to prevent possible issues.
             window.UpdateWindowTitle();
             _backupService.StopTimedBackup();
         }
@@ -756,14 +758,14 @@ public class OutlineViewModel : ObservableRecipient
     {
         using (new SerializationLock(logger))
         {
-            if (shellVm.RightTappedNode == null)
+            if (appState.RightTappedNode == null)
             {
                 Messenger.Send(new StatusChangedMessage(new StatusMessage("Right tap a node to print", LogLevel.Warn)));
                 logger.Log(LogLevel.Info, "Print node failed as no node is selected");
                 return Task.CompletedTask;
             }
 
-            Ioc.Default.GetRequiredService<PrintReportDialogVM>().PrintSingleNode(shellVm.RightTappedNode);
+            Ioc.Default.GetRequiredService<PrintReportDialogVM>().PrintSingleNode(appState.RightTappedNode);
         }
 
         return Task.CompletedTask;
@@ -774,9 +776,9 @@ public class OutlineViewModel : ObservableRecipient
         logger.Log(LogLevel.Info, "Displaying KeyQuestions tool dialog");
         using (new SerializationLock(logger))
         {
-            if (shellVm.RightTappedNode == null)
+            if (appState.RightTappedNode == null)
             {
-                shellVm.RightTappedNode = shellVm.CurrentNode;
+                appState.RightTappedNode = appState.CurrentNode;
             }
 
             //Creates and shows dialog
@@ -799,9 +801,9 @@ public class OutlineViewModel : ObservableRecipient
         logger.Log(LogLevel.Info, "Displaying Topics tool dialog");
         using (new SerializationLock(logger))
         {
-            if (shellVm.RightTappedNode == null)
+            if (appState.RightTappedNode == null)
             {
-                shellVm.RightTappedNode = shellVm.CurrentNode;
+                appState.RightTappedNode = appState.CurrentNode;
             }
 
             ContentDialog dialog = new()
@@ -824,7 +826,7 @@ public class OutlineViewModel : ObservableRecipient
         using (new SerializationLock(logger))
         {
             logger.Log(LogLevel.Info, "Displaying MasterPlot tool dialog");
-            if (VerifyToolUse(true, true))
+            if (_toolValidationService.VerifyToolUse(true, true))
             {
                 ContentDialog dialog = null;
                 if (!appState.Headless)
@@ -848,9 +850,9 @@ public class OutlineViewModel : ObservableRecipient
                     var model = masterPlotsVm.MasterPlots[masterPlotName];
                     IList<PlotPatternScene> scenes = model.PlotPatternScenes;
                     var problem = new ProblemModel(masterPlotName, appState.CurrentDocument.Model,
-                        shellVm.RightTappedNode);
-                    // add the new ProblemModel & node to the end of the target (shellVm.RightTappedNode) children
-                    shellVm.RightTappedNode.IsExpanded = true;
+                        appState.RightTappedNode);
+                    // add the new ProblemModel & node to the end of the target (appState.RightTappedNode) children
+                    appState.RightTappedNode.IsExpanded = true;
                     problem.Node.IsSelected = true;
                     problem.Node.IsExpanded = true;
                     if (scenes.Count == 1)
@@ -862,7 +864,7 @@ public class OutlineViewModel : ObservableRecipient
                     {
                         foreach (var scene in scenes)
                         {
-                            SceneModel child = new(appState.CurrentDocument.Model, shellVm.RightTappedNode)
+                            SceneModel child = new(appState.CurrentDocument.Model, appState.RightTappedNode)
                                 { Name = scene.SceneTitle, Description = "See Notes.", Notes = scene.Notes };
 
                             child.Node.IsSelected = true;
@@ -883,12 +885,12 @@ public class OutlineViewModel : ObservableRecipient
         logger.Log(LogLevel.Info, "Displaying Dramatic Situations tool dialog");
         using (new SerializationLock(logger))
         {
-            if (shellVm.RightTappedNode == null)
+            if (appState.RightTappedNode == null)
             {
                 shellVm.ShowMessage(LogLevel.Warn, "Right tap a node to insert a dramatic situation", false);
             }
 
-            if (VerifyToolUse(true, true))
+            if (_toolValidationService.VerifyToolUse(true, true))
             {
                 ContentDialog dialog = null;
                 if (!appState.Headless)
@@ -921,7 +923,7 @@ public class OutlineViewModel : ObservableRecipient
                 if (result == ContentDialogResult.Primary)
                 {
                     // Create and insert the new Problem as the target's child
-                    ProblemModel problem = new(situationModel.SituationName, appState.CurrentDocument.Model, shellVm.RightTappedNode)
+                    ProblemModel problem = new(situationModel.SituationName, appState.CurrentDocument.Model, appState.RightTappedNode)
                     {
                         Notes = situationModel.Notes
                     };
@@ -931,7 +933,7 @@ public class OutlineViewModel : ObservableRecipient
                 else if (result == ContentDialogResult.Secondary)
                 {
                     // Create and insert the new Scene as the target's child
-                    SceneModel sceneVar = new(situationModel.SituationName, appState.CurrentDocument.Model, shellVm.RightTappedNode)
+                    SceneModel sceneVar = new(situationModel.SituationName, appState.CurrentDocument.Model, appState.RightTappedNode)
                     {
                         Notes = situationModel.Notes
                     };
@@ -957,7 +959,7 @@ public class OutlineViewModel : ObservableRecipient
     public async Task StockScenesTool()
     {
         logger.Log(LogLevel.Info, "Displaying Stock Scenes tool dialog");
-        if (VerifyToolUse(true, true))
+        if (_toolValidationService.VerifyToolUse(true, true))
         {
             using (new SerializationLock(logger))
             {
@@ -990,11 +992,11 @@ public class OutlineViewModel : ObservableRecipient
                         }
 
                         SceneModel sceneVar = new(Ioc.Default.GetRequiredService<StockScenesViewModel>().SceneName,
-                            appState.CurrentDocument.Model, shellVm.RightTappedNode);
+                            appState.CurrentDocument.Model, appState.RightTappedNode);
 
-                        shellVm._sourceChildren = shellVm.RightTappedNode.Children;
+                        shellVm._sourceChildren = appState.RightTappedNode.Children;
                         shellVm.TreeViewNodeClicked(sceneVar.Node);
-                        shellVm.RightTappedNode.IsExpanded = true;
+                        appState.RightTappedNode.IsExpanded = true;
                         sceneVar.Node.IsSelected = true;
                         Messenger.Send(
                             new StatusChangedMessage(new StatusMessage("Stock Scenes inserted", LogLevel.Info)));
@@ -1013,75 +1015,6 @@ public class OutlineViewModel : ObservableRecipient
         }
     }
 
-
-    /// <summary>
-    ///     Verify that the tool being called has its prerequisites met.
-    /// </summary>
-    /// <param name="explorerViewOnly">This tool can only run in StoryExplorer view</param>
-    /// <param name="nodeRequired">A node (right-clicked or clicked) must be present</param>
-    /// <param name="checkOutlineIsOpen">A checks an outline is open (defaults to true)</param>
-    /// <returns>true if prerequisites are met</returns>
-    public bool VerifyToolUse(bool explorerViewOnly, bool nodeRequired, bool checkOutlineIsOpen = true)
-    {
-        try
-        {
-            if (explorerViewOnly && shellVm.CurrentViewType != StoryViewType.ExplorerView)
-            {
-                Messenger.Send(new StatusChangedMessage(new StatusMessage(
-                    "This tool can only be run in Story Explorer view", LogLevel.Warn)));
-                return false;
-            }
-
-            if (checkOutlineIsOpen)
-            {
-                if (appState.CurrentDocument?.Model == null)
-                {
-                    Messenger.Send(
-                        new StatusChangedMessage(new StatusMessage("Open or create an outline first", LogLevel.Warn)));
-                    return false;
-                }
-
-                if (shellVm.CurrentViewType == StoryViewType.ExplorerView &&
-                    appState.CurrentDocument.Model.ExplorerView.Count == 0)
-                {
-                    Messenger.Send(
-                        new StatusChangedMessage(new StatusMessage("Open or create an outline first", LogLevel.Warn)));
-                    return false;
-                }
-
-                if (shellVm.CurrentViewType == StoryViewType.NarratorView &&
-                    appState.CurrentDocument.Model.NarratorView.Count == 0)
-                {
-                    Messenger.Send(
-                        new StatusChangedMessage(new StatusMessage("Open or create an outline first", LogLevel.Warn)));
-                    return false;
-                }
-            }
-
-            if (nodeRequired)
-            {
-                if (shellVm.RightTappedNode == null)
-                {
-                    shellVm.RightTappedNode = shellVm.CurrentNode;
-                }
-
-                if (shellVm.RightTappedNode == null)
-                {
-                    Messenger.Send(
-                        new StatusChangedMessage(new StatusMessage("You need to select a node first", LogLevel.Warn)));
-                    return false;
-                }
-            }
-
-            return true;
-        }
-        catch (Exception ex)
-        {
-            logger.LogException(LogLevel.Error, ex, "Error in ShellVM.VerifyToolUse()");
-            return false; // Return false to prevent any issues.
-        }
-    }
-
     #endregion
 
     #region Add and Remove Story Element Commands
@@ -1095,7 +1028,7 @@ public class OutlineViewModel : ObservableRecipient
         using (new SerializationLock(logger))
         {
             logger.Log(LogLevel.Info, $"Adding StoryElement {typeToAdd}");
-            if (shellVm.RightTappedNode == null)
+            if (appState.RightTappedNode == null)
             {
                 Messenger.Send(
                     new StatusChangedMessage(new StatusMessage("Right tap a node to add to", LogLevel.Warn)));
@@ -1103,7 +1036,7 @@ public class OutlineViewModel : ObservableRecipient
                 return;
             }
 
-            if (StoryNodeItem.RootNodeType(shellVm.RightTappedNode) == StoryItemType.TrashCan)
+            if (StoryNodeItem.RootNodeType(appState.RightTappedNode) == StoryItemType.TrashCan)
             {
                 Messenger.Send(new StatusChangedMessage(new StatusMessage("Cannot add add to Deleted Items",
                     LogLevel.Warn, true)));
@@ -1112,7 +1045,7 @@ public class OutlineViewModel : ObservableRecipient
 
             //Create new element via outline service
             var newNode =
-                outlineService.AddStoryElement(appState.CurrentDocument.Model, typeToAdd, shellVm.RightTappedNode);
+                outlineService.AddStoryElement(appState.CurrentDocument.Model, typeToAdd, appState.RightTappedNode);
 
             // UI operations - skip in headless/test mode
             if (!appState.Headless)
@@ -1135,7 +1068,7 @@ public class OutlineViewModel : ObservableRecipient
     {
         try
         {
-            if (shellVm.RightTappedNode == null)
+            if (appState.RightTappedNode == null)
             {
                 Messenger.Send(
                     new StatusChangedMessage(new StatusMessage("Right tap a node to delete", LogLevel.Warn)));
@@ -1143,10 +1076,10 @@ public class OutlineViewModel : ObservableRecipient
             }
 
             var _delete = true;
-            var elementToDelete = shellVm.RightTappedNode.Uuid;
+            var elementToDelete = appState.RightTappedNode.Uuid;
 
             // Collect all GUIDs (element + all children)
-            var allGuids = outlineService.CollectAllDescendantGuids(shellVm.RightTappedNode, appState.CurrentDocument.Model);
+            var allGuids = outlineService.CollectAllDescendantGuids(appState.RightTappedNode, appState.CurrentDocument.Model);
 
             // Find references to ANY of these GUIDs
             var _foundElements = new List<StoryElement>();
@@ -1215,14 +1148,14 @@ public class OutlineViewModel : ObservableRecipient
                             outlineService.MoveToTrash(element, appState.CurrentDocument.Model);
 
                             // Clear the selected nodes to prevent issues (fix for #1056)
-                            if (shellVm.CurrentNode?.Uuid == elementToDelete)
+                            if (appState.CurrentNode?.Uuid == elementToDelete)
                             {
-                                shellVm.CurrentNode = null;
+                                appState.CurrentNode = null;
                             }
 
-                            if (shellVm.RightTappedNode?.Uuid == elementToDelete)
+                            if (appState.RightTappedNode?.Uuid == elementToDelete)
                             {
-                                shellVm.RightTappedNode = null;
+                                appState.RightTappedNode = null;
                             }
 
                             // Mark the model as changed
@@ -1257,7 +1190,7 @@ public class OutlineViewModel : ObservableRecipient
     public void RestoreStoryElement()
     {
         logger.Log(LogLevel.Trace, "RestoreStoryElement");
-        if (shellVm.RightTappedNode == null)
+        if (appState.RightTappedNode == null)
         {
             Messenger.Send(new StatusChangedMessage(new StatusMessage("Right tap a node to restore", LogLevel.Warn)));
             return;
@@ -1268,13 +1201,13 @@ public class OutlineViewModel : ObservableRecipient
             using (new SerializationLock(logger))
             {
                 // Use the new OutlineService method to restore from trash
-                outlineService.RestoreFromTrash(shellVm.RightTappedNode, appState.CurrentDocument.Model);
+                outlineService.RestoreFromTrash(appState.RightTappedNode, appState.CurrentDocument.Model);
 
                 // Mark the model as changed
                 Messenger.Send(new IsChangedMessage(true));
 
                 Messenger.Send(new StatusChangedMessage(new StatusMessage(
-                    $"Restored node {shellVm.RightTappedNode.Name} and all its contents", LogLevel.Info, true)));
+                    $"Restored node {appState.RightTappedNode.Name} and all its contents", LogLevel.Info, true)));
             }
         }
         catch (InvalidOperationException ex)
@@ -1297,23 +1230,23 @@ public class OutlineViewModel : ObservableRecipient
     public void CopyToNarrative()
     {
         logger.Log(LogLevel.Trace, "CopyToNarrative");
-        if (shellVm.RightTappedNode == null)
+        if (appState.RightTappedNode == null)
         {
             Messenger.Send(new StatusChangedMessage(new StatusMessage("Select a node to copy", LogLevel.Info)));
             return;
         }
 
-        if (shellVm.RightTappedNode.Type != StoryItemType.Scene)
+        if (appState.RightTappedNode.Type != StoryItemType.Scene)
         {
             Messenger.Send(new StatusChangedMessage(new StatusMessage("You can only copy a scene", LogLevel.Warn)));
             return;
         }
 
-        if (shellVm.RightTappedNode.CopyToNarratorView(appState.CurrentDocument.Model))
+        if (appState.RightTappedNode.CopyToNarratorView(appState.CurrentDocument.Model))
         {
             Messenger.Send(new IsChangedMessage(true));
             Messenger.Send(new StatusChangedMessage(new StatusMessage(
-                $"Copied node {shellVm.RightTappedNode.Name} to Narrative View", LogLevel.Info, true)));
+                $"Copied node {appState.RightTappedNode.Name} to Narrative View", LogLevel.Info, true)));
         }
         else
         {
@@ -1349,8 +1282,8 @@ public class OutlineViewModel : ObservableRecipient
                         LogLevel.Info)));
 
                     // Fix error #1056 - clear selected nodes even when trash is empty
-                    shellVm.RightTappedNode = null;
-                    shellVm.CurrentNode = null;
+                    appState.RightTappedNode = null;
+                    appState.CurrentNode = null;
                     return;
                 }
 
@@ -1363,8 +1296,8 @@ public class OutlineViewModel : ObservableRecipient
                     logger.Log(LogLevel.Info, "Emptied Trash.");
 
                     // Fix error #1056 - clear selected nodes
-                    shellVm.RightTappedNode = null;
-                    shellVm.CurrentNode = null;
+                    appState.RightTappedNode = null;
+                    appState.CurrentNode = null;
 
                     // Navigate to Overview to avoid showing deleted element
                     if (appState.CurrentDocument.Model.ExplorerView?.Count > 0)
@@ -1397,13 +1330,13 @@ public class OutlineViewModel : ObservableRecipient
     {
         logger.Log(LogLevel.Trace, "RemoveFromNarrative");
 
-        if (shellVm.RightTappedNode == null)
+        if (appState.RightTappedNode == null)
         {
             Messenger.Send(new StatusChangedMessage(new StatusMessage("Select a node to remove", LogLevel.Info)));
             return;
         }
 
-        if (shellVm.RightTappedNode.Type != StoryItemType.Scene)
+        if (appState.RightTappedNode.Type != StoryItemType.Scene)
         {
             Messenger.Send(
                 new StatusChangedMessage(new StatusMessage("You can only remove a Scene copy", LogLevel.Info)));
@@ -1412,19 +1345,19 @@ public class OutlineViewModel : ObservableRecipient
 
         // Find the node in narrator view by UUID and delete it
         var nodeInNarrator = appState.CurrentDocument.Model.NarratorView[0].Children
-            .FirstOrDefault(item => item.Uuid == shellVm.RightTappedNode.Uuid);
+            .FirstOrDefault(item => item.Uuid == appState.RightTappedNode.Uuid);
 
         if (nodeInNarrator != null)
         {
             nodeInNarrator.Delete(StoryViewType.NarratorView);
             Messenger.Send(new IsChangedMessage(true));
             Messenger.Send(new StatusChangedMessage(new StatusMessage(
-                $"Removed node {shellVm.RightTappedNode.Name} from Narrative View", LogLevel.Info, true)));
+                $"Removed node {appState.RightTappedNode.Name} from Narrative View", LogLevel.Info, true)));
         }
         else
         {
             Messenger.Send(new StatusChangedMessage(
-                new StatusMessage($"Node {shellVm.RightTappedNode.Name} not in Narrative View", LogLevel.Info, true)));
+                new StatusMessage($"Node {appState.RightTappedNode.Name} not in Narrative View", LogLevel.Info, true)));
         }
     }
 
@@ -1433,13 +1366,13 @@ public class OutlineViewModel : ObservableRecipient
     /// </summary>
     public void ConvertProblemToScene()
     {
-        if (shellVm.RightTappedNode == null)
+        if (appState.RightTappedNode == null)
         {
             Messenger.Send(new StatusChangedMessage(new StatusMessage("Select a node to convert", LogLevel.Info)));
             return;
         }
 
-        if (shellVm.RightTappedNode.Type != StoryItemType.Problem)
+        if (appState.RightTappedNode.Type != StoryItemType.Problem)
         {
             Messenger.Send(
                 new StatusChangedMessage(new StatusMessage("You can only convert a Problem", LogLevel.Warn)));
@@ -1448,7 +1381,7 @@ public class OutlineViewModel : ObservableRecipient
 
         var problem =
             (ProblemModel)outlineService.GetStoryElementByGuid(appState.CurrentDocument.Model,
-                shellVm.RightTappedNode.Uuid);
+                appState.RightTappedNode.Uuid);
         var scene = outlineService.ConvertProblemToScene(appState.CurrentDocument.Model, problem);
         shellVm.TreeViewNodeClicked(scene.Node, false);
         Messenger.Send(new StatusChangedMessage(new StatusMessage("Converted Problem to Scene", LogLevel.Info, true)));
@@ -1459,20 +1392,20 @@ public class OutlineViewModel : ObservableRecipient
     /// </summary>
     public void ConvertSceneToProblem()
     {
-        if (shellVm.RightTappedNode == null)
+        if (appState.RightTappedNode == null)
         {
             Messenger.Send(new StatusChangedMessage(new StatusMessage("Select a node to convert", LogLevel.Info)));
             return;
         }
 
-        if (shellVm.RightTappedNode.Type != StoryItemType.Scene)
+        if (appState.RightTappedNode.Type != StoryItemType.Scene)
         {
             Messenger.Send(new StatusChangedMessage(new StatusMessage("You can only convert a Scene", LogLevel.Warn)));
             return;
         }
 
         var scene = (SceneModel)outlineService.GetStoryElementByGuid(appState.CurrentDocument.Model,
-            shellVm.RightTappedNode.Uuid);
+            appState.RightTappedNode.Uuid);
         var problem = outlineService.ConvertSceneToProblem(appState.CurrentDocument.Model, scene);
         shellVm.TreeViewNodeClicked(problem.Node, false);
         Messenger.Send(new StatusChangedMessage(new StatusMessage("Converted Scene to Problem", LogLevel.Info, true)));

--- a/StoryCADLib/ViewModels/Tools/NarrativeToolVM.cs
+++ b/StoryCADLib/ViewModels/Tools/NarrativeToolVM.cs
@@ -23,8 +23,6 @@ public class NarrativeToolVM : ObservableRecipient
 
     private readonly ILogService _logger;
 
-    // ShellViewModel required for CurrentViewType, CurrentNode, and RightTappedNode
-    // See ToolValidationService.cs:11-17 for refactoring plan (deferred - requires ~123 changes)
     private readonly ShellViewModel _shellVM;
     private readonly ToolValidationService _toolValidationService;
     private readonly Windowing _windowing;
@@ -75,15 +73,10 @@ public class NarrativeToolVM : ObservableRecipient
     /// </summary>
     public async Task OpenNarrativeTool()
     {
-        // Use ToolValidationService instead of direct OutlineViewModel dependency
-        // Note: Still requires ShellViewModel for state, see ToolValidationService docs for future refactoring
+        // ToolValidationService reads state from AppState (Issue #1146)
         if (_toolValidationService.VerifyToolUse(
-                _shellVM.CurrentViewType,
-                _shellVM.CurrentNode,
-                _shellVM.RightTappedNode,
-                _appState.CurrentDocument?.Model,
-                false, // explorerViewOnly
-                false)) // nodeRequired
+                explorerViewOnly: false,
+                nodeRequired: false))
         {
             using (new SerializationLock(_logger))
             {

--- a/StoryCADTests/Models/AppStateTests.cs
+++ b/StoryCADTests/Models/AppStateTests.cs
@@ -1,5 +1,6 @@
 using StoryCADLib.Models;
 using StoryCADLib.Services;
+using StoryCADLib.ViewModels;
 
 namespace StoryCADTests.Models;
 
@@ -75,4 +76,121 @@ public class AppStateTests
         {
         }
     }
+
+    #region CurrentViewType Tests (Issue #1146)
+
+    [TestMethod]
+    public void CurrentViewType_WhenSet_StoresValue()
+    {
+        // Arrange
+        var appState = new AppState();
+
+        // Act
+        appState.CurrentViewType = StoryViewType.NarratorView;
+
+        // Assert
+        Assert.AreEqual(StoryViewType.NarratorView, appState.CurrentViewType);
+    }
+
+    [TestMethod]
+    public void CurrentViewType_InitiallyDefault()
+    {
+        // Arrange
+        var appState = new AppState();
+
+        // Act & Assert - enum defaults to first value (0 = ExplorerView)
+        Assert.AreEqual(default(StoryViewType), appState.CurrentViewType);
+    }
+
+    #endregion
+
+    #region CurrentNode Tests (Issue #1146)
+
+    [TestMethod]
+    public void CurrentNode_WhenSet_StoresValue()
+    {
+        // Arrange
+        var appState = new AppState();
+        var model = new StoryModel();
+        var node = new StoryNodeItem(new OverviewModel("Test", model, null), null);
+
+        // Act
+        appState.CurrentNode = node;
+
+        // Assert
+        Assert.AreSame(node, appState.CurrentNode);
+    }
+
+    [TestMethod]
+    public void CurrentNode_InitiallyNull()
+    {
+        // Arrange
+        var appState = new AppState();
+
+        // Act & Assert
+        Assert.IsNull(appState.CurrentNode);
+    }
+
+    [TestMethod]
+    public void CurrentNode_CanBeSetToNull()
+    {
+        // Arrange
+        var appState = new AppState();
+        var model = new StoryModel();
+        var node = new StoryNodeItem(new OverviewModel("Test", model, null), null);
+        appState.CurrentNode = node;
+
+        // Act
+        appState.CurrentNode = null;
+
+        // Assert
+        Assert.IsNull(appState.CurrentNode);
+    }
+
+    #endregion
+
+    #region RightTappedNode Tests (Issue #1146)
+
+    [TestMethod]
+    public void RightTappedNode_WhenSet_StoresValue()
+    {
+        // Arrange
+        var appState = new AppState();
+        var model = new StoryModel();
+        var node = new StoryNodeItem(new OverviewModel("Test", model, null), null);
+
+        // Act
+        appState.RightTappedNode = node;
+
+        // Assert
+        Assert.AreSame(node, appState.RightTappedNode);
+    }
+
+    [TestMethod]
+    public void RightTappedNode_InitiallyNull()
+    {
+        // Arrange
+        var appState = new AppState();
+
+        // Act & Assert
+        Assert.IsNull(appState.RightTappedNode);
+    }
+
+    [TestMethod]
+    public void RightTappedNode_CanBeSetToNull()
+    {
+        // Arrange
+        var appState = new AppState();
+        var model = new StoryModel();
+        var node = new StoryNodeItem(new OverviewModel("Test", model, null), null);
+        appState.RightTappedNode = node;
+
+        // Act
+        appState.RightTappedNode = null;
+
+        // Assert
+        Assert.IsNull(appState.RightTappedNode);
+    }
+
+    #endregion
 }

--- a/StoryCADTests/Services/Dialogs/ToolValidationServiceTests.cs
+++ b/StoryCADTests/Services/Dialogs/ToolValidationServiceTests.cs
@@ -1,0 +1,401 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using StoryCADLib.Models;
+using StoryCADLib.Services;
+using StoryCADLib.Services.Dialogs;
+using StoryCADLib.ViewModels;
+
+#nullable disable
+
+namespace StoryCADTests.Services.Dialogs;
+
+/// <summary>
+///     Tests for ToolValidationService which validates prerequisites for tool usage.
+///     These tests verify validation logic for explorer view requirements, outline state,
+///     and node selection requirements. The service reads state from AppState.
+/// </summary>
+[TestClass]
+public class ToolValidationServiceTests
+{
+    private ToolValidationService _toolValidationService;
+    private AppState _appState;
+    private StoryModel _model;
+    private StoryNodeItem _testNode;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        _toolValidationService = Ioc.Default.GetRequiredService<ToolValidationService>();
+        _appState = Ioc.Default.GetRequiredService<AppState>();
+
+        // Create a minimal story model for testing
+        _model = new StoryModel();
+        _testNode = new StoryNodeItem(new OverviewModel("Test Story", _model, null), null);
+        _model.ExplorerView.Add(_testNode);
+        _model.NarratorView.Add(new StoryNodeItem(new FolderModel("Narrative View", _model, StoryItemType.Folder, null), null));
+
+        // Set up AppState with default test state
+        _appState.CurrentDocument = new StoryDocument(_model, "test.stbx");
+        _appState.CurrentViewType = StoryViewType.ExplorerView;
+        _appState.CurrentNode = _testNode;
+        _appState.RightTappedNode = null;
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        // Reset AppState after each test
+        _appState.CurrentDocument = null;
+        _appState.CurrentViewType = default;
+        _appState.CurrentNode = null;
+        _appState.RightTappedNode = null;
+    }
+
+    #region Basic Validation Tests (6)
+
+    [TestMethod]
+    public void VerifyToolUse_WithExplorerViewOnly_InExplorerView_ReturnsTrue()
+    {
+        // Arrange
+        _appState.CurrentViewType = StoryViewType.ExplorerView;
+        _appState.RightTappedNode = _testNode;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: true, nodeRequired: false);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_WithExplorerViewOnly_InNarratorView_ReturnsFalse()
+    {
+        // Arrange
+        _appState.CurrentViewType = StoryViewType.NarratorView;
+        _appState.RightTappedNode = _testNode;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: true, nodeRequired: false);
+
+        // Assert
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_WithoutExplorerViewOnly_InNarratorView_ReturnsTrue()
+    {
+        // Arrange
+        _appState.CurrentViewType = StoryViewType.NarratorView;
+        _appState.RightTappedNode = _testNode;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: false);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_WithNodeRequired_WhenRightTappedNodeExists_ReturnsTrue()
+    {
+        // Arrange
+        _appState.CurrentNode = null;
+        _appState.RightTappedNode = _testNode;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: true);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_WithNodeRequired_WhenOnlyCurrentNodeExists_ReturnsTrue()
+    {
+        // Arrange
+        _appState.CurrentNode = _testNode;
+        _appState.RightTappedNode = null;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: true);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_WithoutNodeRequired_WhenBothNodesNull_ReturnsTrue()
+    {
+        // Arrange
+        _appState.CurrentNode = null;
+        _appState.RightTappedNode = null;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: false);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    #endregion
+
+    #region Outline Open Validation Tests (5)
+
+    [TestMethod]
+    public void VerifyToolUse_WithCheckOutlineIsOpen_WhenModelIsNull_ReturnsFalse()
+    {
+        // Arrange
+        _appState.CurrentDocument = null;
+        _appState.RightTappedNode = _testNode;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: false, checkOutlineIsOpen: true);
+
+        // Assert
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_WithCheckOutlineIsOpen_WhenExplorerViewEmpty_ReturnsFalse()
+    {
+        // Arrange
+        var emptyModel = new StoryModel();
+        emptyModel.ExplorerView.Clear();
+        _appState.CurrentDocument = new StoryDocument(emptyModel, "test.stbx");
+        _appState.CurrentViewType = StoryViewType.ExplorerView;
+        _appState.RightTappedNode = _testNode;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: false, checkOutlineIsOpen: true);
+
+        // Assert
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_WithCheckOutlineIsOpen_WhenNarratorViewEmpty_ReturnsFalse()
+    {
+        // Arrange
+        var model = new StoryModel();
+        model.ExplorerView.Add(_testNode);
+        model.NarratorView.Clear();
+        _appState.CurrentDocument = new StoryDocument(model, "test.stbx");
+        _appState.CurrentViewType = StoryViewType.NarratorView;
+        _appState.RightTappedNode = _testNode;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: false, checkOutlineIsOpen: true);
+
+        // Assert
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_WithCheckOutlineIsOpen_WhenModelPopulated_ReturnsTrue()
+    {
+        // Arrange
+        _appState.RightTappedNode = _testNode;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: false, checkOutlineIsOpen: true);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_WithoutCheckOutlineIsOpen_WhenModelIsNull_ReturnsTrue()
+    {
+        // Arrange
+        _appState.CurrentDocument = null;
+        _appState.RightTappedNode = _testNode;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: false, checkOutlineIsOpen: false);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    #endregion
+
+    #region Side Effect Tests (4) - Critical for issue #1146
+
+    [TestMethod]
+    public void VerifyToolUse_WithNodeRequired_WhenBothNodesNull_ReturnsFalse()
+    {
+        // Arrange
+        _appState.CurrentNode = null;
+        _appState.RightTappedNode = null;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: true);
+
+        // Assert
+        Assert.IsFalse(result, "Should return false when node is required but both nodes are null");
+        Assert.IsNull(_appState.RightTappedNode, "Should not set RightTappedNode when both are null");
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_WithNodeRequired_WhenRightTappedNull_SetsRightTappedToCurrentNode()
+    {
+        // Arrange - RightTappedNode is null, but CurrentNode exists
+        _appState.CurrentNode = _testNode;
+        _appState.RightTappedNode = null;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: true);
+
+        // Assert
+        Assert.IsTrue(result, "Should return true when CurrentNode exists");
+        Assert.AreSame(_testNode, _appState.RightTappedNode, "Should set RightTappedNode to CurrentNode (side effect)");
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_WithNodeRequired_WhenRightTappedExists_DoesNotChangeRightTapped()
+    {
+        // Arrange - Both nodes exist, RightTappedNode should NOT be changed
+        var rightTappedNode = new StoryNodeItem(new FolderModel("Test Folder", _model, StoryItemType.Folder, null), null);
+        _appState.CurrentNode = _testNode;
+        _appState.RightTappedNode = rightTappedNode;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: true);
+
+        // Assert
+        Assert.IsTrue(result, "Should return true when RightTappedNode exists");
+        Assert.AreSame(rightTappedNode, _appState.RightTappedNode, "Should NOT change RightTappedNode when it already exists");
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_WithoutNodeRequired_NoSideEffect()
+    {
+        // Arrange - nodeRequired=false, so no side effect should occur
+        _appState.CurrentNode = _testNode;
+        _appState.RightTappedNode = null;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: false);
+
+        // Assert
+        Assert.IsTrue(result, "Should return true when nodeRequired is false");
+        Assert.IsNull(_appState.RightTappedNode, "Should NOT set RightTappedNode when nodeRequired is false");
+    }
+
+    #endregion
+
+    #region Edge Case Tests (3)
+
+    [TestMethod]
+    public void VerifyToolUse_WithDefaultViewType_AndExplorerViewOnly_ReturnsTrue()
+    {
+        // Arrange - default StoryViewType is ExplorerView (enum value 0)
+        _appState.CurrentViewType = default;
+        _appState.RightTappedNode = _testNode;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: true, nodeRequired: false);
+
+        // Assert
+        Assert.IsTrue(result, "Default StoryViewType is ExplorerView, should pass explorerViewOnly check");
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_WithAllValidationsPassed_ReturnsTrue()
+    {
+        // Arrange - all conditions met
+        _appState.CurrentViewType = StoryViewType.ExplorerView;
+        _appState.RightTappedNode = _testNode;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: true, nodeRequired: true, checkOutlineIsOpen: true);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_WithMultipleValidationFailures_ReturnsFalseForFirst()
+    {
+        // Arrange - multiple failures: wrong view, no node, no model
+        _appState.CurrentViewType = StoryViewType.NarratorView;
+        _appState.CurrentNode = null;
+        _appState.RightTappedNode = null;
+        _appState.CurrentDocument = null;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: true, nodeRequired: true, checkOutlineIsOpen: true);
+
+        // Assert
+        Assert.IsFalse(result, "Should return false on first validation failure");
+    }
+
+    #endregion
+
+    #region Status Message Tests (3)
+
+    [TestMethod]
+    public void VerifyToolUse_ExplorerViewOnlyFailure_ReturnsFalse()
+    {
+        // Arrange
+        _appState.CurrentViewType = StoryViewType.NarratorView;
+        _appState.RightTappedNode = _testNode;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: true, nodeRequired: false);
+
+        // Assert
+        Assert.IsFalse(result, "Should return false and send status message for explorer view failure");
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_NodeRequiredFailure_ReturnsFalse()
+    {
+        // Arrange
+        _appState.CurrentNode = null;
+        _appState.RightTappedNode = null;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: true);
+
+        // Assert
+        Assert.IsFalse(result, "Should return false and send status message for node required failure");
+    }
+
+    [TestMethod]
+    public void VerifyToolUse_OutlineOpenFailure_ReturnsFalse()
+    {
+        // Arrange
+        _appState.CurrentDocument = null;
+        _appState.RightTappedNode = _testNode;
+
+        // Act
+        var result = _toolValidationService.VerifyToolUse(
+            explorerViewOnly: false, nodeRequired: false, checkOutlineIsOpen: true);
+
+        // Assert
+        Assert.IsFalse(result, "Should return false and send status message for outline open failure");
+    }
+
+    #endregion
+}

--- a/StoryCADTests/ViewModels/ShellViewModelTests.cs
+++ b/StoryCADTests/ViewModels/ShellViewModelTests.cs
@@ -24,21 +24,22 @@ public class ShellViewModelTests
         var outlineService = Ioc.Default.GetService<OutlineService>();
         var outlineVM = Ioc.Default.GetService<OutlineViewModel>();
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await outlineService.CreateModel("Test1056", "StoryBuilder", 2);
         // Set up the current view (Explorer view)
         outlineService.SetCurrentView(model, StoryViewType.ExplorerView);
 
         //Create node to be deleted
-        shell.CurrentNode = model.StoryElements
+        appState.CurrentNode = model.StoryElements
             .First(e => e.ElementType == StoryItemType.Folder
                         && e.Name != "Narrative View").Node;
-        shell.RightTappedNode = shell.CurrentNode;
+        appState.RightTappedNode = appState.CurrentNode;
         await outlineVM.RemoveStoryElement();
         outlineVM.EmptyTrash();
 
         //Assert we have cleared the stuff that could go wrong
-        Assert.IsNull(shell.CurrentNode);
-        Assert.IsNull(shell.RightTappedNode);
+        Assert.IsNull(appState.CurrentNode);
+        Assert.IsNull(appState.RightTappedNode);
     }
 
     /// <summary>
@@ -251,14 +252,15 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
-        var previousNode = shell.CurrentNode;
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var previousNode = appState.CurrentNode;
         var previousPageType = shell.CurrentPageType;
 
         // Act - should handle null gracefully
         shell.TreeViewNodeClicked(null);
 
         // Assert - state should not change
-        Assert.AreEqual(previousNode, shell.CurrentNode);
+        Assert.AreEqual(previousNode, appState.CurrentNode);
         Assert.AreEqual(previousPageType, shell.CurrentPageType);
     }
 
@@ -270,6 +272,7 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
 
         // Find a character element
@@ -282,7 +285,7 @@ public class ShellViewModelTests
         shell.TreeViewNodeClicked(characterElement.Node);
 
         // Assert
-        Assert.AreEqual(characterElement.Node, shell.CurrentNode);
+        Assert.AreEqual(characterElement.Node, appState.CurrentNode);
         Assert.AreEqual("CharacterPage", shell.CurrentPageType);
     }
 
@@ -294,6 +297,7 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
 
         // Find a scene element
@@ -306,7 +310,7 @@ public class ShellViewModelTests
         shell.TreeViewNodeClicked(sceneElement.Node);
 
         // Assert
-        Assert.AreEqual(sceneElement.Node, shell.CurrentNode);
+        Assert.AreEqual(sceneElement.Node, appState.CurrentNode);
         Assert.AreEqual("ScenePage", shell.CurrentPageType);
     }
 
@@ -318,6 +322,7 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
 
         // Find a problem element
@@ -330,7 +335,7 @@ public class ShellViewModelTests
         shell.TreeViewNodeClicked(problemElement.Node);
 
         // Assert
-        Assert.AreEqual(problemElement.Node, shell.CurrentNode);
+        Assert.AreEqual(problemElement.Node, appState.CurrentNode);
         Assert.AreEqual("ProblemPage", shell.CurrentPageType);
     }
 
@@ -342,6 +347,7 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
 
         // Find a folder element
@@ -354,7 +360,7 @@ public class ShellViewModelTests
         shell.TreeViewNodeClicked(folderElement.Node);
 
         // Assert
-        Assert.AreEqual(folderElement.Node, shell.CurrentNode);
+        Assert.AreEqual(folderElement.Node, appState.CurrentNode);
         Assert.AreEqual("FolderPage", shell.CurrentPageType);
     }
 
@@ -366,6 +372,7 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
 
         // Find a setting element
@@ -378,7 +385,7 @@ public class ShellViewModelTests
         shell.TreeViewNodeClicked(settingElement.Node);
 
         // Assert
-        Assert.AreEqual(settingElement.Node, shell.CurrentNode);
+        Assert.AreEqual(settingElement.Node, appState.CurrentNode);
         Assert.AreEqual("SettingPage", shell.CurrentPageType);
     }
 
@@ -390,6 +397,7 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
 
         // Find overview element
@@ -402,7 +410,7 @@ public class ShellViewModelTests
         shell.TreeViewNodeClicked(overviewElement.Node);
 
         // Assert
-        Assert.AreEqual(overviewElement.Node, shell.CurrentNode);
+        Assert.AreEqual(overviewElement.Node, appState.CurrentNode);
         Assert.AreEqual("OverviewPage", shell.CurrentPageType);
     }
 
@@ -414,6 +422,7 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
 
         // Find a web element
@@ -426,7 +435,7 @@ public class ShellViewModelTests
         shell.TreeViewNodeClicked(webElement.Node);
 
         // Assert
-        Assert.AreEqual(webElement.Node, shell.CurrentNode);
+        Assert.AreEqual(webElement.Node, appState.CurrentNode);
         Assert.AreEqual("WebPage", shell.CurrentPageType);
     }
 
@@ -438,6 +447,7 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
 
         // Find a notes element
@@ -450,7 +460,7 @@ public class ShellViewModelTests
         shell.TreeViewNodeClicked(notesElement.Node);
 
         // Assert
-        Assert.AreEqual(notesElement.Node, shell.CurrentNode);
+        Assert.AreEqual(notesElement.Node, appState.CurrentNode);
         Assert.AreEqual("FolderPage", shell.CurrentPageType); // Notes use FolderPage
     }
 
@@ -462,6 +472,7 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
 
         // Find a section element - Section is created as Folder type with "Test Section" name
@@ -474,7 +485,7 @@ public class ShellViewModelTests
         shell.TreeViewNodeClicked(sectionElement.Node);
 
         // Assert
-        Assert.AreEqual(sectionElement.Node, shell.CurrentNode);
+        Assert.AreEqual(sectionElement.Node, appState.CurrentNode);
         Assert.AreEqual("FolderPage", shell.CurrentPageType); // Section uses FolderPage
     }
 
@@ -486,6 +497,7 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
 
         // Find trash can element
@@ -498,7 +510,7 @@ public class ShellViewModelTests
         shell.TreeViewNodeClicked(trashElement.Node);
 
         // Assert
-        Assert.AreEqual(trashElement.Node, shell.CurrentNode);
+        Assert.AreEqual(trashElement.Node, appState.CurrentNode);
         Assert.AreEqual("TrashCanPage", shell.CurrentPageType);
     }
 
@@ -510,14 +522,15 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
-        var previousNode = shell.CurrentNode;
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var previousNode = appState.CurrentNode;
         var previousPageType = shell.CurrentPageType;
 
         // Act - pass a non-StoryNodeItem object
         shell.TreeViewNodeClicked("Not a StoryNodeItem");
 
         // Assert - state should not change since it's not a StoryNodeItem
-        Assert.AreEqual(previousNode, shell.CurrentNode);
+        Assert.AreEqual(previousNode, appState.CurrentNode);
         Assert.AreEqual(previousPageType, shell.CurrentPageType);
     }
 
@@ -548,7 +561,7 @@ public class ShellViewModelTests
 
         // Assert
         Assert.AreEqual("Story Narrator View", shell.CurrentView);
-        Assert.AreEqual(StoryViewType.NarratorView, shell.CurrentViewType);
+        Assert.AreEqual(StoryViewType.NarratorView, appState.CurrentViewType);
         Assert.AreEqual(StoryViewType.NarratorView, appState.CurrentDocument.Model.CurrentViewType);
     }
 
@@ -577,7 +590,7 @@ public class ShellViewModelTests
 
         // Assert
         Assert.AreEqual("Story Explorer View", shell.CurrentView);
-        Assert.AreEqual(StoryViewType.ExplorerView, shell.CurrentViewType);
+        Assert.AreEqual(StoryViewType.ExplorerView, appState.CurrentViewType);
         Assert.AreEqual(StoryViewType.ExplorerView, appState.CurrentDocument.Model.CurrentViewType);
     }
 
@@ -600,14 +613,14 @@ public class ShellViewModelTests
         // Set both to same view
         shell.CurrentView = "Story Explorer View";
         shell.SelectedView = "Story Explorer View";
-        var initialViewType = shell.CurrentViewType;
+        var initialViewType = appState.CurrentViewType;
 
         // Act
         shell.ViewChanged();
 
         // Assert - nothing should change
         Assert.AreEqual("Story Explorer View", shell.CurrentView);
-        Assert.AreEqual(initialViewType, shell.CurrentViewType);
+        Assert.AreEqual(initialViewType, appState.CurrentViewType);
     }
 
     /// <summary>
@@ -669,12 +682,13 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
         var trashNode = model.StoryElements
             .FirstOrDefault(e => e.ElementType == StoryItemType.TrashCan)?.Node;
 
         Assert.IsNotNull(trashNode, "Should have trash node");
-        shell.RightTappedNode = trashNode;
+        appState.RightTappedNode = trashNode;
 
         // Act
         shell.ShowFlyoutButtons();
@@ -695,12 +709,13 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
         var characterNode = model.StoryElements
             .FirstOrDefault(e => e.ElementType == StoryItemType.Character)?.Node;
 
         Assert.IsNotNull(characterNode, "Should have character node");
-        shell.RightTappedNode = characterNode;
+        appState.RightTappedNode = characterNode;
         shell.SelectedView = "Story Explorer View";
 
         // Act
@@ -722,12 +737,13 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
         var sceneNode = model.StoryElements
             .FirstOrDefault(e => e.ElementType == StoryItemType.Scene)?.Node;
 
         Assert.IsNotNull(sceneNode, "Should have scene node");
-        shell.RightTappedNode = sceneNode;
+        appState.RightTappedNode = sceneNode;
         shell.SelectedView = "Story Narrator View";
 
         // Act
@@ -749,7 +765,8 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
-        shell.RightTappedNode = null;
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        appState.RightTappedNode = null;
         shell.SelectedView = "Story Explorer View";
 
         // Act - should handle exception internally
@@ -772,6 +789,7 @@ public class ShellViewModelTests
         // Arrange
         var outlineService = Ioc.Default.GetService<OutlineService>();
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
         var overview = model.ExplorerView.First();
 
@@ -781,7 +799,7 @@ public class ShellViewModelTests
         var character = outlineService.AddStoryElement(model, StoryItemType.Character, folder.Node);
         character.Name = "Test Character";
 
-        shell.CurrentNode = character.Node;
+        appState.CurrentNode = character.Node;
         var initialParent = character.Node.Parent;
         var grandparent = initialParent.Parent;
 
@@ -806,10 +824,11 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
         var overview = model.ExplorerView.First();
 
-        shell.CurrentNode = overview;
+        appState.CurrentNode = overview;
         var initialParent = overview.Parent;
 
         // Act
@@ -827,8 +846,9 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         await CreateTestModelWithAllElements();
-        shell.CurrentNode = null;
+        appState.CurrentNode = null;
 
         // Act
         shell.MoveLeftCommand.Execute(null);
@@ -846,6 +866,7 @@ public class ShellViewModelTests
         // Arrange
         var outlineService = Ioc.Default.GetService<OutlineService>();
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
         var overview = model.ExplorerView.First();
 
@@ -855,7 +876,7 @@ public class ShellViewModelTests
         var folder2 = outlineService.AddStoryElement(model, StoryItemType.Folder, overview);
         folder2.Name = "Folder 2";
 
-        shell.CurrentNode = folder2.Node;
+        appState.CurrentNode = folder2.Node;
 
         // Act
         shell.MoveRightCommand.Execute(null);
@@ -875,6 +896,7 @@ public class ShellViewModelTests
         // Arrange
         var outlineService = Ioc.Default.GetService<OutlineService>();
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await outlineService.CreateModel("Test Story", "Test Author", 0);
         var overview = model.ExplorerView.First();
 
@@ -884,7 +906,7 @@ public class ShellViewModelTests
         // Create just one folder (first child, no previous sibling)
         var folder = outlineService.AddStoryElement(model, StoryItemType.Folder, overview);
         folder.Name = "First Folder";
-        shell.CurrentNode = folder.Node;
+        appState.CurrentNode = folder.Node;
         var initialParent = folder.Node.Parent;
 
         // Act
@@ -903,8 +925,9 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         await CreateTestModelWithAllElements();
-        shell.CurrentNode = null;
+        appState.CurrentNode = null;
 
         // Act
         shell.MoveRightCommand.Execute(null);
@@ -922,6 +945,7 @@ public class ShellViewModelTests
         // Arrange
         var outlineService = Ioc.Default.GetService<OutlineService>();
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
         var overview = model.ExplorerView.First();
 
@@ -933,7 +957,7 @@ public class ShellViewModelTests
         var char3 = outlineService.AddStoryElement(model, StoryItemType.Character, overview);
         char3.Name = "Character 3";
 
-        shell.CurrentNode = char2.Node;
+        appState.CurrentNode = char2.Node;
 
         // Act
         shell.MoveUpCommand.Execute(null);
@@ -955,6 +979,7 @@ public class ShellViewModelTests
         // Arrange
         var outlineService = Ioc.Default.GetService<OutlineService>();
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
         var overview = model.ExplorerView.First();
 
@@ -969,7 +994,7 @@ public class ShellViewModelTests
         var folder2Child = outlineService.AddStoryElement(model, StoryItemType.Scene, folder2.Node);
         folder2Child.Name = "Folder 2 Child";
 
-        shell.CurrentNode = folder2Child.Node;
+        appState.CurrentNode = folder2Child.Node;
 
         // Act
         shell.MoveUpCommand.Execute(null);
@@ -989,11 +1014,12 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
         var overview = model.ExplorerView.First();
 
         // Overview is a root node
-        shell.CurrentNode = overview;
+        appState.CurrentNode = overview;
 
         // Act
         shell.MoveUpCommand.Execute(null);
@@ -1010,8 +1036,9 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         await CreateTestModelWithAllElements();
-        shell.CurrentNode = null;
+        appState.CurrentNode = null;
 
         // Act
         shell.MoveUpCommand.Execute(null);
@@ -1029,6 +1056,7 @@ public class ShellViewModelTests
         // Arrange
         var outlineService = Ioc.Default.GetService<OutlineService>();
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
         var overview = model.ExplorerView.First();
 
@@ -1040,7 +1068,7 @@ public class ShellViewModelTests
         var scene3 = outlineService.AddStoryElement(model, StoryItemType.Scene, overview);
         scene3.Name = "Scene 3";
 
-        shell.CurrentNode = scene2.Node;
+        appState.CurrentNode = scene2.Node;
 
         // Act
         shell.MoveDownCommand.Execute(null);
@@ -1062,6 +1090,7 @@ public class ShellViewModelTests
         // Arrange
         var outlineService = Ioc.Default.GetService<OutlineService>();
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
         var overview = model.ExplorerView.First();
 
@@ -1074,7 +1103,7 @@ public class ShellViewModelTests
         var folder2 = outlineService.AddStoryElement(model, StoryItemType.Folder, overview);
         folder2.Name = "Folder 2";
 
-        shell.CurrentNode = folder1Child.Node;
+        appState.CurrentNode = folder1Child.Node;
 
         // Act
         shell.MoveDownCommand.Execute(null);
@@ -1097,6 +1126,7 @@ public class ShellViewModelTests
         // Arrange
         var outlineService = Ioc.Default.GetService<OutlineService>();
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
 
         // In Explorer view, the last root is typically before TrashCan
@@ -1108,7 +1138,7 @@ public class ShellViewModelTests
         {
             // Get last child of last non-trash root
             var lastChild = lastNonTrashRoot.Children.Last();
-            shell.CurrentNode = lastChild;
+            appState.CurrentNode = lastChild;
             var initialParent = lastChild.Parent;
 
             // Act
@@ -1127,11 +1157,12 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
         var overview = model.ExplorerView.First();
 
         // Overview is a root node
-        shell.CurrentNode = overview;
+        appState.CurrentNode = overview;
 
         // Act
         shell.MoveDownCommand.Execute(null);
@@ -1148,8 +1179,9 @@ public class ShellViewModelTests
     {
         // Arrange
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         await CreateTestModelWithAllElements();
-        shell.CurrentNode = null;
+        appState.CurrentNode = null;
 
         // Act
         shell.MoveDownCommand.Execute(null);
@@ -1167,6 +1199,7 @@ public class ShellViewModelTests
         // Arrange
         var outlineService = Ioc.Default.GetService<OutlineService>();
         var shell = Ioc.Default.GetRequiredService<ShellViewModel>();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await CreateTestModelWithAllElements();
         var overview = model.ExplorerView.First();
 
@@ -1191,7 +1224,7 @@ public class ShellViewModelTests
         scene1.Name = "Scene 1";
 
         // Test 1: Move Character 2 left (should become sibling of Folder A)
-        shell.CurrentNode = char2.Node;
+        appState.CurrentNode = char2.Node;
         shell.MoveLeftCommand.Execute(null);
         Assert.AreEqual(overview, char2.Node.Parent, "Character 2 should be child of Overview");
 
@@ -1200,7 +1233,7 @@ public class ShellViewModelTests
         Assert.AreEqual(folderA.Node, char2.Node.Parent, "Character 2 should be back in Folder A");
 
         // Test 3: Move Scene 1 up (should move to end of Folder A)
-        shell.CurrentNode = scene1.Node;
+        appState.CurrentNode = scene1.Node;
         shell.MoveUpCommand.Execute(null);
         Assert.AreEqual(folderA.Node, scene1.Node.Parent, "Scene 1 should be in Folder A");
 

--- a/StoryCADTests/ViewModels/SubViewModels/OutlineViewModelTests.cs
+++ b/StoryCADTests/ViewModels/SubViewModels/OutlineViewModelTests.cs
@@ -43,7 +43,7 @@ public class OutlineViewModelTests
         var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await outlineService.CreateModel("TestRootDelete", "StoryBuilder", 0);
         appState.CurrentDocument = new StoryDocument(model, Path.Combine(App.ResultsDir, "TestRootDelete.stbx"));
-        shell.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
+        appState.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
 
         //Assert root is there and still is
         Assert.IsTrue(appState.CurrentDocument.Model.StoryElements[0].Node.IsRoot &&
@@ -68,7 +68,7 @@ public class OutlineViewModelTests
         // Create a character to delete
         var character = outlineService.AddStoryElement(appState.CurrentDocument.Model, StoryItemType.Character,
             appState.CurrentDocument.Model.ExplorerView[0]);
-        shell.RightTappedNode = character.Node;
+        appState.RightTappedNode = character.Node;
 
         // Verify Changed is false after model creation (CreateModel sets it to false)
         Assert.IsFalse(appState.CurrentDocument.Model.Changed, "Changed should be false initially");
@@ -95,7 +95,7 @@ public class OutlineViewModelTests
         appState.CurrentDocument = new StoryDocument(model, Path.Combine(App.ResultsDir, "TestNodeDelete.stbx"));
 
         //Create a character
-        shell.RightTappedNode = outlineService.AddStoryElement(appState.CurrentDocument.Model, StoryItemType.Character,
+        appState.RightTappedNode = outlineService.AddStoryElement(appState.CurrentDocument.Model, StoryItemType.Character,
             appState.CurrentDocument.Model.ExplorerView[0]).Node;
 
         //Assert Character is still in explorer
@@ -129,7 +129,7 @@ public class OutlineViewModelTests
         var model = await outlineService.CreateModel("TestNullDelete", "StoryBuilder", 0);
         appState.CurrentDocument = new StoryDocument(model, Path.Combine(App.ResultsDir, "NullDelete.stbx"));
 
-        shell.RightTappedNode = null;
+        appState.RightTappedNode = null;
         var before = appState.CurrentDocument.Model.StoryElements.Count;
         await outlineVM.RemoveStoryElement();
         Assert.AreEqual(before, appState.CurrentDocument.Model.StoryElements.Count);
@@ -148,11 +148,11 @@ public class OutlineViewModelTests
         var child = outlineService.AddStoryElement(appState.CurrentDocument.Model, StoryItemType.Scene, parent.Node);
 
         // Delete parent (child goes with it)
-        shell.RightTappedNode = parent.Node;
+        appState.RightTappedNode = parent.Node;
         await outlineVM.RemoveStoryElement();
 
         // Try to restore child - should fail (not a top-level item in trash)
-        shell.RightTappedNode = child.Node;
+        appState.RightTappedNode = child.Node;
         outlineVM.RestoreStoryElement();
 
         // Verify child is still in trash under parent
@@ -162,7 +162,7 @@ public class OutlineViewModelTests
             "Child should still be under parent in trash");
 
         // Restore parent - child should come with it
-        shell.RightTappedNode = parent.Node;
+        appState.RightTappedNode = parent.Node;
         outlineVM.RestoreStoryElement();
 
         int CountNodes(StoryNodeItem n, Guid g)
@@ -273,15 +273,15 @@ public class OutlineViewModelTests
         var model = await outlineService.CreateModel("MoveRoot", "StoryBuilder", 0);
         appState.CurrentDocument = new StoryDocument(model);
         outlineService.SetCurrentView(appState.CurrentDocument.Model, StoryViewType.ExplorerView);
-        shell.CurrentNode = appState.CurrentDocument.Model.StoryElements[0].Node;
-        shell.RightTappedNode = shell.CurrentNode;
+        appState.CurrentNode = appState.CurrentDocument.Model.StoryElements[0].Node;
+        appState.RightTappedNode = appState.CurrentNode;
 
         shell.MoveLeftCommand.Execute(null);
         shell.MoveRightCommand.Execute(null);
         shell.MoveUpCommand.Execute(null);
         shell.MoveDownCommand.Execute(null);
 
-        Assert.IsTrue(shell.CurrentNode.IsRoot);
+        Assert.IsTrue(appState.CurrentNode.IsRoot);
     }
 
 
@@ -312,7 +312,7 @@ public class OutlineViewModelTests
         var model = await outlineService.CreateModel("Test-Masterplots", "StoryBuilder", 0);
         appState.CurrentDocument = new StoryDocument(model, Path.Combine(App.ResultsDir, "Masterplots.stbx"));
         outlineService.SetCurrentView(appState.CurrentDocument.Model, StoryViewType.ExplorerView);
-        shell.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
+        appState.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
 
 
         //Setup plot vm
@@ -332,7 +332,7 @@ public class OutlineViewModelTests
         var model = await outlineService.CreateModel("MasterPlot", "StoryBuilder", 0);
         appState.CurrentDocument = new StoryDocument(model);
         outlineService.SetCurrentView(appState.CurrentDocument.Model, StoryViewType.ExplorerView);
-        shell.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
+        appState.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
         var master = Ioc.Default.GetRequiredService<MasterPlotsViewModel>();
         master.PlotPatternName = master.PlotPatternNames[0];
         await outlineVM.MasterPlotTool();
@@ -352,7 +352,7 @@ public class OutlineViewModelTests
 
         //Set view
         outlineService.SetCurrentView(appState.CurrentDocument.Model, StoryViewType.ExplorerView);
-        shell.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
+        appState.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
 
         //Run scenario
         Ioc.Default.GetRequiredService<DramaticSituationsViewModel>().SituationName = "Abduction";
@@ -368,7 +368,7 @@ public class OutlineViewModelTests
         var model = await outlineService.CreateModel("Dramatic", "StoryBuilder", 0);
         appState.CurrentDocument = new StoryDocument(model);
         outlineService.SetCurrentView(appState.CurrentDocument.Model, StoryViewType.ExplorerView);
-        shell.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
+        appState.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
         var vm = Ioc.Default.GetRequiredService<DramaticSituationsViewModel>();
         vm.SituationName = "Abduction";
         await outlineVM.DramaticSituationsTool();
@@ -384,7 +384,7 @@ public class OutlineViewModelTests
         var model = await outlineService.CreateModel("NullSituation", "StoryBuilder", 0);
         appState.CurrentDocument = new StoryDocument(model);
         outlineService.SetCurrentView(appState.CurrentDocument.Model, StoryViewType.ExplorerView);
-        shell.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
+        appState.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
 
         var vm = Ioc.Default.GetRequiredService<DramaticSituationsViewModel>();
         vm.Situation = null; // Set Situation directly to null, not SituationName
@@ -407,7 +407,7 @@ public class OutlineViewModelTests
 
         //Set view
         outlineService.SetCurrentView(appState.CurrentDocument.Model, StoryViewType.ExplorerView);
-        shell.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
+        appState.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
 
         //run scenario
         var stockVM = Ioc.Default.GetRequiredService<StockScenesViewModel>();
@@ -430,7 +430,7 @@ public class OutlineViewModelTests
         var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await outlineService.CreateModel("ProblemTest", "StoryBuilder", 0);
         appState.CurrentDocument = new StoryDocument(model, Path.Combine(App.ResultsDir, "ProblemTest.stbx"));
-        shell.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
+        appState.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
 
         //Create char and try to assign as a story problem
         outlineService.AddStoryElement(appState.CurrentDocument.Model, StoryItemType.Character,
@@ -456,7 +456,7 @@ public class OutlineViewModelTests
         var appState = Ioc.Default.GetRequiredService<AppState>();
         var model = await outlineService.CreateModel("ProblemTest2", "StoryBuilder", 0);
         appState.CurrentDocument = new StoryDocument(model, Path.Combine(App.ResultsDir, "ProblemTest2.stbx"));
-        shell.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
+        appState.RightTappedNode = appState.CurrentDocument.Model.StoryElements[0].Node;
 
         //Create char and try to assign as a story problem
         outlineService.AddStoryElement(appState.CurrentDocument.Model, StoryItemType.Problem,


### PR DESCRIPTION
## Summary

- Move `CurrentViewType`, `CurrentNode`, `RightTappedNode` from `ShellViewModel` to `AppState`
- Rewrite `ToolValidationService` with DI to read from `AppState` instead of requiring ViewModel parameters
- Update ~170 references across production code
- Add 21 new tests for `ToolValidationService`
- Update 57 existing tests to use `appState` instead of `shell`

## Why

This refactor removes ViewModel dependencies from the service layer, enabling:
- Better testability (services don't need ViewModel mocks)
- Cleaner architecture (state in AppState, behavior in services)
- Simplified `ToolValidationService` API (3 params instead of 6)

## Test plan

- [x] All 799 tests pass (785 passed, 14 skipped)
- [x] Build succeeds with 0 errors
- [x] Code review completed (no critical issues)
- [x] Legacy `VerifyToolUse` method removed from `OutlineViewModel`

## Files changed

| File | Changes |
|------|---------|
| `AppState.cs` | Added 3 navigation state properties |
| `ToolValidationService.cs` | Rewritten with DI |
| `ShellViewModel.cs` | Removed properties, updated references |
| `OutlineViewModel.cs` | Injected service, removed legacy method |
| `ToolValidationServiceTests.cs` | New file (21 tests) |

Closes #1146

🤖 Generated with [Claude Code](https://claude.ai/code)