### PR TITLE
Adjust Sizing of PreferenceInitialisation and changelog version IDs

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -107,7 +107,7 @@ jobs:
             $v = "1.0.${{ github.run_number }}.65534"
           }
           "version=$v"       >> $env:GITHUB_OUTPUT
-          "tag_version=v$v"  >> $env:GITHUB_OUTPUT
+          "tag_version=$v"   >> $env:GITHUB_OUTPUT
           Write-Host "Generated version: $v"
           
       - name: Restore

--- a/StoryCAD/Views/PreferencesInitialization.xaml
+++ b/StoryCAD/Views/PreferencesInitialization.xaml
@@ -28,7 +28,7 @@
                 </StackPanel>
 
                 <StackPanel Grid.Row="1" VerticalAlignment="Stretch">
-                    <Border Height="50" />
+                    <Border Height="10" />
                     <TextBox PlaceholderText="What's your first name?" Margin="15" VerticalAlignment="Center"
                              Text="{x:Bind _initVM.Preferences.FirstName, Mode=TwoWay}" />
                     <TextBox PlaceholderText="What's your surname?" Margin="15" VerticalAlignment="Center"
@@ -62,7 +62,7 @@
                 <TextBlock Text="{x:Bind _initVM.ErrorMessage, Mode=TwoWay}" Foreground="Red" Grid.Row="3"
                            HorizontalAlignment="Center" />
                 <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Center">
-                    <Button Content="Continue" Margin="25" HorizontalAlignment="Center" Click="Check" />
+                    <Button Content="Continue" Margin="25,10" HorizontalAlignment="Center" Click="Check" />
                     <Button Content="Join our community discord!" Background="#5865F2" Foreground="White" Margin="25"
                             HorizontalAlignment="Center" Click="Discord" />
                 </StackPanel>

--- a/StoryCADLib/Services/Dialogs/Changelog.cs
+++ b/StoryCADLib/Services/Dialogs/Changelog.cs
@@ -31,9 +31,7 @@ public class Changelog
             }
 
             //Returns body of release
-            var version = _appDat.Version.Replace("Version: ", "") + ".0";
-
-            return (await _client.Repository.Release.Get("StoryBuilder-org", "StoryCAD", version)).Body;
+            return (await _client.Repository.Release.Get("StoryBuilder-org", "StoryCAD", _appDat.Version)).Body;
         }
         catch (Exception _e)
         {


### PR DESCRIPTION
This PR fixes two things:
- The version number created by Build Release and one being checked for within storycad are out of sync, this PR adjusts them to be in line with eachother.
- Preferences Initalisation buttons are slightly truncated, this has been fixed.