### PR TITLE
docs(#1345): Enable XML doc generation and fix malformed comments

### DIFF
--- a/StoryCADLib/Collaborator/Views/ElementPicker.xaml.cs
+++ b/StoryCADLib/Collaborator/Views/ElementPicker.xaml.cs
@@ -87,9 +87,4 @@ public sealed partial class ElementPicker : Page
             }
         }
     }
-
-    /// <summary>
-    /// Custom XAML initialization for dynamically loaded plugin DLL.
-    /// See WorkflowShell.xaml.cs for detailed explanation of this pattern.
-    /// </summary>
 }

--- a/StoryCADLib/Services/API/StoryCADAPI.cs
+++ b/StoryCADLib/Services/API/StoryCADAPI.cs
@@ -13,32 +13,32 @@ using StoryCADLib.ViewModels.Tools;
 
 namespace StoryCADLib.Services.API;
 
+/// <summary>
 ///     This class is designed for integration with Semantic Kernel, if you are writing
 ///     something that's not AI, you probably want to use OutlineService directly.
-/// 
+///
 ///     For detailed documentation on using the StoryCAD API, please refer to:
 ///     https://manual.storybuilder.org/docs/For%20Developers/Using_the_API.html
-/// 
+///
 ///     Usage:
 ///     - State Handling: The API operates on a CurrentModel property which holds the active StoryModel instance.
 ///     This model must be set before most operations can be performed, either via SetCurrentModel() or by
 ///     creating a new outline with CreateEmptyOutline().
-///     - Calling Standard: All public API methods return OperationResult<T> to ensure safe external consumption.
+///     - Calling Standard: All public API methods return OperationResult&lt;T&gt; to ensure safe external consumption.
 ///         No exceptions are thrown to external callers; all errors are communicated through the OperationResult
 ///         pattern with IsSuccess flags and descriptive ErrorMessage strings.
