### PR TITLE
Fix display version: 4.0.0 → 4.0.2

### DIFF
--- a/StoryCAD/Platforms/Desktop/Info.plist
+++ b/StoryCAD/Platforms/Desktop/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0</string>
+	<string>4.0.2</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>MacOSX</string>

--- a/StoryCAD/StoryCAD.csproj
+++ b/StoryCAD/StoryCAD.csproj
@@ -8,7 +8,7 @@
         <!-- App Identifier -->
         <ApplicationId>com.storybuilder.storycad</ApplicationId>
         <!-- Versions -->
-        <ApplicationDisplayVersion>4.0.0</ApplicationDisplayVersion>
+        <ApplicationDisplayVersion>4.0.2</ApplicationDisplayVersion>
         <ApplicationVersion>2</ApplicationVersion>
         <!-- Package Description -->
         <Description>StoryCAD powered by Uno Platform.</Description>


### PR DESCRIPTION
## Summary
- `ApplicationDisplayVersion` in `StoryCAD.csproj` bumped from `4.0.0` to `4.0.2`
- `CFBundleShortVersionString` in `Info.plist` bumped from `4.0.0` to `4.0.2`
- These are the only two user-facing version strings not stamped by the autobuilder

Closes #1375

## Test plan
- [ ] Merge to main
- [ ] Delete existing `4.0.2.0` release and tag
- [ ] Re-run autobuilder with `v4.0.2.0`, `skip_release=false`
- [ ] Verify macOS PKG shows `4.0.2` in `CFBundleShortVersionString`
- [ ] Jake uploads new PKG via Transporter
- [ ] Merge fix to `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)