### PR TITLE
fix(#1305): Update SemanticKernel to 1.70.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,8 +7,8 @@
   -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.68.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.68.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.70.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.70.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Planners.OpenAI" Version="1.16.0-preview" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="dotenv.net" Version="4.0.0" />


### PR DESCRIPTION
## Summary
- Update Microsoft.SemanticKernel and Abstractions from 1.68.0 to 1.70.0 in Directory.Packages.props (critical vulnerability GHSA-2ww3-72rp-wpp4, CVSS 10.0)

Related: storybuilder-org/Collaborator#63

## Test plan
- [x] Clean build: 0 warnings, 0 errors
- [x] Collaborator tests passing (233/233)

🤖 Generated with [Claude Code](https://claude.com/claude-code)