### PR TITLE
Fix Browse button

### DIFF
--- a/StoryCAD/Platforms/Desktop/Entitlements.plist
+++ b/StoryCAD/Platforms/Desktop/Entitlements.plist
@@ -8,6 +8,8 @@
     <true/>
     <key>com.apple.security.network.client</key>
     <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
     <key>com.apple.application-identifier</key>
     <string>3T4DPS2D5Y.com.storybuilder.storycad</string>
 </dict>


### PR DESCRIPTION
This PR fixes an issue where the browse button does nothing on macos under the sandbox.

This was a plist perms releated issue.

Fixes #1351 and #1348