### PR TITLE
fix(#1325): Prevent tools from inserting elements into trash

### DIFF
--- a/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
+++ b/StoryCADLib/ViewModels/SubViewModels/OutlineViewModel.cs
@@ -845,6 +845,13 @@ public class OutlineViewModel : ObservableRecipient
 
                 if (result == ContentDialogResult.Primary) // Copy command
                 {
+                    if (StoryNodeItem.RootNodeType(appState.RightTappedNode) == StoryItemType.TrashCan)
+                    {
+                        Messenger.Send(new StatusChangedMessage(new StatusMessage("Cannot add to Deleted Items",
+                            LogLevel.Warn, true)));
+                        return;
+                    }
+
                     var masterPlotsVm = Ioc.Default.GetRequiredService<MasterPlotsViewModel>();
                     var masterPlotName = masterPlotsVm.PlotPatternName;
                     var model = masterPlotsVm.MasterPlots[masterPlotName];
@@ -918,6 +925,13 @@ public class OutlineViewModel : ObservableRecipient
                     return;
                 }
 
+                if (StoryNodeItem.RootNodeType(appState.RightTappedNode) == StoryItemType.TrashCan)
+                {
+                    Messenger.Send(new StatusChangedMessage(new StatusMessage("Cannot add to Deleted Items",
+                        LogLevel.Warn, true)));
+                    return;
+                }
+
                 string msg;
 
                 if (result == ContentDialogResult.Primary)
@@ -983,6 +997,13 @@ public class OutlineViewModel : ObservableRecipient
 
                     if (result == ContentDialogResult.Primary) // Copy command
                     {
+                        if (StoryNodeItem.RootNodeType(appState.RightTappedNode) == StoryItemType.TrashCan)
+                        {
+                            Messenger.Send(new StatusChangedMessage(new StatusMessage("Cannot add to Deleted Items",
+                                LogLevel.Warn, true)));
+                            return;
+                        }
+
                         if (string.IsNullOrWhiteSpace(Ioc.Default.GetRequiredService<StockScenesViewModel>().SceneName))
                         {
                             Messenger.Send(new StatusChangedMessage(new StatusMessage(

--- a/StoryCADTests/ViewModels/SubViewModels/OutlineViewModelTests.cs
+++ b/StoryCADTests/ViewModels/SubViewModels/OutlineViewModelTests.cs
@@ -341,6 +341,36 @@ public class OutlineViewModelTests
     }
 
     [TestMethod]
+    public async Task MasterPlotTool_WhenTargetIsTrash_DoesNotCreateElements()
+    {
+        // Arrange
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var model = await outlineService.CreateModel("MasterPlotTrash", "StoryBuilder", 0);
+        appState.CurrentDocument = new StoryDocument(model);
+        outlineService.SetCurrentView(appState.CurrentDocument.Model, StoryViewType.ExplorerView);
+
+        // Get the TrashCan node
+        var trashCanNode = appState.CurrentDocument.Model.TrashView
+            .FirstOrDefault(n => n.Type == StoryItemType.TrashCan);
+        Assert.IsNotNull(trashCanNode, "TrashCan node should exist");
+        appState.RightTappedNode = trashCanNode;
+
+        // Configure tool with valid selection
+        var masterPlotsVM = Ioc.Default.GetRequiredService<MasterPlotsViewModel>();
+        masterPlotsVM.PlotPatternName = masterPlotsVM.PlotPatternNames[0];
+
+        var countBefore = appState.CurrentDocument.Model.StoryElements.Count;
+
+        // Act
+        await outlineVM.MasterPlotTool();
+
+        // Assert - no elements should have been created
+        var countAfter = appState.CurrentDocument.Model.StoryElements.Count;
+        Assert.AreEqual(countBefore, countAfter,
+            "MasterPlotTool should not create elements when target is in trash");
+    }
+
+    [TestMethod]
     public async Task TestDramaticSituationsTool()
     {
         //Create outline
@@ -397,6 +427,35 @@ public class OutlineViewModelTests
     }
 
     [TestMethod]
+    public async Task DramaticSituationsTool_WhenTargetIsTrash_DoesNotCreateElements()
+    {
+        // Arrange
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var model = await outlineService.CreateModel("DramaticTrash", "StoryBuilder", 0);
+        appState.CurrentDocument = new StoryDocument(model);
+        outlineService.SetCurrentView(appState.CurrentDocument.Model, StoryViewType.ExplorerView);
+
+        // Get the TrashCan node
+        var trashCanNode = appState.CurrentDocument.Model.TrashView
+            .FirstOrDefault(n => n.Type == StoryItemType.TrashCan);
+        Assert.IsNotNull(trashCanNode, "TrashCan node should exist");
+        appState.RightTappedNode = trashCanNode;
+
+        // Configure tool with valid selection
+        Ioc.Default.GetRequiredService<DramaticSituationsViewModel>().SituationName = "Abduction";
+
+        var countBefore = appState.CurrentDocument.Model.StoryElements.Count;
+
+        // Act
+        await outlineVM.DramaticSituationsTool();
+
+        // Assert - no elements should have been created
+        var countAfter = appState.CurrentDocument.Model.StoryElements.Count;
+        Assert.AreEqual(countBefore, countAfter,
+            "DramaticSituationsTool should not create elements when target is in trash");
+    }
+
+    [TestMethod]
     public async Task TestStockScenesTool()
     {
         //Create outline
@@ -417,6 +476,35 @@ public class OutlineViewModelTests
 
         Assert.IsTrue(appState.CurrentDocument.Model.StoryElements[3].Name == "The police join the chase",
             "Stock scene not added.");
+    }
+
+    [TestMethod]
+    public async Task StockScenesTool_WhenTargetIsTrash_DoesNotCreateElements()
+    {
+        // Arrange
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var model = await outlineService.CreateModel("StockTrash", "StoryBuilder", 0);
+        appState.CurrentDocument = new StoryDocument(model, Path.Combine(App.ResultsDir, "StockTrash.stbx"));
+        outlineService.SetCurrentView(appState.CurrentDocument.Model, StoryViewType.ExplorerView);
+
+        // Get the TrashCan node
+        var trashCanNode = appState.CurrentDocument.Model.TrashView
+            .FirstOrDefault(n => n.Type == StoryItemType.TrashCan);
+        Assert.IsNotNull(trashCanNode, "TrashCan node should exist");
+        appState.RightTappedNode = trashCanNode;
+
+        // Configure tool with valid selection
+        Ioc.Default.GetRequiredService<StockScenesViewModel>().SceneName = "The police join the chase";
+
+        var countBefore = appState.CurrentDocument.Model.StoryElements.Count;
+
+        // Act
+        await outlineVM.StockScenesTool();
+
+        // Assert - no elements should have been created
+        var countAfter = appState.CurrentDocument.Model.StoryElements.Count;
+        Assert.AreEqual(countBefore, countAfter,
+            "StockScenesTool should not create elements when target is in trash");
     }
 
 


### PR DESCRIPTION
## Summary
- Adds trash guard checks to MasterPlotTool, DramaticSituationsTool, and StockScenesTool
- Uses the same `StoryNodeItem.RootNodeType()` pattern already in `AddStoryElement()`
- Cross-platform bug — affects both Windows and macOS
- Fixes #1325

## Root Cause
When right-clicking a trash node, `AppState.RightTappedNode` is set to that node. The three tool methods used it as the parent for new elements without checking if it was in the trash.

## Changes
- `OutlineViewModel.cs`: Added trash guard before element creation in all three tool methods
- `OutlineViewModelTests.cs`: Added 3 TDD tests (red-green verified for each)

## Test Plan
- [x] `MasterPlotTool_WhenTargetIsTrash_DoesNotCreateElements` — passed
- [x] `DramaticSituationsTool_WhenTargetIsTrash_DoesNotCreateElements` — passed
- [x] `StockScenesTool_WhenTargetIsTrash_DoesNotCreateElements` — passed
- [x] Full regression suite: 831 tests, 0 failures
- [ ] Manual verification on Windows
- [x] Manual verification on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)