+/// </summary>
 public class StoryCADApi(OutlineService outlineService, ListData listData, ControlData controlData, ToolsData toolsData) : IStoryCADAPI
 {
     public StoryModel CurrentModel { get; set; }
 
     /// <summary>
     ///     Creates a new empty story outline based on a template.
-    ///     Parameters:
-    ///     filePath - full path to the file that will back the outline
-    ///     name - the name to use for the outline's Overview element
-    ///     author - the author name for the overview
-    ///     templateIndex - index (as a string) specifying the template to use
-    ///     Returns a JSON-serialized OperationResult payload containing a list of the StoryElement Guids.
     /// </summary>
+    /// <param name="name">The name to use for the outline's Overview element.</param>
+    /// <param name="author">The author name for the overview.</param>
+    /// <param name="templateIndex">Index (as a string) specifying the template to use.</param>
+    /// <returns>An OperationResult containing a list of the StoryElement Guids.</returns>
     [KernelFunction]
     [Description("Creates a new empty story outline from a template.")]
     public async Task<OperationResult<List<Guid>>> CreateEmptyOutline(string name, string author, string templateIndex)
@@ -379,9 +379,6 @@ public class StoryCADApi(OutlineService outlineService, ListData listData, Contr
         or if any error occurs (such as a type conversion issue), the operation will fails.
         You should use AddCastMember and AddRelationship for updating those fields when updating those fields.
         """)]
-    /// <summary>
-    /// Implementation of IStoryCADAPI.UpdateElementProperty with compatible return type
-    /// </summary>
     OperationResult<object> IStoryCADAPI.UpdateElementProperty(Guid elementUuid, string propertyName, object value)
     {
         var result = UpdateElementProperty(elementUuid, propertyName, value);

--- a/StoryCADLib/Services/Navigation/INavigationService.cs
+++ b/StoryCADLib/Services/Navigation/INavigationService.cs
@@ -80,9 +80,9 @@ public interface INavigationService
     ///     a specified frame.
     ///     Depending on the platforms, the navigation service might
     ///     have to be configured with a key/page list.
-    ///     <param name="frame"> The frame or subframe on which to display the page </param>
-    ///     <param name="pageKey">The key corresponding to the page that should be displayed.</param>
     /// </summary>
+    /// <param name="frame">The frame or subframe on which to display the page.</param>
+    /// <param name="pageKey">The key corresponding to the page that should be displayed.</param>
     void NavigateTo(Frame frame, string pageKey);
 
     /// <summary>
@@ -92,7 +92,7 @@ public interface INavigationService
     ///     Depending on the platforms, the navigation service might
     ///     have to be Configure with a key/page list.
     /// </summary>
-    /// <param name="frame"> The frame or subframe on which to display the page </Param>
+    /// <param name="frame"> The frame or subframe on which to display the page </param>
     /// <param name="pageKey">
     ///     The key corresponding to the page
     ///     that should be displayed.

--- a/StoryCADLib/Services/Outline/OutlineService.cs
+++ b/StoryCADLib/Services/Outline/OutlineService.cs
@@ -484,9 +484,10 @@ public class OutlineService
     /// <summary>
     ///     Adds a new cast member to a scene.
     /// </summary>
-    /// <param name="source">Scene element you are adding the cast member to </param>
+    /// <param name="Model">The story model containing the elements.</param>
+    /// <param name="source">Scene element you are adding the cast member to.</param>
     /// <param name="castMember">Cast member you want to add.</param>
-    /// <returns></returns>
+    /// <returns>True if the cast member was added successfully.</returns>
     internal bool AddCastMember(StoryModel Model, StoryElement source, Guid castMember)
     {
         if (source == null)
@@ -744,10 +745,10 @@ public class OutlineService
     /// <summary>
     ///     Add beat to a ProblemModel.
     /// </summary>
-    /// <param name="Parent"></param>
-    /// <param name="Title"></param>
-    /// <param name="Description"></param>
-    /// <exception cref="ArgumentNullException"></exception>
+    /// <param name="Parent">The problem model to add the beat to.</param>
+    /// <param name="Title">The title of the beat.</param>
+    /// <param name="Description">The description of the beat.</param>
+    /// <exception cref="ArgumentNullException">Thrown when Parent is null.</exception>
     internal void CreateBeat(ProblemModel Parent, string Title, string Description)
     {
         if (Parent == null)
@@ -760,10 +761,11 @@ public class OutlineService
     }
 
     /// <summary>
-    ///     Deletes a beat and unbinds elements if nesscessary.
+    ///     Deletes a beat and unbinds elements if necessary.
     /// </summary>
-    /// <param name="Model"></param>
-    /// <param name="Index"></param>
+    /// <param name="Model">The story model containing the elements.</param>
+    /// <param name="Parent">The problem model containing the beat.</param>
+    /// <param name="Index">The index of the beat to delete.</param>
     internal void DeleteBeat(StoryModel Model, ProblemModel Parent, int Index)
     {
         if (Model == null)
@@ -811,16 +813,17 @@ public class OutlineService
     }
 
     /// <summary>
-    ///     Sets basic infomation about the beat sheet/creates a new one
+    ///     Sets basic information about the beat sheet/creates a new one.
     ///     If one exists, it will be overwritten and any beats in it will be unbound.
     /// </summary>
-    /// <param name="Description">Description of you beatsheet, i.e. what is its structure?</param>
-    /// <param name="Model">Problem element you are trying to add the beatsheet to</param>
+    /// <param name="Model">The story model containing the elements.</param>
+    /// <param name="Parent">Problem element you are trying to add the beat sheet to.</param>
+    /// <param name="Description">Description of your beat sheet, i.e. what is its structure?</param>
     /// <param name="Title">
-    ///     This is the title of your beat sheet,
-    ///     if it is not Custom Beat Sheet it will not be editable within the StoryCAD app.
+    ///     This is the title of your beat sheet.
+    ///     If it is not "Custom Beat Sheet" it will not be editable within the StoryCAD app.
     /// </param>
-    /// <param name="Beats">Beats that this sheet will contain, can be added later</param>
+    /// <param name="Beats">Beats that this sheet will contain, can be added later.</param>
     public void SetBeatSheet(StoryModel Model, ProblemModel Parent, string Description,
         string Title = "Custom Beat Sheet", ObservableCollection<StructureBeatViewModel> Beats = null)
     {

--- a/StoryCADLib/StoryCADLib.csproj
+++ b/StoryCADLib/StoryCADLib.csproj
@@ -22,6 +22,10 @@
     -->
         <WarningsAsErrors>UNO0001</WarningsAsErrors>
 
+        <!-- Generate XML documentation for API reference -->
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
+
     </PropertyGroup>
 
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -472,7 +472,7 @@ public class ShellViewModel : ObservableRecipient
 
     /// <summary>
     ///     Controls visibility for elements that should only be shown in the Trash view.
-    /// </summary
+    /// </summary>
     public Visibility TrashButtonVisibility
     {
         get => _trashButtonVisibility;


### PR DESCRIPTION
## Summary

- Enable `GenerateDocumentationFile` in StoryCADLib.csproj with CS1591 suppression
- Fix malformed XML doc comments across 5 files (missing tags, wrong casing, nested params, phantom parameter references, typos)
- Supports [StoryCADAPI #1246](https://github.com/storybuilder-org/StoryCADAPI/issues/1246) (API documentation guidance)

Closes #1345

## Test plan

- [x] Build passes (0 errors)
- [x] All 835 tests pass (821 passed, 14 pre-existing skips)
- [x] Code review confirmed all XML doc comments well-formed

🤖 Generated with [Claude Code](https://claude.com/claude-code)