### PR TITLE
Rename SemanticKernelApi to StoryCADApi

### DIFF
--- a/.claude/docs/architecture/StoryCAD_architecture_notes.md
+++ b/.claude/docs/architecture/StoryCAD_architecture_notes.md
@@ -184,7 +184,7 @@ ManualTest/docs/
 - Integration examples
 - Test scenarios for API consumers
 
-**Note**: StoryCAD has a public API (SemanticKernelAPI) that external tools can use
+**Note**: StoryCAD has a public API (StoryCADAPI) that external tools can use
 
 
 ### Repository Relationships
@@ -405,7 +405,7 @@ Architecture documentation links to:
 | Navigation | `StoryCAD/Views/Shell.xaml` | `Quick Start/Navigating_in_StoryCAD.md` |
 | Reports | `StoryCADLib/Services/Reports/` | `Reports/` (4 files) |
 | Preferences | `StoryCAD/Views/Preferences.xaml` | `Preferences/Preferences.md` |
-| API | `StoryCADLib/SemanticKernelAPI.cs` | `For Developers/Using_the_API.md` |
+| API | `StoryCADLib/StoryCADAPI.cs` | `For Developers/Using_the_API.md` |
 | Collaborator (AI features) | `CollaboratorLib/` (separate repo) | User docs TBD (feature in development) |
 
 ### Documentation Standards for Developers
@@ -761,7 +761,7 @@ StoryCADLib/
 │
 ├── /API/ (External integration layer)
 │   ├── IStoryCADAPI.cs
-│   ├── SemanticKernelAPI.cs
+│   ├── StoryCADAPI.cs
 │   └── OperationResult.cs
 │
 ├── /DAL/ (Data Access Layer)
@@ -819,7 +819,7 @@ StoryCADTests/
 │
 ├── /UnitTests/
 │   ├── OutlineServiceTests.cs (Service layer tests)
-│   ├── SemanticKernelAPITests.cs (API layer tests)
+│   ├── StoryCADAPITests.cs (API layer tests)
 │   ├── StoryModelTests.cs
 │   ├── CharacterModelTests.cs
 │   ├── RelationshipTests.cs
@@ -961,7 +961,7 @@ StoryCADTests/
 │                      API LAYER (External Integration)              │
 │                                                                    │
 │  ┌─────────────────────────────────────────────────────────┐     │
-│  │  SemanticKernelAPI (IStoryCADAPI)                       │     │
+│  │  StoryCADAPI (IStoryCADAPI)                       │     │
 │  │  - Implements IStoryCADAPI interface                    │     │
 │  │  - All operations return OperationResult<T>             │     │
 │  │  - Wraps OutlineService calls in try-catch              │     │
@@ -1170,7 +1170,7 @@ Services → Services
   - All methods return OperationResult<T>
   - Versioned for compatibility
 
-- **SemanticKernelAPI**: Implementation of IStoryCADAPI
+- **StoryCADAPI**: Implementation of IStoryCADAPI
   - Calls OutlineService directly
   - All operations wrapped in try-catch
   - Thread-safe with SerializationLock
