### PR TITLE
enable network permission and fix build step

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -258,13 +258,6 @@ jobs:
           Remove-Item "${{ github.workspace }}\StoryCAD\GitHubActionsWorkflow.pfx" -Force -ErrorAction SilentlyContinue
           Remove-Item "${{ github.workspace }}\StoryCAD\.env","${{ github.workspace }}\StoryCADTests\.env" -Force -ErrorAction SilentlyContinue
 
-      - name: Remove .env (macOS)
-        if: matrix.os == 'macos-latest'
-        continue-on-error: true
-        run: |
-          rm -f "${{ github.workspace }}/StoryCAD/.env"
-          rm -f "${{ github.workspace }}/StoryCADTests/.env"
-
       - name: Publish macOS package
         if: matrix.os == 'macos-latest'
         run: |
@@ -305,6 +298,13 @@ jobs:
 
           # Delete build .app to prevent installer relocation bug
           rm -rf "$APP_DIR"
+
+      - name: Remove .env (macOS)
+        if: matrix.os == 'macos-latest'
+        continue-on-error: true
+        run: |
+          rm -f "${{ github.workspace }}/StoryCAD/.env"
+          rm -f "${{ github.workspace }}/StoryCADTests/.env"
 
       - name: Zip MSIX artifacts (Windows)
         if: matrix.os == 'windows-latest'

--- a/StoryCAD/Platforms/Desktop/Entitlements.plist
+++ b/StoryCAD/Platforms/Desktop/Entitlements.plist
@@ -6,6 +6,8 @@
     <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
     <key>com.apple.application-identifier</key>
     <string>3T4DPS2D5Y.com.storybuilder.storycad</string>
 </dict>


### PR DESCRIPTION
This PR fixes two issues found in StoryCAD 4.0 RC1:
- ENV File mssing, .ENV was being removed too early in the build pipeline on MacOS
- Changelog not loading, resolved by enabling the Network permission