### PR TITLE
feat(#52): Add ILogService to ICollaborator.OpenAsync

### DIFF
--- a/StoryCADLib/Services/Collaborator/CollaboratorService.cs
+++ b/StoryCADLib/Services/Collaborator/CollaboratorService.cs
@@ -105,7 +105,7 @@ public class CollaboratorService
                 // DIAG-55: Log before OpenAsync - verify both references match
                 _logService.Log(LogLevel.Info, $"DIAG-55: Before OpenAsync - storyModel hash={RuntimeHelpers.GetHashCode(storyModel)}, api.CurrentModel hash={RuntimeHelpers.GetHashCode(api.CurrentModel)}");
                 var filePath = _appState.CurrentDocument?.FilePath ?? string.Empty;
-                await _collaboratorInterface.OpenAsync(api, storyModel, CollaboratorWindow, hostFrame, filePath);
+                await _collaboratorInterface.OpenAsync(api, storyModel, CollaboratorWindow, hostFrame, filePath, _logService);
             }
             catch (Exception ex)
             {

--- a/StoryCADLib/Services/Collaborator/Contracts/ICollaborator.cs
+++ b/StoryCADLib/Services/Collaborator/Contracts/ICollaborator.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS8632 // Nullable annotations used without nullable context
 using StoryCADLib.Models;
 using StoryCADLib.Services.API;
+using StoryCADLib.Services.Logging;
 
 namespace StoryCADLib.Services.Collaborator.Contracts;
 
@@ -18,8 +19,9 @@ public interface ICollaborator
 /// <param name="hostWindow">Host-created window for Collaborator UI</param>
 /// <param name="hostFrame">Host-created frame (with region) for navigation</param>
 /// <param name="filePath">Path to the story file for saving via API</param>
+/// <param name="logger">StoryCAD's logger for high-level audit events (null if unavailable)</param>
 /// <returns>The window hosting Collaborator's UI</returns>
-Task<Window> OpenAsync(IStoryCADAPI api, StoryModel model, Window hostWindow, Frame hostFrame, string filePath);
+Task<Window> OpenAsync(IStoryCADAPI api, StoryModel model, Window hostWindow, Frame hostFrame, string filePath, ILogService? logger = null);
 
 /// <summary>
 ///     Signals that the host is closing Collaborator and retrieves a session summary.

--- a/StoryCADTests/Collaborator/CollaboratorInterfaceTests.cs
+++ b/StoryCADTests/Collaborator/CollaboratorInterfaceTests.cs
@@ -31,7 +31,7 @@ public class CollaboratorInterfaceTests
     /// </summary>
     private class MockCollaborator : ICollaborator
     {
-        public Task<Window> OpenAsync(IStoryCADAPI api, StoryModel model, Window hostWindow, Frame hostFrame, string filePath)
+        public Task<Window> OpenAsync(IStoryCADAPI api, StoryModel model, Window hostWindow, Frame hostFrame, string filePath, StoryCADLib.Services.Logging.ILogService? logger = null)
         {
             return Task.FromResult<Window>(null);
         }


### PR DESCRIPTION
## Summary
- Adds optional `ILogService` parameter to `ICollaborator.OpenAsync()` so Collaborator can write audit events to StoryCAD's log
- `CollaboratorService` passes its existing `_logService` at session open
- Keeps `IStoryCADAPI` clean for public consumers (StoryCADAPI samples repo)

## Test plan
- [x] Build StoryCAD solution — zero errors
- [x] Mock in `CollaboratorInterfaceTests` updated for new signature
- [ ] Manual: open StoryCAD, launch Collaborator, verify log entries appear

**Note:** Merge this PR before the corresponding Collaborator PR (storybuilder-org/Collaborator#65) since it changes the interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)