@@ -1709,7 +1709,7 @@ using (var serializationLock = new SerializationLock(autoSaveService, backupServ
 
 **Used in**:
 - OutlineService (all state-modifying operations)
-- SemanticKernelAPI (all API operations)
+- StoryCADAPI (all API operations)
 - StoryIO (file read/write operations)
 
 **Prevents**:
@@ -2566,7 +2566,7 @@ public Guid AddStoryElement(Guid parentGuid, ...)
 ### Coverage Requirements
 
 **Critical Components**:
-- SemanticKernelAPI: 100% coverage achieved
+- StoryCADAPI: 100% coverage achieved
 - OutlineService: 100% coverage achieved
 - Critical paths have integration tests
 - Thread safety verified in tests
@@ -3131,7 +3131,7 @@ public interface IPlatformService
 
 ### API Evolution
 
-**Current**: SemanticKernelAPI for LLM integration
+**Current**: StoryCADAPI for LLM integration
 
 **Future Possibilities**:
 - RESTful API for web integration
@@ -3156,7 +3156,7 @@ public interface IPlatformService
 ### AI/LLM Integration
 
 **Current**:
-- Via SemanticKernelAPI
+- Via StoryCADAPI
 - CollaboratorService for AI assistance
 - Microsoft.SemanticKernel 1.41.0
 
@@ -3173,7 +3173,7 @@ public interface IPlatformService
 ### External Tools
 
 **API Enablement**:
-- SemanticKernelAPI enables external tool integration
+- StoryCADAPI enables external tool integration
 - OperationResult<T> for safe consumption
 - Thread-safe operations
 

--- a/.claude/docs/architecture/patterns-quick-ref.md
+++ b/.claude/docs/architecture/patterns-quick-ref.md
@@ -98,7 +98,7 @@ using (var serializationLock = new SerializationLock(autoSaveService, backupServ
 
 **Used In**:
 - `OutlineService` - All state-modifying operations
-- `SemanticKernelAPI` - All API operations
+- `StoryCADAPI` - All API operations
 - `StoryIO` - File read/write operations
 
 **Prevents**:
@@ -169,7 +169,7 @@ protected override void OnNavigatedFrom(NavigationEventArgs e)
 
 **Purpose**: Safe error handling for API operations
 
-**When to Use**: All SemanticKernelAPI methods
+**When to Use**: All StoryCADAPI methods
 
 **Implementation**:
 ```csharp

--- a/.claude/docs/architecture/testing-guide.md
+++ b/.claude/docs/architecture/testing-guide.md
@@ -111,10 +111,10 @@ public async Task UIElement_Action_ExpectedResult()
 
 ## Creating Test Data
 
-### Method 1: Using SemanticKernelApi (Preferred)
+### Method 1: Using StoryCADApi (Preferred)
 ```csharp
 // Create API instance
-var api = new SemanticKernelApi();
+var api = new StoryCADApi();
 
 // Create outline with template
 var result = await api.CreateEmptyOutline("Test Story", "Test Author", "0");

--- a/.claude/docs/examples/new-story-element-checklist.md
+++ b/.claude/docs/examples/new-story-element-checklist.md
@@ -19,7 +19,7 @@ This checklist ensures all integration points are covered when adding a new stor
 | OutlineService | 2 | OutlineService.cs |
 | DI/Registration | 2 | BootStrapper.cs, Lists.json |
 | Reports | 7 | Multiple files |
-| API | 3 | SemanticKernelAPI.cs |
+| API | 3 | StoryCADAPI.cs |
 | Tests | 5+ | Test project |
 | Documentation | 4+ | User manual |
 
@@ -187,16 +187,16 @@ This checklist ensures all integration points are covered when adding a new stor
 
 ### 8. API Integration
 
-- [ ] **SemanticKernelAPI GetXxx** (if singleton) - Add convenience method
-  - File: `StoryCADLib/Services/API/SemanticKernelAPI.cs`
+- [ ] **StoryCADAPI GetXxx** (if singleton) - Add convenience method
+  - File: `StoryCADLib/Services/API/StoryCADAPI.cs`
   - Add: `Get[ElementName]()` method returning `OperationResult<StoryElement>`
 
-- [ ] **SemanticKernelAPI GetElementsByType** - Update to handle new type
-  - File: `StoryCADLib/Services/API/SemanticKernelAPI.cs`
+- [ ] **StoryCADAPI GetElementsByType** - Update to handle new type
+  - File: `StoryCADLib/Services/API/StoryCADAPI.cs`
   - Update switch or filtering logic
 
 - [ ] **API Description Attributes** - Update documentation
-  - File: `StoryCADLib/Services/API/SemanticKernelAPI.cs`
+  - File: `StoryCADLib/Services/API/StoryCADAPI.cs`
   - Update `[Description]` attributes to mention new element type
 
 ### 9. Tests (TDD)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,7 +347,7 @@ When creating pull requests, include any design documentation directly in the PR
 
 ### Test File Naming
 - **Pattern**: `[SourceFileName]Tests.cs`
-- **Example**: `SemanticKernelAPITests.cs` for source file `SemanticKernelAPI.cs`
+- **Example**: `StoryCADAPITests.cs` for source file `StoryCADAPI.cs`
 - **Location**: Test files in StoryCADTests project, mirroring source structure where practical
 
 ### Test Method Naming

--- a/StoryCADLib/Services/API/StoryCADAPI.cs
+++ b/StoryCADLib/Services/API/StoryCADAPI.cs
@@ -26,7 +26,7 @@ namespace StoryCADLib.Services.API;
 ///     - Calling Standard: All public API methods return OperationResult<T> to ensure safe external consumption.
 ///         No exceptions are thrown to external callers; all errors are communicated through the OperationResult
 ///         pattern with IsSuccess flags and descriptive ErrorMessage strings.
-public class SemanticKernelApi(OutlineService outlineService, ListData listData, ControlData controlData, ToolsData toolsData) : IStoryCADAPI
+public class StoryCADApi(OutlineService outlineService, ListData listData, ControlData controlData, ToolsData toolsData) : IStoryCADAPI
 {
     public StoryModel CurrentModel { get; set; }
 

--- a/StoryCADLib/Services/Collaborator/CollaboratorService.cs
+++ b/StoryCADLib/Services/Collaborator/CollaboratorService.cs
@@ -81,7 +81,7 @@ public class CollaboratorService
         var toolsData = Ioc.Default.GetService<ToolsData>();
         if (outlineService != null && listData != null && controlData != null && toolsData != null)
         {
-            var api = new SemanticKernelApi(outlineService, listData, controlData, toolsData);
+            var api = new StoryCADApi(outlineService, listData, controlData, toolsData);
             api.SetCurrentModel(storyModel);
             // DIAG-55: Log API.CurrentModel after SetCurrentModel
             _logService.Log(LogLevel.Info, $"DIAG-55: After SetCurrentModel - api.CurrentModel hash={RuntimeHelpers.GetHashCode(api.CurrentModel)}");

--- a/StoryCADLib/Services/Collaborator/Contracts/IStoryCADAPI.cs
+++ b/StoryCADLib/Services/Collaborator/Contracts/IStoryCADAPI.cs
@@ -4,7 +4,7 @@ using StoryCADLib.Services.API;
 namespace StoryCADLib.Services.Collaborator.Contracts;
 
 /// <summary>
-///     Interface for existing SemanticKernelAPI methods that Collaborator uses
+///     Interface for existing StoryCADAPI methods that Collaborator uses
 /// </summary>
 public interface IStoryCADAPI
 {

--- a/StoryCADLib/Services/IoC/ServiceLocator.cs
+++ b/StoryCADLib/Services/IoC/ServiceLocator.cs
@@ -85,7 +85,7 @@ public static class BootStrapper
         Services.AddSingleton<StoryIO>();
         Services.AddSingleton<MySqlIo>();
         Services.AddSingleton<OutlineService>();
-        Services.AddSingleton<SemanticKernelApi>();
+        Services.AddSingleton<StoryCADApi>();
         Services.AddSingleton<BackupService>();
         Services.AddSingleton<AutoSaveService>();
         Services.AddSingleton<BackendService>();

--- a/StoryCADLib/ViewModels/Tools/CopyElementsDialogVM.cs
+++ b/StoryCADLib/ViewModels/Tools/CopyElementsDialogVM.cs
@@ -18,7 +18,7 @@ public class CopyElementsDialogVM : ObservableRecipient
 {
     private readonly AppState _appState;
     private readonly OutlineService _outlineService;
-    private readonly SemanticKernelApi _api;
+    private readonly StoryCADApi _api;
     private readonly Windowing _windowing;
     private readonly ILogService _logger;
 
@@ -39,7 +39,7 @@ public class CopyElementsDialogVM : ObservableRecipient
     public CopyElementsDialogVM(
         AppState appState,
         OutlineService outlineService,
-        SemanticKernelApi api,
+        StoryCADApi api,
         Windowing windowing,
         ILogService logger)
     {

--- a/StoryCADTests/DAL/StoryIOTests.cs
+++ b/StoryCADTests/DAL/StoryIOTests.cs
@@ -279,7 +279,7 @@ public partial class StoryIOTests
     public async Task DetectLegacyDualRoot_WithTrashCanAsSecondRoot_ReturnsTrue()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
         // All templates create the legacy dual-root structure automatically
         var createResult = await api.CreateEmptyOutline("Test Story", "Test Author", "0");
         Assert.IsTrue(createResult.IsSuccess);
@@ -304,7 +304,7 @@ public partial class StoryIOTests
     public async Task MigrateLegacyDualRoot_MovesTrashCanChildrenToTrashView()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
         var createResult = await api.CreateEmptyOutline("Test Story", "Test Author", "0");
         Assert.IsTrue(createResult.IsSuccess);
 
@@ -360,7 +360,7 @@ public partial class StoryIOTests
     public async Task MigrateLegacyDualRoot_PreservesHierarchyInTrashView()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
         var createResult = await api.CreateEmptyOutline("Test Story", "Test Author", "0");
         Assert.IsTrue(createResult.IsSuccess);
 

--- a/StoryCADTests/Services/API/StoryCADAPITests.cs
+++ b/StoryCADTests/Services/API/StoryCADAPITests.cs
@@ -11,9 +11,9 @@ using StoryCADLib.ViewModels;
 namespace StoryCADTests.Services.API;
 
 [TestClass]
-public class SemanticKernelApiTests
+public class StoryCADApiTests
 {
-    private readonly SemanticKernelApi _api = new(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+    private readonly StoryCADApi _api = new(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
 
     [TestMethod]
     public async Task CreateOutlineWithInvalidTemplate()
@@ -317,7 +317,7 @@ public class SemanticKernelApiTests
         Assert.IsTrue(writeResult.IsSuccess, "WriteOutline should succeed.");
 
         // Act: Create a new API instance and open the written file.
-        var newApi = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var newApi = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
         var openResult = await newApi.OpenOutline(filePath);
 
         // Assert
@@ -417,7 +417,7 @@ public class SemanticKernelApiTests
     public async Task SetCurrentModel_WithValidModel_SetsCurrentModel()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
 
         // Create a test model
         var createResult = await api.CreateEmptyOutline("Test Story", "Test Author", "0");
@@ -449,7 +449,7 @@ public class SemanticKernelApiTests
     public void SetCurrentModel_WithNullModel_SetsCurrentModelToNull()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
 
         // Act
         api.SetCurrentModel(null);
@@ -465,7 +465,7 @@ public class SemanticKernelApiTests
     public async Task SetCurrentModel_AllowsOperationsOnNewModel()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
 
         // Create first model
         var firstResult = await api.CreateEmptyOutline("First Story", "Author 1", "0");
@@ -559,7 +559,7 @@ public class SemanticKernelApiTests
     public void DeleteStoryElement_WithNoModel_ReturnsFailure()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
 
         // Act
         var result = api.DeleteStoryElement(Guid.NewGuid().ToString());
@@ -600,7 +600,7 @@ public class SemanticKernelApiTests
     public async Task DeleteElement_WithNoModel_ReturnsFailure()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
 
         // Act
         var result = await api.DeleteElement(Guid.NewGuid());
@@ -664,7 +664,7 @@ public class SemanticKernelApiTests
     public async Task RestoreFromTrash_WithNoModel_ReturnsFailure()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
 
         // Act
         var result = await api.RestoreFromTrash(Guid.NewGuid());
@@ -731,7 +731,7 @@ public class SemanticKernelApiTests
     public async Task EmptyTrash_WithNoModel_ReturnsFailure()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
 
         // Act
         var result = await api.EmptyTrash();
@@ -776,7 +776,7 @@ public class SemanticKernelApiTests
     public void GetStoryElement_WithNoCurrentModel_ReturnsFailure()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
         var someGuid = Guid.NewGuid();
 
         // Act
@@ -835,7 +835,7 @@ public class SemanticKernelApiTests
     public void SearchForText_WithNoModel_ReturnsFailure()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
 
         // Act
         var result = api.SearchForText("test");
@@ -937,7 +937,7 @@ public class SemanticKernelApiTests
     public void SearchForReferences_WithNoModel_ReturnsFailure()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
 
         // Act
         var result = api.SearchForReferences(Guid.NewGuid());
@@ -1024,7 +1024,7 @@ public class SemanticKernelApiTests
     public void RemoveReferences_WithNoModel_ReturnsFailure()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
 
         // Act
         var result = api.RemoveReferences(Guid.NewGuid());
@@ -1115,7 +1115,7 @@ public class SemanticKernelApiTests
     public void SearchInSubtree_WithNoModel_ReturnsFailure()
     {
         // Arrange
-        var api = new SemanticKernelApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
+        var api = new StoryCADApi(Ioc.Default.GetRequiredService<OutlineService>(), Ioc.Default.GetRequiredService<ListData>(), Ioc.Default.GetRequiredService<ControlData>(), Ioc.Default.GetRequiredService<ToolsData>());
 
         // Act
         var result = api.SearchInSubtree(Guid.NewGuid(), "test");
@@ -2230,7 +2230,7 @@ public class SemanticKernelApiTests
     public void GetElementsByType_WithNoModel_ReturnsFailure()
     {
         // Arrange - create fresh API instance with no model
-        var api = new SemanticKernelApi(
+        var api = new StoryCADApi(
             Ioc.Default.GetRequiredService<OutlineService>(),
             Ioc.Default.GetRequiredService<ListData>(),
             Ioc.Default.GetRequiredService<ControlData>(),
@@ -2306,7 +2306,7 @@ public class SemanticKernelApiTests
     public void GetStoryWorld_WithNoModel_ReturnsFailure()
     {
         // Arrange - create fresh API instance with no model
-        var api = new SemanticKernelApi(
+        var api = new StoryCADApi(
             Ioc.Default.GetRequiredService<OutlineService>(),
             Ioc.Default.GetRequiredService<ListData>(),
             Ioc.Default.GetRequiredService<ControlData>(),

--- a/StoryCADTests/ViewModels/Tools/CopyElementsDialogVMTests.cs
+++ b/StoryCADTests/ViewModels/Tools/CopyElementsDialogVMTests.cs
@@ -29,13 +29,13 @@ public class CopyElementsDialogVMTests
         var diConstructor = constructors.FirstOrDefault(c =>
             c.GetParameters().Any(p => p.ParameterType == typeof(AppState)) &&
             c.GetParameters().Any(p => p.ParameterType == typeof(OutlineService)) &&
-            c.GetParameters().Any(p => p.ParameterType == typeof(SemanticKernelApi)) &&
+            c.GetParameters().Any(p => p.ParameterType == typeof(StoryCADApi)) &&
             c.GetParameters().Any(p => p.ParameterType == typeof(Windowing)) &&
             c.GetParameters().Any(p => p.ParameterType == typeof(ILogService)));
 
         // Assert
         Assert.IsNotNull(diConstructor,
-            "CopyElementsDialogVM should have a constructor with AppState, OutlineService, SemanticKernelApi, Windowing, and ILogService parameters");
+            "CopyElementsDialogVM should have a constructor with AppState, OutlineService, StoryCADApi, Windowing, and ILogService parameters");
     }
 
     [TestMethod]
@@ -1131,7 +1131,7 @@ public class CopyElementsDialogVMTests
         var vm = Ioc.Default.GetRequiredService<CopyElementsDialogVM>();
         var appState = Ioc.Default.GetRequiredService<AppState>();
         var outlineService = Ioc.Default.GetRequiredService<OutlineService>();
-        var api = Ioc.Default.GetRequiredService<SemanticKernelApi>();
+        var api = Ioc.Default.GetRequiredService<StoryCADApi>();
 
         // Set up source with a character
         var sourceModel = await outlineService.CreateModel("Source Story", "Test Author", 0);

--- a/devdocs/issue_1246_api_samples/issue_1246_research.md
+++ b/devdocs/issue_1246_api_samples/issue_1246_research.md
@@ -1,0 +1,624 @@
+# Issue 1246: Research & Information Gathering
+
+## NuGet Package: StoryCADLib
+
+**URL**: https://www.nuget.org/packages/StoryCADLib
+
+| Property | Published | Codebase |
+|----------|-----------|----------|
+| Version | 3.3.0 | 4.0.0 |
+| Target | net9.0-windows10.0.22621 | net10.0-desktop + net10.0-windows10.0.22621 |
+| Platform | Windows-only | UNO (cross-platform) |
+
+### Version History
+| Version | Downloads | Date |
+|---------|-----------|------|
+| 3.3.0 | 296 | Sep 19, 2025 |
+| 3.2.1 | 285 | Aug 7, 2025 |
+| 3.2.0 | 204 | Jul 7, 2025 |
+| 3.1.0 | 193 | Apr 25, 2025 |
+| 3.0.8 | 271 | Apr 14, 2025 |
+| 3.0.0 | 255 | Apr 10, 2025 |
+
+**Total Downloads**: ~1.9K (~5/day average)
+**Owner**: StoryBuilderFoundation
+
+### Current Consumers
+
+**NuGet page states**: "Not used by any NuGet packages or popular GitHub repositories"
+
+**Known consumers**:
+- **Outliner** (internal project) - references 3.3.0
+- StoryCAD team CI/CD builds
+
+**Likely sources of ~1.9K downloads**:
+- Internal development and CI/CD
+- Outliner project
+- Occasional curious developers
+- NuGet indexing/bots
+
+**Implication**: Low external adoption gives freedom for breaking changes in 4.0 (namespace, class naming) without significant impact.
+
+### Dependencies (3.3.0)
+- CommunityToolkit.Mvvm >= 8.4.0
+- Microsoft.SemanticKernel >= 1.61.0
+- Microsoft.WindowsAppSDK >= 1.7.250606001
+- MySql.Data >= 9.4.0
+- NLog >= 6.0.3
+- Octokit >= 14.0.0
+
+---
+
+## API-Samples Repository
+
+**Location**: `/mnt/d/dev/src/API-Samples/`
+**Status**: Private (never released)
+**Source**: repos.md line 47-49
+
+### Contents
+1. **StoryCADChat/** - Console app using SK + LLM for natural language interaction
+   - `Program.cs` - 49 lines
+   - `StoryCADChat.csproj` - References StoryCADLib 3.0.8, net8.0
+
+2. **Blank Project/StoryCAD-API-Starter/** - Minimal starter template
+   - `Program.cs` - 12 lines (just BootStrapper.Initialise())
+   - References StoryCADLib 3.0.8, net8.0
+
+### README Sample Code
+```csharp
+using StoryCAD.Services.API;
+
+var api = new StoryCADApi();
+var outlineResult = await api.CreateEmptyOutline("Title", "Author", "0");
+var updateResult = api.UpdateElementProperty(guid, "Name", "New Name");
+var writeResult = await api.WriteOutline("path.stbx");
+```
+
+---
+
+## Outliner Directory
+
+**Location**: `/mnt/d/dev/src/Outliner/`
+**Git Repo**: No
+
+### Variants (by modification date)
+
+| Folder | Modified | Structure | StoryCADLib |
+|--------|----------|-----------|-------------|
+| Outliner/Outliner/ | Sep 20 | Single project | - |
+| Outliner shell/ProseToOutline/ | Sep 20 | Single project | 3.3.0 |
+| **OutlinerAlt/** | **Sep 21** | Full solution | **3.3.0** |
+
+### OutlinerAlt (Latest)
+**Purpose**: Prose-to-outline converter using LLM
+
+**Projects**:
+- `Outliner/` - WinUI executable
+- `OutlinerLib/` - Core library
+- `OutlinerTests/` - Tests
+
+**Architecture** (from Documentation/Architecture.md):
+1. **Phase 1 (LLM Analysis)**: Single-pass extraction via Semantic Kernel
+2. **Phase 2 (API Construction)**: Build outline via StoryCADLib API
+
+**Processing Order**:
+1. Story Overview (root)
+2. Characters (referenced by others)
+3. Settings (scenes occur in them)
+4. Scenes (reference chars/settings)
+5. Problems (reference all types)
+
+**Known Issue** (from csproj):
+```xml
+<!-- Workaround for StoryCADLib content files being in wrong location in package -->
+<Target Name="RemoveStoryCADLibContentFiles" ...>
+```
+
+---
+
+## Key Source Files
+
+| File | Location | Purpose |
+|------|----------|---------|
+| StoryCADAPI.cs | StoryCADLib/Services/API/ | Main API (77KB) |
+| OperationResult.cs | StoryCADLib/Services/API/ | Result pattern |
+| BootStrapper.cs | StoryCADLib/Services/IoC/ | DI initialization |
+
+---
+
+## Gap Analysis
+
+### Version Gaps
+- Published NuGet: 3.3.0 → Codebase: 4.0.0
+- Samples target: net8.0 → Current: net10.0
+- Semantic Kernel in samples: 1.41.0 → Current: 1.61.0+
+
+### Platform Gap
+- Published: Windows-only (WinAppSDK)
+- Codebase: UNO Platform (cross-platform)
+
+### Documentation Gaps
+- No public API documentation
+- No migration guide (3.x → 4.0)
+- No UNO-specific guidance for API consumers
+
+### Packaging Issue
+- StoryCADLib content files in wrong location
+- Documented workaround exists in Outliner projects
+
+---
+
+## Open Research Questions
+
+### Can non-UNO apps consume StoryCADLib 4.0?
+
+**Status**: ✅ RESEARCHED
+
+**Answer**: **Yes, with minor caveats.**
+
+#### Dependencies Analysis
+
+| Package | UNO-Specific? |
+|---------|---------------|
+| CommunityToolkit.Mvvm | No |
+| Microsoft.SemanticKernel* | No |
+| MySql.Data, NLog, Octokit, etc. | No |
+| **Uno.Fonts.Fluent** | **Yes (only one)** |
+
+**Critical Finding**: Only ONE UNO-specific package exists (Uno.Fonts.Fluent, for UI fonts).
+
+#### Initialization
+
+```csharp
+// Minimal initialization for non-UI app
+BootStrapper.Initialise(headless: true);
+var api = Ioc.Default.GetRequiredService<StoryCADApi>();
+```
+
+- Default `headless = true` requires no UI context
+- All services register successfully without UI
+- Test suite runs in headless mode
+
+#### API Compatibility
+
+| Aspect | Status |
+|--------|--------|
+| Core API (StoryCADAPI) | ✅ Fully Compatible |
+| OutlineService | ✅ Fully Compatible |
+| Data Models | ✅ Fully Compatible |
+| Semantic Kernel Integration | ✅ Fully Compatible |
+| File Operations | ✅ Fully Compatible |
+| Windowing Service | ⚠️ Non-functional in headless |
+| UI Dialogs | ⚠️ Returns Primary result |
+| File Picker UI | ⚠️ Requires own implementation |
+
+#### Recommendations
+
+1. **Works now**: Console apps, ASP.NET, web APIs can consume StoryCADLib
+2. **Workarounds**: Implement own file picker (pass paths to API)
+3. **Optional improvements**:
+   - Extract Uno.Fonts.Fluent as conditional
+   - Create headless-specific NuGet package
+   - Add headless mode documentation
+
+**Sources**:
+- StoryCADLib.csproj: `/mnt/d/dev/src/StoryCAD/StoryCADLib/StoryCADLib.csproj`
+- ServiceLocator.cs: `/mnt/d/dev/src/StoryCAD/StoryCADLib/Services/IoC/ServiceLocator.cs`
+- StoryCADAPI.cs: `/mnt/d/dev/src/StoryCAD/StoryCADLib/Services/API/StoryCADAPI.cs`
+
+#### Architectural Options for Headless Support
+
+**Current State**: Single package with UI and headless code mixed. Uno.Fonts.Fluent only used in XAML for icons.
+
+**Option A: Extract StoryCADLib.Core**
+
+```
+StoryCADLib.Core (new)
+├── Models/ (StoryModel, elements)
+├── DAL/ (StoryIO, JSONResourceLoader)
+├── Services/Outline/ (OutlineService)
+└── Services/API/ (IStoryCADApi - core operations, no SK attributes)
+
+StoryCADLib.SemanticKernel (new, optional)
+├── StoryCADApi (wraps IStoryCADApi)
+├── [KernelFunction] attributes
+└── References: Core + Microsoft.SemanticKernel
+
+StoryCADLib (refactored)
+├── UI, ViewModels, XAML, Windowing
+└── References: Core
+```
+
+**Benefits**:
+- Core has minimal dependencies (no UI, no SK)
+- SK integration is opt-in
+- Clearer naming for non-SK users
+- .NET console/ASP.NET apps get lean package
+
+**Trade-offs**:
+
+| Approach | Effort | Maintenance | Benefit |
+|----------|--------|-------------|---------|
+| Extract Core + SK packages | High | 3 packages to publish | Clean separation |
+| Conditional compilation | Medium | Complex builds | Single source |
+| Just document headless | Low | None | Unused deps acceptable |
+
+**Recommendation**: Start with documentation (low effort). Consider extraction if demand grows or during major refactor.
+
+**Note**: Python access strategy (R3) is unaffected - Python uses .stbx JSON directly, not .NET packages.
+
+---
+
+### Exemplary API Documentation Models
+
+**Status**: ✅ RESEARCHED
+
+#### Top Models Identified
+
+| Library | Key Pattern | Adopt For |
+|---------|-------------|-----------|
+| **UNO Platform Samples** | Feature-based organization, progressive complexity | Sample structure |
+| **Semantic Kernel** | Test-based samples, multi-language (C#/Python/Java) | Sample implementation |
+| **Azure SDK Guidelines** | Naming conventions, OperationResult pattern, README-first | API design |
+| **FluentValidation** | Progressive learning path (8 sections) | Doc structure |
+| **Polly** | Plain language before technical details | Accessibility |
+| **Serilog** | Minimal 5-line examples, copy-paste ready | Quick start |
+| **CommunityToolkit.Mvvm** | Before/after comparisons, platform-specific samples | Comparison docs |
+
+#### Key Recommendations
+
+| Priority | Recommendation | Source |
+|----------|----------------|--------|
+| 1 | XML docs with `<summary>`, `<param>`, `<returns>`, `<example>` | Microsoft |
+| 2 | Progressive disclosure (quick start → basic → advanced) | FluentValidation |
+| 3 | Test-based sample projects that always compile | Semantic Kernel |
+| 4 | Plain language before technical details | Polly |
+| 5 | Standardize naming (Create, Get, Update, Delete) | Azure SDK |
+| 6 | Copy-paste ready examples for every method | Serilog |
+| 7 | "When to use this" guidance | MediatR |
+| 8 | Side-by-side comparisons (API vs. direct service) | CommunityToolkit |
+
+#### Recommended Doc Structure
+
+```
+/docs/api/
+├── README.md                    # Overview and quick start
+├── getting-started.md           # Installation and first API call
+├── concepts/                    # OperationResult, StoryModel, element types
+├── operations/                  # Outline, element, navigation, file ops
+├── samples/                     # HelloWorld, CreateStory, AIAgent, Batch
+├── advanced/                    # Error handling, testing, extensibility
+└── reference/                   # Auto-generated from XML docs
+```
+
+#### Progressive Disclosure Levels
+
+- **Level 1 (30 sec)**: Install, create instance, CreateEmptyOutline()
+- **Level 2 (5 min)**: Create elements, navigate, modify, save
+- **Level 3 (15+ min)**: Templates, batch ops, error handling, SK integration
+- **Level 4 (reference)**: Complete API reference, edge cases
+
+#### References
+
+1. UNO Platform Samples. https://github.com/unoplatform/Uno.Samples
+2. Semantic Kernel Documentation. https://learn.microsoft.com/en-us/semantic-kernel/
+3. Azure SDK .NET Design Guidelines. https://azure.github.io/azure-sdk/dotnet_introduction.html
+4. FluentValidation Documentation. https://docs.fluentvalidation.net/
+5. Polly Documentation. https://www.pollydocs.org/
+6. Serilog Getting Started. https://github.com/serilog/serilog/wiki/Getting-Started
+7. CommunityToolkit.Mvvm. https://learn.microsoft.com/en-us/dotnet/communitytoolkit/mvvm/
+8. Microsoft XML Documentation. https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/
+
+---
+
+### Python Access Strategy
+
+**Status**: ✅ RESEARCHED
+
+**Recommendation**: **Direct .stbx JSON** (Option 4) as primary approach.
+
+#### Options Evaluated
+
+| Option | Complexity | Educational Value | Recommendation |
+|--------|------------|-------------------|----------------|
+| REST Wrapper | Medium-High | Medium | Future enhancement |
+| gRPC Service | High | Low-Medium | Not recommended |
+| Python.NET | Medium | Medium | Not recommended |
+| **Direct .stbx JSON** | **Low-Medium** | **High** | **Primary approach** |
+
+#### Why Direct .stbx JSON?
+
+1. **Educational Alignment**: Aligns with StoryBuilder Foundation's teaching mission
+2. **Zero Dependencies**: No .NET runtime or servers required
+3. **Format Already Exists**: Well-structured JSON with discriminator-based types
+4. **Pythonic**: Can design truly native Python API
+
+#### .stbx Format Structure
+
+```json
+{
+  "CreatedVersion": "...",
+  "LastVersion": "...",
+  "FlattenedExplorerView": [{"Uuid": "...", "ParentUuid": "..."}],
+  "Elements": [
+    {"Type": "Character|Scene|Problem|...", "GUID": "...", "Name": "...", ...}
+  ]
+}
+```
+
+**Element Types**: StoryOverview, Problem, Character, Setting, Scene, Folder, Notes, Web, TrashCan, Section, StoryWorld
+
+#### Proposed Python API
+
+```python
+from storycad import Outline, Character
+
+outline = Outline.load("my_story.stbx")
+for char in outline.characters:
+    print(f"{char.name}: {char.role}")
+outline.save("my_story.stbx")
+```
+
+#### Implementation Roadmap
+
+1. **Phase 1**: Document JSON Schema (2-3 weeks)
+2. **Phase 2**: Create `storycad` Python package (4-6 weeks)
+3. **Phase 3**: Educational materials (2-4 weeks)
+4. **Phase 4** (Future): REST API if demand warrants
+
+#### References
+
+1. Python.NET Official Site. http://pythonnet.github.io/
+2. jsonschema Python Library. https://python-jsonschema.readthedocs.io/
+3. Pydantic JSON Schema. https://docs.pydantic.dev/latest/concepts/json_schema/
+
+---
+
+### Migration Path (3.x → 4.0)
+
+**Status**: ✅ RESEARCHED
+
+#### Breaking Changes
+
+| Aspect | 3.x | 4.0 | Action |
+|--------|-----|-----|--------|
+| **Namespace** | `StoryCAD.Services.API` | `StoryCADLib.Services.API` | Update imports |
+| **Class Name** | `StoryCADAPI` | `StoryCADApi` | Rename (casing) |
+| **.NET Target** | `net8.0-windows10.0.22621` | `net10.0-*` | Update TFM |
+| **Platform** | Windows only | Cross-platform (UNO) | No code change |
+
+#### Migration Steps
+
+1. **Update project file**:
+```xml
+<TargetFramework>net10.0-windows10.0.22621</TargetFramework>
+<PackageReference Include="StoryCADLib" Version="4.0.0" />
+```
+
+2. **Update using statements**:
+```csharp
+// Old
+using StoryCAD.Services.API;
+// New
+using StoryCADLib.Services.API;
+```
+
+3. **Update class references**:
+```csharp
+var api = Ioc.Default.GetRequiredService<StoryCADApi>(); // lowercase 'i'
+```
+
+#### New Features in 4.0
+
+- **Beat Sheets API**: 19 new methods for beat sheet management
+- **Enhanced Search**: `SearchForText()`, `SearchForReferences()`, `SearchInSubtree()`
+- **Trash/Restore**: `RestoreFromTrash()`, `EmptyTrash()`
+- **Resource APIs**: Full access to ControlData, ListData, ToolsData
+
+#### Backward Compatibility
+
+- Core CRUD operations unchanged
+- OperationResult<T> pattern identical
+- BootStrapper.Initialise() unchanged
+
+**Sources**:
+- StoryCADAPI.cs: `/mnt/d/dev/src/StoryCAD/StoryCADLib/Services/API/StoryCADAPI.cs`
+- IStoryCADAPI.cs: `/mnt/d/dev/src/StoryCAD/StoryCADLib/Services/Collaborator/Contracts/IStoryCADAPI.cs`
+- API-Samples: `/mnt/d/dev/src/API-Samples/`
+
+---
+
+### Sample Distribution Strategy
+
+**Status**: ✅ RESEARCHED
+
+**Recommendation**: **Separate public repository** with strong cross-linking.
+
+#### Options Evaluated
+
+| Option | Pros | Cons | Used By |
+|--------|------|------|---------|
+| **Separate public repo** | Clean separation, independent releases, beginner-friendly | Version sync burden, discoverability | Microsoft, UNO Platform |
+| Part of main repo | Always synced, single repo | Increases size, mixes concerns | Semantic Kernel |
+| NuGet samples folder | Auto-delivered, version-matched | Increases package size, not standard | Not common |
+| Combination | Maximum discoverability | Highest maintenance, confusing | - |
+
+#### Recommended Structure
+
+```
+storybuilder-org/API-Samples (public)
+├── README.md                      # Links to main repo, NuGet, docs
+├── Directory.Packages.props       # Central package management
+├── /getting-started/
+│   └── HelloStoryCAD/             # Minimal sample
+├── /scenarios/
+│   ├── StoryCADChat/              # Natural language
+│   └── ProseToOutline/            # Document conversion
+└── /advanced/
+    └── CustomPlugins/             # Extensions
+```
+
+#### Cross-Linking Strategy
+
+- **NuGet README**: Link to API-Samples repo
+- **Main StoryCAD README**: Link to API-Samples
+- **API-Samples README**: Link back to NuGet and main repo
+- **User Manual**: "Samples" section linking to repo
+
+#### Version Synchronization
+
+Use Central Package Management (`Directory.Packages.props`):
+```xml
+<PackageVersion Include="StoryCADLib" Version="4.0.0" />
+```
+
+#### Action Items
+
+1. Make API-Samples repository public
+2. Add cross-links to all READMEs
+3. Implement Central Package Management
+4. Add governance docs (CONTRIBUTING.md, CODE_OF_CONDUCT.md)
+
+#### References
+
+1. dotnet/samples. https://github.com/dotnet/samples
+2. unoplatform/Uno.Samples. https://github.com/unoplatform/Uno.Samples
+3. NuGet Central Package Management. https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management
+
+---
+
+### Packaging Issue Status
+
+**Status**: ✅ RESEARCHED
+
+**Answer**: **Fixed in 4.0.** Workaround only needed for 3.3.0 consumers.
+
+#### Root Cause (3.3.0)
+
+In 3.3.0, Assets/Install files were configured as `Content` with `PackagePath`:
+```xml
+<Content Update="Assets\*.*" PackagePath="contentFiles\any\net8.0-windows10.0-22621\$(PackageId)\Assets\..." />
+```
+
+This caused files to copy to wrong locations in consuming projects (`StoryCADLib\Assets\Install`).
+
+#### Fix (4.0)
+
+Commit `7e4bf92c` (2025-11-04) changed all Assets/Install from `Content` to `EmbeddedResource`:
+```xml
+<Content Remove="Assets\Install\*" />
+<EmbeddedResource Include="Assets\Install\Bibliog.txt" />
+<EmbeddedResource Include="Assets\Install\Controls.json" />
+<!-- ... all Install files ... -->
+```
+
+This is correct because `JSONResourceLoader` uses `GetManifestResourceStream()` which requires embedded resources.
+
+#### Impact
+
+| Version | Status | Workaround Needed? |
+|---------|--------|-------------------|
+| 3.3.0 (NuGet) | Bug present | Yes |
+| 4.0.0 (codebase) | Fixed | No |
+
+#### Recommendations
+
+1. Publish 4.0 from commit `7e4bf92c` or later
+2. Consuming projects on 3.3.0 should upgrade to 4.0+
+3. Outliner workaround can be removed after upgrade
+
+**Sources**:
+- StoryCADLib.csproj: `/mnt/d/dev/src/StoryCAD/StoryCADLib/StoryCADLib.csproj` (lines 200-252)
+- JSONResourceLoader.cs: `/mnt/d/dev/src/StoryCAD/StoryCADLib/DAL/JSONResourceLoader.cs`
+- Fix commit: `7e4bf92c` (2025-11-04)
+
+---
+
+### Snippet Style Strategy
+
+**Decision**: Both standalone and cohesive samples.
+
+- **Standalone snippets**: Per-method, referenced/inlined in API guide
+- **Cohesive samples**: Build complete outline step-by-step, show workflow
+
+---
+
+### API Documentation Hosting Strategy
+
+**Question**: Should we have a dedicated website for the API, or add to existing infrastructure?
+
+**Status**: Open - collecting options
+
+**Options**:
+| Option | Example | Pros | Cons |
+|--------|---------|------|------|
+| Add to storybuilder.org | - | Single brand, no new infra | Different audience |
+| Add to user manual | storybuilder-org.github.io/StoryCAD/ | Already exists, Jekyll | Mixes audiences |
+| Dedicated docs site | pollydocs.org | Clean separation, polished | More to maintain |
+| README-driven in repo | GitHub markdown | Simplest, co-located | Less polished |
+
+**Examples to study**:
+- Polly: https://www.pollydocs.org/ (dedicated site)
+- Semantic Kernel: Microsoft Learn (integrated)
+- UNO Platform: platform.uno/docs (dedicated)
+
+**Considerations**:
+- Educational mission (accessibility for learners)
+- Small team (maintenance burden)
+- Auto-generated API reference (DocFX, etc.)
+- Cross-linking with samples repo
+
+---
+
+## Sample Project Ideas
+
+### A. Core API Samples (No LLM)
+
+| # | Sample | Description | Value |
+|---|--------|-------------|-------|
+| 1 | **Story Graph Basics** | Create story, add elements, link them, save/load | Canonical "hello world" |
+| 2 | **Scene-Centric Workflow** | Create scenes, assign POV/goal/conflict/outcome, reorder, validate | Scene-first philosophy |
+| 3 | **Master Plot + Beat Sheet** | Define master plot, attach beat sheet, map beats → scenes | Structure from data |
+| 4 | **Subplots & Sequences** | Create subplot problems, associate scenes, query by subplot | Multi-thread narratives |
+| 5 | **Consistency & Validation** | Detect: scenes without conflict, characters before intro, unresolved problems | Story integrity engine |
+| 6 | **Story Metrics** | Scenes per act, POV distribution, character frequency, conflict density | Dashboards/analytics |
+| 7 | **Import / Export** | Export to JSON, import from JSON, Scrivener-like import | Interop and tooling |
+| 8 | **Project Tracker** | Scan folder for .stbx files, summarize: titles, word counts, completeness | Portfolio management |
+| 9 | **Prompt Generator** | Generate prompts from Master Plots, Dramatic Situations, Stock Scenes | Writing exercises |
+
+### B. Semantic Kernel / LLM Samples
+
+| # | Sample | Description | Value |
+|---|--------|-------------|-------|
+| 10 | **Scene Expansion** | Input goal/conflict/outcome → prose draft (not auto-stored) | Assistive, not generative-first |
+| 11 | **Beat-to-Scene Generator** | Beat description → scene skeleton, user approves before insert | LLM as structured data generator |
+| 12 | **Story Diagnostic Agent** | Analyze structure: sagging middle, missing reversals, passive protagonist | Coaching use case |
+| 13 | **Character Voice Check** | Profile + dialogue → inconsistencies in tone, diction, motivation | Strong differentiator |
+| 14 | **Subplot Balance Analyzer** | Detect dominance/neglect, recommend redistribution | Structural intelligence |
+| 15 | **"What If" Branching** | Clone scene, ask LLM for alternate outcome, compare impact | Non-destructive experimentation |
+| 16 | **Multi-Level Summary** | Scene → sequence → subplot → full story (uses API structure) | Shows why model matters |
+| 17 | **Automated Critique** | Analyze against craft principles, checklist feedback | Educational feedback |
+| 18 | **Prose to Outline** | Convert txt/docx/pdf → StoryCAD outline | Content pipeline |
+
+### C. Packaging Recommendations
+
+- **One folder per sample** with minimal console app
+- **Single README**: "What this demonstrates"
+- **Paired samples** where applicable:
+  - `SceneValidation.Basic`
+  - `SceneValidation.SemanticKernel`
+- **API-first** - avoid UI samples initially
+- **Central Package Management** for version sync
+
+### D. Suggested v1 Minimum Set
+
+Core (no LLM):
+1. Story Graph Basics (hello world)
+2. Story Metrics (analytics)
+3. Consistency & Validation (integrity)
+
+With SK/LLM:
+4. Story Diagnostic Agent (coaching)
+5. Automated Critique (educational)
+
+This gives a balanced introduction without overwhelming maintenance.

--- a/devdocs/issue_1246_api_samples/issue_1246_status_log.md
+++ b/devdocs/issue_1246_api_samples/issue_1246_status_log.md
@@ -1,0 +1,320 @@
+# Issue 1246: Update and Release New Samples and API Guidance
+
+## Current Status
+- **Phase**: Phase 1-6 Complete (Infrastructure + Getting Started + API Reference + Samples + Concepts/Operations/Advanced). Website content complete.
+- **Date**: 2026-02-06
+- **Branch**: `issue-1246-api-docs` (StoryCADAPI repo)
+- **Branch**: `issue-1246-xml-docs` (StoryCAD repo - XML doc generation + comment fixes)
+- **Local folder renamed**: `/mnt/d/dev/src/API-Samples` → `/mnt/d/dev/src/StoryCADAPI`
+- **Website nav**: Home, Getting Started, Concepts, Operations, Samples, Advanced, API Reference (7 sections)
+
+### Cross-Reference: Issue #61 (Prompt Generator)
+
+Issue #61 (Collaborator repo) researched deployment options and arrived at a solution that applies to both issues:
+
+**Selected approach:** Blazor WASM + GitHub Pages on public StoryCADAPI repo
+- docfx for API documentation
+- Blazor WASM for interactive samples (Prompt Generator)
+- GitHub Pages hosting (free)
+- Follows [pollydocs.org](https://www.pollydocs.org/) model
+
+**Repo renamed:** `API-Samples` → `StoryCADAPI` (2026-02-04)
+
+**Deployment guide:** See `/mnt/d/dev/src/Collaborator/devdocs/issue_61_prompt_generator/blazor_github_pages_deployment.md`
+
+This resolves **D2 (Documentation Hosting)** - use GitHub Pages with docfx + Blazor WASM.
+
+## Session Log
+
+### 2026-01-24
+- Set up PIE template on GitHub issue
+- Created devdocs/api_samples folder
+- Investigated existing resources:
+  - NuGet package (StoryCADLib 3.3.0 published, 4.0.0 in codebase)
+  - API-Samples repo (private, outdated samples)
+  - Outliner directory (3 variants, OutlinerAlt is latest)
+- Documented findings in issue_1246_research.md
+- Discussed guidance strategy with user:
+  - Three tracks: external examples, internal XML docs, sample projects
+  - Educational mission framing
+  - StoryCAD API vs Semantic Kernel as consumer (naming clarification)
+- Defined 7 research items (R1-R7)
+- **Starting research phase** - launching parallel agents for R1, R2, R6
+- **Research phase complete** - all 7 items researched
+- Added open question: API documentation hosting strategy (website options)
+- Discussed headless package architecture:
+  - Uno.Fonts.Fluent only used in XAML (UI icons)
+  - Options: Extract Core package vs conditional compilation vs just document
+  - Could separate: StoryCADLib.Core, StoryCADLib.SemanticKernel, StoryCADLib (UI)
+  - Recommendation: Start with documentation, consider extraction later
+- Brainstormed sample project ideas:
+  - Core samples (9): Story Graph Basics, Scene Workflow, Beat Sheets, Validation, Metrics, etc.
+  - SK/LLM samples (9): Scene Expansion, Diagnostic Agent, Voice Check, Critique, etc.
+  - Our additions: Project Tracker, Prompt Generator, Automated Critique
+  - Suggested v1 minimum: 5 samples (3 core + 2 SK)
+- Built decision framework (D1-D5) with dependency chain
+- Documented current NuGet consumers (~1.9K downloads, mostly internal/Outliner)
+- Created issue #1277 for publicity/outreach (depends on #1246)
+- **Session paused** - next step: decisions on D1 (package architecture) and D2 (doc hosting)
+
+### 2026-02-04 - Repo Cleanup & Rename
+- **Repo renamed:** `API-Samples` → `StoryCADAPI` on GitHub
+- Updated local git remote to new URL
+- **Security cleanup for public release:**
+  - Removed hardcoded API key placeholder from `StoryCADChat/Program.cs`
+  - Replaced with `Environment.GetEnvironmentVariable("OPENAI_API_KEY")`
+  - Added `.env` patterns to `.gitignore`
+  - Created `.env.example` documenting required environment variables
+  - Updated `README.md` with environment setup instructions
+- **Repo is now ready to make public** - no secrets, clear setup docs
+- Cross-reference: Work done during Collaborator #61 session
+
+### 2026-02-04 - Phase 1: Infrastructure Setup
+- Created website plan document (`website_plan.md`)
+- Established branching model for StoryCADAPI (matching StoryCAD: main + dev)
+- Created branches: `dev` from `main`, `issue-1246-api-docs` from `dev`
+- Committed security cleanup changes
+- **Created docfx infrastructure:**
+  - `docs/docfx.json` - configuration for API reference generation
+  - `docs/filterConfig.yml` - API filter rules
+  - `docs/toc.yml` - top-level navigation
+  - `docs/index.md` - homepage with quick example
+  - `docs/getting-started/` - installation, quick-start, hello-world docs
+  - `docs/.nojekyll` - disable Jekyll processing
+  - `docs/404.md` - not found page
+- **Created GitHub Actions workflow:**
+  - `.github/workflows/deploy-docs.yml` - build-only (deploy commented out)
+  - Workflow can access org-private NuGet packages
+  - Uploads build artifact for inspection without deploying
+- Added `.gitattributes` for future Blazor WASM support
+- **Phase 1 complete** - infrastructure ready, not yet deployed
+
+### 2026-02-04 - API Reference & Documentation Polish
+- **Attempted auto-generated API docs** - blocked by build issues:
+  - Initially tried `dotnet build StoryCADLib.csproj` directly (wrong approach)
+  - Correct approach is MSBuild via solution, but discovered stale `StoryCADLib/global.json`
+  - StoryCADLib has its own global.json with `Uno.Sdk: 6.0.67`
+  - Solution root has `Uno.Sdk: 6.4.53`
+  - This causes version mismatch when building project directly
+- **Pivoted to manual API documentation** (like pollydocs.org):
+  - `docs/api/index.md` - API overview with quick reference tables
+  - `docs/api/semantic-kernel-api.md` - Full method documentation with examples
+  - `docs/api/operation-result.md` - OperationResult<T> pattern documentation
+  - `docs/api/toc.yml` - Section navigation
+  - Removed unused `docs/filterConfig.yml`
+- **Updated README.md**:
+  - Correct namespace (`StoryCADLib.Services.API` not `StoryCAD.Services.API`)
+  - Proper DI initialization (`ServiceLocator.Initialize(headless: true)`)
+  - Added NuGet and license badges
+  - Documented OperationResult pattern and headless mode
+  - Cross-links to related projects
+- **Local preview tested**:
+  - `docfx docs/docfx.json --serve` runs successfully
+  - Site renders at http://localhost:8080
+  - Navigation pane, search, modern template all working
+- **Renamed local folder**: `API-Samples` → `StoryCADAPI`
+
+### 2026-02-04 - XML Documentation Generation (continued)
+- **Resolved stale global.json issue:**
+  - Deleted `/mnt/d/dev/src/StoryCAD/StoryCADLib/global.json` (had Uno.Sdk 6.0.67)
+  - Solution root global.json (Uno.Sdk 6.4.53) now applies correctly
+  - Builds now work without version conflicts
+- **Enabled XML documentation in StoryCADLib.csproj:**
+  - Added `<GenerateDocumentationFile>true</GenerateDocumentationFile>`
+  - Added `<NoWarn>$(NoWarn);CS1591</NoWarn>` to suppress missing-doc warnings
+- **Build successful:**
+  - `StoryCADLib.xml` generated (217KB)
+  - Contains documentation for Collaborator, Services, ViewModels, Models
+  - StoryCADApi methods are documented
+- **Fixed all malformed XML comments:**
+  - `StoryCADAPI.cs` - Added `<summary>` tags, escaped `<T>` as `&lt;T&gt;`, removed orphaned comment
+  - `INavigationService.cs` - Fixed `</Param>` to `</param>` (case mismatch)
+  - `ShellViewModel.cs` - Fixed missing `>` in `</summary>`
+  - `OutlineService.cs` - Added missing param tags for Model, Parent, Index parameters
+  - `ElementPicker.xaml.cs` - Removed orphaned XML comment at end of class
+- **Rebuild verified** - No XML documentation warnings, clean build
+
+### 2026-02-05 - HeadlessTest Console App (Verification)
+- **Created HeadlessTest project** in `/mnt/d/dev/src/StoryCADAPI/HeadlessTest/`
+  - `global.json` - Uno.Sdk 6.4.53, .NET 10.0.102
+  - `HeadlessTest.csproj` - Uno.Sdk console app, `net10.0-desktop`, ProjectReference to StoryCADLib
+  - `Program.cs` - 7-step verification of headless API usage
+- **All 7 checks passed:**
+  1. Headless initialization (`BootStrapper.Initialise()`)
+  2. DI resolution of `StoryCADApi`
+  3. `CreateEmptyOutline` - 3 element GUIDs returned
+  4. Element inspection - StoryOverview, TrashCan, Narrative View Folder
+  5. `WriteOutline` - 1407-byte `.stbx` file written to disk
+  6. `OpenOutline` - read back successfully
+  7. Round-trip verification - element count matches
+- **Key finding:** `UnoSingleProject=true` required in csproj for `net10.0-desktop` to resolve correctly on Windows
+- **Build/run command:** `dotnet run -f net10.0-desktop` (via Windows dotnet.exe from WSL)
+- **Empirically proves** non-UI consumers can use StoryCADLib 4.0 via ProjectReference
+
+### 2026-02-05 - Release Roadmap Clarification
+- **Resolved D1 (Package Architecture):** Single package (StoryCADLib), publish to NuGet.org at launch. No Core/SK split needed.
+- **Defined two-phase release roadmap:**
+  - **Phase 1 (NOW):** All development uses ProjectReference. StoryCADAPI repo stays private. No NuGet package needed.
+  - **Phase 2 (at 4.0 store release):** Publish NuGet, switch to PackageReference, make repo public, deploy website.
+- **Key insight:** NuGet publication is gated on 4.0 shipping to Windows Store + Apple Store, not on architecture decisions. This unblocks all Phase 1 work immediately.
+- Updated status log with roadmap, resolved decisions, and updated dependency chain.
+
+### 2026-02-05 - v1 Sample Projects (5 samples)
+- **Built 5 educational console app samples** in `/mnt/d/dev/src/StoryCADAPI/`:
+  1. **StoryGraphBasics** - Create, populate, link, save & reload an outline (10 API methods)
+  2. **StoryMetrics** - Analytics dashboard: element counts, character appearances, setting usage
+  3. **ConsistencyValidation** - 6 validation checks detecting 7 intentional issues (orphan chars, unused settings, etc.)
+  4. **StoryDiagnosticAgent** - SK + LLM diagnoses pacing, passive protagonist, plot holes
+  5. **AutomatedCritique** - SK + LLM scores outline against 5 craft criteria with rubric
+- **Each sample is self-contained** (4 files: global.json, .csproj, Program.cs, README.md)
+- **All 5 build with 0 errors, 0 warnings** (Windows dotnet.exe, `net10.0-desktop`)
+- **Samples 1-3 run successfully** with verified output
+- **Samples 4-5 build-only** (require OPENAI_API_KEY at runtime)
+- **SK samples use** `Environment.GetEnvironmentVariable("OPENAI_API_KEY")` — no hardcoded keys
+- **API coverage across samples:**
+  - Core: CreateEmptyOutline, AddElement, UpdateElementProperties, AddCastMember, AddRelationship, GetAllElements, GetElementsByType, GetElement, GetStoryElement, WriteOutline, OpenOutline, SearchForReferences, GetKeyQuestionElements, GetKeyQuestions
+  - SK: Kernel.CreateBuilder().AddOpenAIChatCompletion(), IChatCompletionService, ChatHistory
+
+### 2026-02-06 - Sample Documentation for docfx Website
+- **Created `docs/samples/` section** in StoryCADAPI docfx site (7 new files):
+  - `toc.yml` — Section navigation (6 entries)
+  - `index.md` — Overview with sample table, prerequisites, run instructions, API coverage matrix
+  - `story-graph-basics.md` — Create/link/query/persist workflow
+  - `story-metrics.md` — Analytics and query APIs
+  - `consistency-validation.md` — Validation checks and orphan detection
+  - `story-diagnostic-agent.md` — SK + LLM structural diagnosis
+  - `automated-critique.md` — SK + LLM scored craft evaluation
+- **Updated 2 existing files:**
+  - `docs/toc.yml` — Added Samples to top-level nav (between Getting Started and API Reference)
+  - `docs/index.md` — Fixed broken Samples link (was GitHub URL, now `samples/index.md`)
+- **docfx build verified** — 0 errors, all 7 HTML pages generated in `_site/samples/`
+- **Local preview confirmed** — pages render correctly, sidebar nav works, TIP/NOTE callouts display
+- **Known:** "View source on GitHub" links return 404 while repo is private; will resolve at Phase 2
+
+### 2026-02-06 - Concepts, Operations, and Advanced Sections
+- **Created `docs/concepts/` section** (4 new files):
+  - `toc.yml` — Section navigation (3 entries)
+  - `story-model.md` — StoryModel structure, StoryElementCollection, GUID-based cross-referencing, ExplorerView/NarratorView/TrashView trees, singleton elements, file format
+  - `element-types.md` — All 11 StoryItemType values with model class, key properties organized by category, value types (plain string vs GUID reference vs GetExamples enum), containment rules, quick-reference tables for UpdateElementProperty
+  - `resource-data.md` — Overview of 6 resource categories (example lists, conflict builder, key questions, master plots, stock scenes, beat sheets) with access patterns and cross-references to Operations pages
+- **Created `docs/operations/` section** (4 new files):
+  - `toc.yml` — Section navigation (3 entries)
+  - `search.md` — SearchForText, SearchForReferences, SearchInSubtree, RemoveReferences with full examples, return structures, and practical patterns (orphan detection, dependency graphs)
+  - `resource-workflows.md` — Step-by-step code examples for conflict builder (4-step), key questions (2-step), master plots (3-step), stock scenes (2-step), plus combined workflow example
+  - `beat-sheets.md` — Complete beat sheet workflow: browse templates, preview, apply to Problem, view structure, assign elements, customize (create/update/delete/move), save/load .stbeat files, complete end-to-end example
+- **Created `docs/advanced/` section** (3 new files):
+  - `toc.yml` — Section navigation (2 entries)
+  - `semantic-kernel.md` — [KernelFunction] attribute pattern, plugin registration, automatic function calling, complete agent example with system prompt, multi-step agent patterns, system prompt tips, NuGet dependencies
+  - `migration-3x-to-4x.md` — Breaking changes (namespace, class rename, TFM, StoryWorld), before/after code for each, new API methods summary, file format compatibility, migration checklist
+- **Updated `docs/toc.yml`** — Reordered to 7 sections following developer learning path: Home → Getting Started → Concepts → Operations → Samples → Advanced → API Reference
+- **Updated `docs/index.md`** — Added links to Concepts, Operations, and Advanced in Documentation area
+- **Updated `README.md`** — Added `taskkill.exe /F /IM docfx.exe` instruction for stopping docfx server from WSL
+- **docfx build verified** — 0 errors, all 7 top-level nav entries render, all section sidebars work
+- **Committed and pushed** to `issue-1246-api-docs` branch (14 files, 1,708 lines)
+- **Content sourced from**: StoryCADApi.cs (method signatures, XML docs, [KernelFunction] attributes), all element model classes (CharacterModel, SceneModel, ProblemModel, SettingModel, OverviewModel, StoryWorldModel, FolderModel, WebModel, TrashCanModel), StoryModel.cs, StoryElement.cs, StoryItemType.cs, OperationResult.cs, existing samples
+
+### Future Enhancements
+- Add logo/branding
+- Diagrams (StoryModel structure, GUID reference graph)
+- Custom CSS styling
+
+## Release Roadmap
+
+### Phase 1: Development (NOW — pre-launch)
+
+**Context:** StoryCADAPI repo is private. API website is not published. All work uses ProjectReference.
+
+- Samples reference StoryCADLib via `ProjectReference` to `../../StoryCAD/StoryCADLib/StoryCADLib.csproj`
+- CI in StoryCADAPI checks out both repos (pattern already in `deploy-docs.yml`)
+- No NuGet package needed during this phase
+
+**Work items:**
+- [x] Build and test sample projects (v1 set: 3 core + 2 SK)
+- [x] Build API website (docfx) — infrastructure, getting started, API reference, samples sections done
+- [ ] Add Blazor WASM interactive samples (Prompt Generator — see Collaborator #61)
+- [ ] Write advanced topics / guides (migration, SK integration, error handling)
+- [ ] Configure docfx to use auto-generated XML docs (optional enhancement)
+- [ ] Add build/run instructions for StoryCADAPI users (website content + repo README)
+
+### Phase 2: Public Launch (when 4.0 ships to Windows Store + Apple Store)
+
+- Add NuGet metadata to `StoryCADLib.csproj` (PackageId, Authors, License, etc.)
+- Publish StoryCADLib 4.0.0 to NuGet.org (public)
+- Switch all samples from `ProjectReference` to `<PackageReference Include="StoryCADLib" Version="4.0.0" />`
+- Make StoryCADAPI repo public
+- Enable GitHub Pages deployment for API website
+- Announce via issue #1277 (publicity/outreach)
+
+### Completed Milestones
+- [x] Determine how StoryCADLib 4.0 (UNO) project creation works (R1 - headless works)
+- [x] Decide on documentation hosting strategy → **GitHub Pages + docfx + Blazor WASM** (resolved via #61)
+- [x] **Phase 1: Infrastructure** - docfx config, GitHub Actions, docs skeleton
+- [x] **Phase 2: Getting Started content** - installation, quick-start, hello-world
+- [x] **Phase 3: API Reference** - manual markdown docs + XML generation now working
+- [x] Resolve stale `StoryCADLib/global.json` - **DELETED**, builds work now
+- [x] Enable XML documentation generation in StoryCADLib
+- [x] Publish StoryCADAPI repo publicly (ready - secrets removed, repo renamed)
+- [x] Decide on package architecture - **Single package (StoryCADLib), publish at launch** (D1 resolved 2026-02-05)
+- [x] **Sample documentation** - 5 sample pages + overview in docfx website (2026-02-06)
+
+## Open Issues
+1. ~~StoryCADLib 4.0.0 not yet published to NuGet (still 3.3.0)~~ — **Phase 2**: NuGet.org publish gated on 4.0 Windows Store + Apple Store release
+2. ~~Samples reference outdated versions (3.0.8, net8.0)~~ — **Phase 1**: samples use ProjectReference during development; switch to PackageReference at launch
+3. ~~UNO platform changes may affect API consumers~~ (R1: headless works fine)
+4. ~~Packaging issue documented in Outliner workaround~~ (R6: fixed in 4.0)
+5. ~~Stale `StoryCADLib/global.json`~~ - **DELETED** (2026-02-04)
+6. ~~Malformed XML doc comments~~ - **FIXED** (2026-02-04)
+7. NuGet.org publish gated on 4.0 Windows Store + Apple Store release (see Phase 2 roadmap)
+
+## Decision Framework
+
+### Tier 1: Foundational — RESOLVED
+
+| ID | Decision | Resolution | Date |
+|----|----------|-----------|------|
+| D1 | **Package Architecture** | **Single package (StoryCADLib)**, publish to NuGet.org at launch. No Core/SK split needed now. | 2026-02-05 |
+| D2 | **Documentation Hosting** | **GitHub Pages + docfx + Blazor WASM** (resolved via #61) | 2026-02-04 |
+| D4 | **Samples in separate public repo?** | **Yes — StoryCADAPI repo.** Made public at Phase 2 (store release). | 2026-02-05 |
+| D5 | **v1 = 5 samples (3 core + 2 SK)?** | **Yes.** See v1 sample list in research doc. | 2026-02-05 |
+
+### Tier 2: Strategy Confirmation (research has recommendations, need sign-off)
+
+| ID | Decision | Recommendation | If Yes, Then... |
+|----|----------|----------------|-----------------|
+| D3 | **Python via .stbx JSON?** | Yes - pure Python library | Document JSON schema first |
+
+### Tier 3: Execution (after Tier 1-2 resolved)
+
+| Action | Depends On |
+|--------|------------|
+| Publish NuGet 4.0.0 | 4.0 store release (Windows + Apple) |
+| Build v1 samples | D4, D5 (use ProjectReference during Phase 1) |
+| Write API documentation | D2 (resolved) |
+| Document .stbx JSON schema | D3 |
+| Add XML doc comments to API | Done (2026-02-04) |
+
+### Dependency Chain
+
+```
+4.0 Store Release (Windows Store + Apple Store)
+ └─► NuGet 4.0.0 publication
+ └─► Samples switch from ProjectReference to PackageReference
+ └─► StoryCADAPI repo made public
+ └─► GitHub Pages deployment enabled
+ └─► Announce via #1277 (publicity/outreach)
+
+D3 + D4 + D5 confirmed
+ └─► Can start building samples and docs now (Phase 1, ProjectReference)
+```
+
+**Current state**: D1 and D2 resolved. NuGet publish gated on 4.0 store release, not on architecture decisions. Phase 1 work can proceed immediately.
+
+## Notes
+- OutlinerAlt is best reference for real-world API usage
+- ~~API-Samples repo is private - needs to be released~~ → Renamed to **StoryCADAPI**, ready to make public
+
+---
+
+## Research
+
+See `issue_1246_research.md` for completed research items (R1-R7).

--- a/devdocs/issue_1246_api_samples/website_plan.md
+++ b/devdocs/issue_1246_api_samples/website_plan.md
@@ -1,0 +1,476 @@
+# StoryCADAPI Documentation Website Plan
+
+## Overview
+
+Create a documentation website for StoryCADLib API, hosted on GitHub Pages at the StoryCADAPI repository. Follows the [pollydocs.org](https://www.pollydocs.org/) model: docfx-generated documentation with sidebar navigation, progressive disclosure, and professional developer experience.
+
+**Target URL:** `https://storybuilder-org.github.io/StoryCADAPI/`
+**Repository:** `storybuilder-org/StoryCADAPI` (currently private, renamed from API-Samples)
+
+---
+
+## Phase 1: Infrastructure Setup
+
+### 1.1 Repository Structure
+
+```
+StoryCADAPI/
+├── .github/
+│   └── workflows/
+│       └── deploy-docs.yml          # GitHub Actions workflow
+├── .gitattributes                    # *.js binary (for future Blazor)
+├── docs/                             # docfx source
+│   ├── docfx.json                    # docfx configuration
+│   ├── toc.yml                       # Top-level table of contents
+│   ├── index.md                      # Homepage
+│   ├── getting-started/
+│   │   ├── toc.yml
+│   │   ├── index.md                  # Installation & first API call
+│   │   ├── quick-start.md            # 5-minute tutorial
+│   │   └── hello-world.md            # Minimal working example
+│   ├── concepts/
+│   │   ├── toc.yml
+│   │   ├── operation-result.md       # OperationResult<T> pattern
+│   │   ├── story-model.md            # StoryModel structure
+│   │   ├── element-types.md          # Character, Scene, Problem, etc.
+│   │   └── headless-mode.md          # Using API without UI
+│   ├── operations/
+│   │   ├── toc.yml
+│   │   ├── outline-operations.md     # Create, open, save outlines
+│   │   ├── element-operations.md     # CRUD for story elements
+│   │   ├── navigation.md             # Tree navigation
+│   │   ├── search.md                 # Search operations
+│   │   └── beat-sheets.md            # Beat sheet API
+│   ├── samples/
+│   │   ├── toc.yml
+│   │   ├── index.md                  # Samples overview
+│   │   └── [sample docs]             # Per-sample documentation
+│   ├── advanced/
+│   │   ├── toc.yml
+│   │   ├── error-handling.md         # Working with OperationResult
+│   │   ├── semantic-kernel.md        # SK integration
+│   │   ├── testing.md                # Testing with the API
+│   │   └── migration-3x-to-4x.md     # Migration guide
+│   ├── api/                          # Auto-generated API reference
+│   │   └── .gitkeep
+│   └── templates/                    # Custom docfx templates (optional)
+├── samples/                          # Sample projects (runnable code)
+│   ├── Directory.Packages.props      # Central package management
+│   ├── getting-started/
+│   │   └── HelloStoryCAD/
+│   ├── core/
+│   │   ├── StoryGraphBasics/
+│   │   ├── StoryMetrics/
+│   │   └── ConsistencyValidation/
+│   └── semantic-kernel/
+│       ├── StoryDiagnosticAgent/
+│       └── AutomatedCritique/
+├── README.md                         # Repository overview
+├── CONTRIBUTING.md                   # Contribution guidelines
+└── LICENSE
+```
+
+### 1.2 docfx.json Configuration
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/docfx.schema.json",
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": ["**/StoryCADLib.csproj"],
+          "src": "../StoryCAD"
+        }
+      ],
+      "dest": "api",
+      "includePrivateMembers": false,
+      "disableGitFeatures": false,
+      "disableDefaultFilter": false,
+      "properties": {
+        "TargetFramework": "net10.0-windows10.0.22621"
+      },
+      "filter": "filterConfig.yml"
+    }
+  ],
+  "build": {
+    "content": [
+      { "files": ["**/*.{md,yml}"], "src": "." }
+    ],
+    "resource": [
+      { "files": ["images/**"] }
+    ],
+    "output": "_site",
+    "template": ["default", "modern"],
+    "globalMetadata": {
+      "_appTitle": "StoryCAD API",
+      "_appName": "StoryCAD API",
+      "_appFooter": "StoryBuilder Foundation - GNU GPL v3",
+      "_enableSearch": true,
+      "_enableNewTab": true,
+      "_disableContribution": false,
+      "_gitContribute": {
+        "repo": "https://github.com/storybuilder-org/StoryCADAPI",
+        "branch": "main",
+        "path": "docs"
+      }
+    },
+    "fileMetadata": {
+      "_layout": { "api/**": "Reference" }
+    },
+    "markdownEngineName": "markdig",
+    "noLangKeyword": false,
+    "keepFileLink": false,
+    "cleanupCacheHistory": false,
+    "disableGitFeatures": false
+  }
+}
+```
+
+### 1.3 GitHub Actions Workflow
+
+Create `.github/workflows/deploy-docs.yml`:
+
+```yaml
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'samples/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout StoryCADAPI
+        uses: actions/checkout@v4
+
+      - name: Checkout StoryCAD (for API metadata)
+        uses: actions/checkout@v4
+        with:
+          repository: storybuilder-org/StoryCAD
+          path: StoryCAD
+          ref: main
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install docfx
+        run: dotnet tool install -g docfx
+
+      - name: Build documentation
+        run: docfx docs/docfx.json
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+### 1.4 Required Static Files
+
+**docs/.nojekyll** (empty file):
+```
+# Create empty file - prevents Jekyll processing
+```
+
+**docs/404.md**:
+```markdown
+---
+_layout: landing
+---
+# Page Not Found
+
+The page you requested could not be found.
+
+[Return to documentation home](/)
+```
+
+---
+
+## Phase 2: Content - Getting Started
+
+### 2.1 Homepage (docs/index.md)
+
+```markdown
+---
+_layout: landing
+---
+# StoryCAD API
+
+Build story outlines programmatically with the StoryCADLib API.
+
+[!INCLUDE[Quick Example](getting-started/quick-example.md)]
+
+## Features
+
+- **Outline Management** - Create, open, save story outlines (.stbx files)
+- **Element CRUD** - Add characters, scenes, problems, settings
+- **Structure Tools** - Beat sheets, master plots, dramatic situations
+- **Headless Mode** - Use in console apps, web APIs, batch processing
+- **Semantic Kernel** - Ready-made functions for AI agents
+
+## Getting Started
+
+- [Installation](getting-started/index.md)
+- [Quick Start Tutorial](getting-started/quick-start.md)
+- [Hello World Sample](getting-started/hello-world.md)
+
+## Learn More
+
+- [Concepts](concepts/index.md) - Core data structures and patterns
+- [Operations](operations/index.md) - API method reference by category
+- [Samples](samples/index.md) - Complete working examples
+- [API Reference](api/index.md) - Full technical documentation
+```
+
+### 2.2 Installation (docs/getting-started/index.md)
+
+Content covering:
+- NuGet installation (`dotnet add package StoryCADLib`)
+- Target framework requirements (net10.0)
+- Headless initialization (`BootStrapper.Initialise(headless: true)`)
+- Getting the API instance via DI
+
+### 2.3 Quick Start (docs/getting-started/quick-start.md)
+
+5-minute tutorial covering:
+1. Create empty outline
+2. Add a character
+3. Add a scene
+4. Save to file
+5. Verify with StoryCAD application
+
+---
+
+## Phase 3: API Reference (XML Documentation)
+
+### 3.1 Enable XML Documentation in StoryCADLib
+
+Update `StoryCADLib.csproj`:
+
+```xml
+<PropertyGroup>
+  <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  <NoWarn>$(NoWarn);CS1591</NoWarn> <!-- Suppress missing XML doc warnings initially -->
+</PropertyGroup>
+```
+
+### 3.2 Priority XML Documentation Targets
+
+Add XML documentation to these files first:
+
+| Priority | File | Methods |
+|----------|------|---------|
+| 1 | StoryCADAPI.cs | All public methods (~80) |
+| 2 | OperationResult.cs | IsSuccess, Payload, ErrorMessage |
+| 3 | BootStrapper.cs | Initialise() |
+| 4 | Key Models | StoryModel, StoryNodeItem, element types |
+
+### 3.3 XML Documentation Template
+
+```csharp
+/// <summary>
+/// Creates a new empty story outline with the specified metadata.
+/// </summary>
+/// <param name="title">The title of the story.</param>
+/// <param name="author">The author's name.</param>
+/// <param name="templateIndex">Template index: "0" for blank, "1" for basic template.</param>
+/// <returns>
+/// An <see cref="OperationResult{T}"/> containing a list of created element GUIDs on success,
+/// or an error message on failure.
+/// </returns>
+/// <example>
+/// <code>
+/// var result = await api.CreateEmptyOutline("My Story", "Jane Doe", "0");
+/// if (result.IsSuccess)
+/// {
+///     Console.WriteLine($"Created {result.Payload.Count} elements");
+/// }
+/// </code>
+/// </example>
+public async Task<OperationResult<List<Guid>>> CreateEmptyOutline(string title, string author, string templateIndex)
+```
+
+---
+
+## Phase 4: Sample Projects
+
+### 4.1 Central Package Management
+
+Create `samples/Directory.Packages.props`:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="StoryCADLib" Version="4.0.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.61.0" />
+  </ItemGroup>
+</Project>
+```
+
+### 4.2 V1 Sample Set (5 Samples)
+
+| # | Sample | Type | Purpose |
+|---|--------|------|---------|
+| 1 | HelloStoryCAD | Core | Minimal example - create outline, add character, save |
+| 2 | StoryGraphBasics | Core | Full CRUD, parent-child relationships, tree navigation |
+| 3 | StoryMetrics | Core | Query outline for statistics (scene count, POV distribution) |
+| 4 | ConsistencyValidation | Core | Detect story problems (scenes without conflict, etc.) |
+| 5 | StoryDiagnosticAgent | SK | LLM-powered story analysis and recommendations |
+
+### 4.3 Sample Project Template
+
+Each sample folder contains:
+```
+SampleName/
+├── SampleName.csproj
+├── Program.cs
+├── README.md           # What it demonstrates, how to run
+└── sample-output.txt   # Expected output (for verification)
+```
+
+### 4.4 Migrate Existing Samples
+
+Update existing samples to 4.0:
+
+| Current | Action |
+|---------|--------|
+| StoryCADChat | Update to net10.0, StoryCADLib 4.0, fix namespace |
+| Blank Project | Rename to HelloStoryCAD, update references |
+
+---
+
+## Phase 5: Advanced Topics
+
+### 5.1 Migration Guide (3.x → 4.0)
+
+Content from research:
+- Namespace change: `StoryCAD.Services.API` → `StoryCADLib.Services.API`
+- Class rename: `StoryCADAPI` → `StoryCADApi`
+- TFM update: net8.0/net9.0 → net10.0
+- New features available in 4.0
+
+### 5.2 Semantic Kernel Integration
+
+Document using StoryCADLib with SK agents:
+- Available KernelFunctions
+- Creating a kernel with StoryCAD plugins
+- Example agent prompts
+
+### 5.3 Error Handling
+
+Deep dive on OperationResult pattern:
+- Checking success/failure
+- Accessing payloads
+- Common error messages and resolutions
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Infrastructure (Week 1)
+- [ ] Create branch `issue-1246-api-docs`
+- [ ] Set up docfx.json in StoryCADAPI repo
+- [ ] Create GitHub Actions workflow
+- [ ] Add .nojekyll and 404.md
+- [ ] Configure GitHub Pages (Settings → Pages → GitHub Actions)
+- [ ] Verify empty site deploys successfully
+
+### Phase 2: Getting Started (Week 2)
+- [ ] Write index.md (homepage)
+- [ ] Write getting-started/index.md (installation)
+- [ ] Write getting-started/quick-start.md (5-min tutorial)
+- [ ] Write getting-started/hello-world.md (minimal example)
+- [ ] Create HelloStoryCAD sample project
+
+### Phase 3: API Reference (Week 3)
+- [ ] Enable XML documentation in StoryCADLib.csproj
+- [ ] Add XML docs to StoryCADAPI.cs (priority methods)
+- [ ] Add XML docs to OperationResult.cs
+- [ ] Add XML docs to BootStrapper.cs
+- [ ] Verify API reference generates in docfx
+
+### Phase 4: Samples (Week 4)
+- [ ] Set up Directory.Packages.props
+- [ ] Migrate StoryCADChat to 4.0
+- [ ] Create StoryGraphBasics sample
+- [ ] Create StoryMetrics sample
+- [ ] Create ConsistencyValidation sample
+- [ ] Document each sample in docs/samples/
+
+### Phase 5: Advanced & Polish (Week 5)
+- [ ] Write migration-3x-to-4x.md
+- [ ] Write semantic-kernel.md
+- [ ] Write error-handling.md
+- [ ] Add cross-links between docs and samples
+- [ ] Review and polish all content
+- [ ] Make repository public
+
+### Phase 6: Release
+- [ ] Publish StoryCADLib 4.0.0 to NuGet
+- [ ] Update README with links to docs site
+- [ ] Add cross-links from StoryCAD main repo
+- [ ] Announce availability
+
+---
+
+## Dependencies
+
+| Dependency | Status | Notes |
+|------------|--------|-------|
+| StoryCADLib 4.0 codebase | Ready | In dev branch |
+| StoryCADLib 4.0 NuGet | Not published | Needed for samples to reference |
+| StoryCADAPI repo public | Private | Make public when ready |
+| GitHub Pages enabled | Not configured | Configure after first push |
+
+---
+
+## Success Criteria
+
+- [ ] Documentation site accessible at GitHub Pages URL
+- [ ] API reference auto-generated from XML docs
+- [ ] All 5 v1 samples compile and run
+- [ ] Getting started guide enables new users in <5 minutes
+- [ ] "Edit this page" links work for community contributions
+- [ ] Search functionality works
+- [ ] Mobile-responsive layout
+
+---
+
+## References
+
+- [docfx Documentation](https://dotnet.github.io/docfx/)
+- [pollydocs.org](https://www.pollydocs.org/) - Model site
+- [GitHub Pages Documentation](https://docs.github.com/en/pages)
+- [Blazor WASM Deployment Guide](file:///mnt/d/dev/src/Collaborator/devdocs/issue_61_prompt_generator/blazor_github_pages_deployment.md) - For future Prompt Generator integration

--- a/docs/For Developers/Using_the_API.md
+++ b/docs/For Developers/Using_the_API.md
@@ -71,8 +71,8 @@ namespace StoryCADConsoleSample
     {
         static async Task Main(string[] args)
         {
-            // Create a new instance of the SemanticKernelApi (assuming dependency injection or manual instantiation)
-            var api = new SemanticKernelApi();
+            // Create a new instance of the StoryCADApi (assuming dependency injection or manual instantiation)
+            var api = new StoryCADApi();
             
             // Create an empty outline
             var outlineResult = await api.CreateEmptyOutline("The Great Adventure", "Jane Doe", "0");


### PR DESCRIPTION
## Summary
- Rename `SemanticKernelApi` class and file to `StoryCADApi` before 4.0 NuGet publish (class name becomes public contract)
- Update all references in StoryCADLib (4 .cs files), StoryCADTests (3 .cs files), and documentation (9 files)
- No behavior changes; `[KernelFunction]` attributes and Semantic Kernel imports remain

## Test plan
- [x] Build passes with zero errors
- [x] All 803 tests pass (789 passed, 14 skipped — matches baseline)
- [x] `grep -r "SemanticKernelApi" --include="*.cs"` returns zero hits
- [ ] Manual smoke test of API operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)