### PR TITLE
Support MacOS STBX File Assoc and clean up MacOS Interop code

### DIFF
--- a/StoryCAD/App.xaml.cs
+++ b/StoryCAD/App.xaml.cs
@@ -9,6 +9,7 @@ using StoryCADLib.Services.IoC;
 using StoryCADLib.Services.Json;
 using StoryCADLib.Services.Locking;
 using StoryCADLib.Services.Logging;
+using StoryCADLib.Services.MacFileAssociation;
 using StoryCADLib.Services.Navigation;
 using StoryCAD.Views;
 using Uno.Extensions;
@@ -40,7 +41,7 @@ public partial class App : Application
     {
         //Set up IOC and the services.
         BootStrapper.Initialise(false);
-        
+
         #if WINDOWS10_0_18362_0_OR_GREATER
         //Check how app was invoked and handle file activation if necessary.
         var activationArgs = Microsoft.Windows.AppLifecycle.AppInstance.GetCurrent().GetActivatedEventArgs();
@@ -236,6 +237,16 @@ public partial class App : Application
                 if (launchPath != string.Empty)
                 {
                     Ioc.Default.GetRequiredService<ShellViewModel>().FilePathToLaunch = launchPath;
+                }
+                else if (OperatingSystem.IsMacOS())
+                {
+                    // On macOS, a kAEOpenDocuments event may have fired during
+                    // NSApplication.finishLaunching (before IoC was ready). Drain it now.
+                    var pending = MacFileOpenService.ConsumePendingPath();
+                    if (!string.IsNullOrEmpty(pending))
+                    {
+                        Ioc.Default.GetRequiredService<ShellViewModel>().FilePathToLaunch = pending;
+                    }
                 }
                 rootFrame.Navigate(typeof(Shell));
             }

--- a/StoryCAD/Platforms/Desktop/Info.plist
+++ b/StoryCAD/Platforms/Desktop/Info.plist
@@ -38,5 +38,45 @@
 	<string>Copyright © StoryBuilder Foundation</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>StoryCAD Outline</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>stbx</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.storybuilder.storycad.outline</string>
+			</array>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.storybuilder.storycad.outline</string>
+			<key>UTTypeDescription</key>
+			<string>StoryCAD Outline</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>stbx</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/StoryCAD/Platforms/Desktop/Program.cs
+++ b/StoryCAD/Platforms/Desktop/Program.cs
@@ -1,3 +1,4 @@
+using StoryCADLib.Services.MacFileAssociation;
 using Uno.UI.Hosting;
 namespace StoryCAD;
 
@@ -6,6 +7,14 @@ public class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        // Install the kAEOpenDocuments handler before UNO creates NSApplication, so the
+        // initial 'odoc' Apple Event on launch (Finder double-click, `open foo.stbx`) is
+        // caught by us rather than NSApp's default NSDocument dispatch path (issue #963).
+        if (OperatingSystem.IsMacOS())
+        {
+            MacFileOpenService.Initialize();
+        }
+
         var host = UnoPlatformHostBuilder.Create()
             .App(() => new App())
             .UseX11()

--- a/StoryCADLib/Services/MacFileAssociation/MacFileOpenService.cs
+++ b/StoryCADLib/Services/MacFileAssociation/MacFileOpenService.cs
@@ -1,0 +1,263 @@
+using System.Runtime.InteropServices;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using StoryCADLib.Models;
+using StoryCADLib.Services.Logging;
+using StoryCADLib.Services.MacInterop;
+using StoryCADLib.ViewModels;
+
+namespace StoryCADLib.Services.MacFileAssociation;
+
+/// <summary>
+/// Receives macOS "Open Documents" Apple Events so that .stbx files double-clicked in
+/// Finder, dropped on the Dock icon, or opened via <c>open foo.stbx</c> are routed into
+/// StoryCAD. Installs a handler on NSAppleEventManager for kCoreEventClass/kAEOpenDocuments
+/// (<c>'aevt'/'odoc'</c>).
+///
+/// Timing detail: NSApplication.finishLaunching installs its OWN kAEOpenDocuments handler
+/// and then processes queued Apple Events — which means any handler we register in
+/// Program.Main is overwritten before the launch event dispatches. To win the race we
+/// also observe <c>NSApplicationWillFinishLaunchingNotification</c>, which fires inside
+/// finishLaunching AFTER NSApp installs its default handler but BEFORE the queued event
+/// processing; our observer re-installs our handler at that exact moment.
+/// </summary>
+public static class MacFileOpenService
+{
+    // Keeps callback delegates alive for the lifetime of the process. class_addMethod and
+    // notification observers store only function pointers — a collected delegate would
+    // produce a jump into freed memory when Cocoa next calls through.
+    private static readonly List<Delegate> PinnedDelegates = new();
+
+    private static IntPtr _handlerClass;
+    private static IntPtr _handlerInstance;
+    private static bool _initialized;
+
+    // Event may fire during NSApplication.finishLaunching — before App() ctor runs and
+    // BootStrapper.Initialise has configured IoC. We can't resolve ShellViewModel yet,
+    // so stash the path here and let startup drain it once IoC is up.
+    private static readonly object PendingLock = new();
+    private static string _pendingPath;
+
+    /// <summary>
+    /// Returns and clears the file path (if any) received from a file-open Apple Event
+    /// that arrived before the app was ready to route it. Called by startup code once
+    /// IoC and ShellViewModel are available.
+    /// </summary>
+    public static string ConsumePendingPath()
+    {
+        lock (PendingLock)
+        {
+            var p = _pendingPath;
+            _pendingPath = null;
+            return p;
+        }
+    }
+
+    // kCoreEventClass = 'aevt', kAEOpenDocuments = 'odoc', keyDirectObject = '----'
+    private static readonly uint KCoreEventClass = ObjCRuntime.FourCharCode("aevt");
+    private static readonly uint KAEOpenDocuments = ObjCRuntime.FourCharCode("odoc");
+    private static readonly uint KeyDirectObject = ObjCRuntime.FourCharCode("----");
+
+    // -(void)handleOpenDocumentsEvent:(NSAppleEventDescriptor*)ev withReplyEvent:(NSAppleEventDescriptor*)reply
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void AppleEventDelegate(IntPtr self, IntPtr selector, IntPtr eventDesc, IntPtr replyDesc);
+
+    // -(void)applicationWillFinishLaunching:(NSNotification*)n
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void NotificationDelegate(IntPtr self, IntPtr selector, IntPtr notification);
+
+    /// <summary>
+    /// Installs the Apple Event handler. Idempotent and a no-op on non-macOS platforms.
+    /// Safe to call from Program.Main before IoC is configured — does not touch IoC.
+    /// </summary>
+    public static void Initialize()
+    {
+        if (!OperatingSystem.IsMacOS() || _initialized) return;
+
+        try
+        {
+            ObjCRuntime.LoadCocoa();
+            RegisterHandlerClass();
+            InstallAppleEventHandler();       // may be overwritten by NSApp.finishLaunching
+            InstallWillFinishLaunchingObserver(); // re-installs us after NSApp's overwrite
+            _initialized = true;
+        }
+        catch (Exception ex)
+        {
+            // IoC may not exist yet — emit to stderr so the error isn't swallowed.
+            Console.Error.WriteLine($"MacFileOpenService.Initialize failed: {ex}");
+        }
+    }
+
+    private static void RegisterHandlerClass()
+    {
+        IntPtr nsObject = ObjCRuntime.objc_getClass("NSObject");
+        _handlerClass = ObjCRuntime.objc_allocateClassPair(nsObject, "StoryCADAppleEventHandler", 0);
+        if (_handlerClass == IntPtr.Zero)
+        {
+            // Class already registered in this process (hot reload) — fetch the existing one.
+            _handlerClass = ObjCRuntime.objc_getClass("StoryCADAppleEventHandler");
+            if (_handlerClass == IntPtr.Zero)
+                throw new InvalidOperationException("Could not create or find StoryCADAppleEventHandler class.");
+        }
+        else
+        {
+            AppleEventDelegate aeThunk = HandleOpenDocuments;
+            PinnedDelegates.Add(aeThunk);
+            IntPtr aeSel = ObjCRuntime.sel_registerName("handleOpenDocumentsEvent:withReplyEvent:");
+            // "v@:@@" — void; self (@); _cmd (:); event desc (@); reply desc (@)
+            if (!ObjCRuntime.class_addMethod(_handlerClass, aeSel,
+                    Marshal.GetFunctionPointerForDelegate(aeThunk), "v@:@@"))
+                throw new InvalidOperationException("class_addMethod failed for handleOpenDocumentsEvent:withReplyEvent:");
+
+            NotificationDelegate nThunk = OnApplicationWillFinishLaunching;
+            PinnedDelegates.Add(nThunk);
+            IntPtr nSel = ObjCRuntime.sel_registerName("applicationWillFinishLaunching:");
+            // "v@:@" — void; self; _cmd; notification
+            if (!ObjCRuntime.class_addMethod(_handlerClass, nSel,
+                    Marshal.GetFunctionPointerForDelegate(nThunk), "v@:@"))
+                throw new InvalidOperationException("class_addMethod failed for applicationWillFinishLaunching:");
+
+            ObjCRuntime.objc_registerClassPair(_handlerClass);
+        }
+
+        IntPtr alloc = ObjCRuntime.objc_msgSend(_handlerClass, ObjCRuntime.sel_registerName("alloc"));
+        _handlerInstance = ObjCRuntime.objc_msgSend(alloc, ObjCRuntime.sel_registerName("init"));
+    }
+
+    private static void InstallAppleEventHandler()
+    {
+        IntPtr aemClass = ObjCRuntime.objc_getClass("NSAppleEventManager");
+        IntPtr aem = ObjCRuntime.objc_msgSend(aemClass, ObjCRuntime.sel_registerName("sharedAppleEventManager"));
+
+        IntPtr setEventHandler = ObjCRuntime.sel_registerName(
+            "setEventHandler:andSelector:forEventClass:andEventID:");
+        IntPtr handleSel = ObjCRuntime.sel_registerName("handleOpenDocumentsEvent:withReplyEvent:");
+
+        ObjCRuntime.objc_msgSend_setEventHandler(
+            aem, setEventHandler,
+            _handlerInstance, handleSel,
+            KCoreEventClass, KAEOpenDocuments);
+    }
+
+    private static void InstallWillFinishLaunchingObserver()
+    {
+        // [NSNotificationCenter defaultCenter] addObserver:_handlerInstance
+        //     selector:@selector(applicationWillFinishLaunching:)
+        //     name:@"NSApplicationWillFinishLaunchingNotification" object:nil
+        IntPtr ncClass = ObjCRuntime.objc_getClass("NSNotificationCenter");
+        IntPtr center = ObjCRuntime.objc_msgSend(ncClass, ObjCRuntime.sel_registerName("defaultCenter"));
+
+        IntPtr addObserver = ObjCRuntime.sel_registerName("addObserver:selector:name:object:");
+        IntPtr sel = ObjCRuntime.sel_registerName("applicationWillFinishLaunching:");
+        IntPtr name = ObjCRuntime.CreateNSString("NSApplicationWillFinishLaunchingNotification");
+
+        // addObserver:selector:name:object: — 4 object/pointer args, void return.
+        ObjCRuntime.objc_msgSend(center, addObserver, _handlerInstance, sel, name, IntPtr.Zero);
+    }
+
+    // Fires inside NSApplication.finishLaunching after NSApp has installed its default
+    // Apple Event handlers but before the queued 'odoc' event is processed. This is our
+    // window to re-install our handler and win the race.
+    private static void OnApplicationWillFinishLaunching(IntPtr self, IntPtr selector, IntPtr notification)
+    {
+        try
+        {
+            InstallAppleEventHandler();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Reinstalling AE handler failed: {ex}");
+        }
+    }
+
+    // Runs on the main thread when NSApplication dispatches the Apple Event. Exceptions must
+    // not escape this method — they would unwind into Cocoa's dispatch loop and kill the app.
+    // This may fire during NSApplication.finishLaunching, i.e. before App() ctor and IoC,
+    // so DO NOT touch IoC directly from here; stash the path and let startup drain it.
+    private static void HandleOpenDocuments(IntPtr self, IntPtr selector, IntPtr eventDesc, IntPtr replyDesc)
+    {
+        try
+        {
+            var paths = ExtractPaths(eventDesc);
+            if (paths.Count == 0) return;
+
+            string path = paths[0];
+
+            // Try the fast path (running app): if IoC is already configured and Shell is loaded,
+            // route directly. Otherwise stash for startup drain.
+            if (!TryRouteImmediately(path))
+            {
+                lock (PendingLock) _pendingPath = path;
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"HandleOpenDocuments failed: {ex}");
+        }
+    }
+
+    private static bool TryRouteImmediately(string path)
+    {
+        try
+        {
+            var shellVm = Ioc.Default.GetService<ShellViewModel>();
+            if (shellVm == null) return false; // IoC not ready — caller will stash
+
+            var windowing = Ioc.Default.GetService<Windowing>();
+            if (windowing?.GlobalDispatcher != null)
+            {
+                // Shell is loaded — open on the UI thread now.
+                windowing.GlobalDispatcher.TryEnqueue(async () =>
+                {
+                    try { await shellVm.OutlineManager.OpenFile(path); }
+                    catch (Exception ex)
+                    {
+                        Ioc.Default.GetService<ILogService>()
+                            ?.LogException(LogLevel.Error, ex, $"OpenFile failed for {path}");
+                    }
+                });
+            }
+            else
+            {
+                // IoC is up but Shell hasn't loaded yet — let Shell_Loaded pick it up.
+                shellVm.FilePathToLaunch = path;
+            }
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static List<string> ExtractPaths(IntPtr eventDesc)
+    {
+        var result = new List<string>();
+        if (eventDesc == IntPtr.Zero) return result;
+
+        IntPtr paramForKeyword = ObjCRuntime.sel_registerName("paramDescriptorForKeyword:");
+        IntPtr list = ObjCRuntime.objc_msgSend_fourcc(eventDesc, paramForKeyword, KeyDirectObject);
+        if (list == IntPtr.Zero) return result;
+
+        int count = ObjCRuntime.objc_msgSend_int(list, ObjCRuntime.sel_registerName("numberOfItems"));
+        if (count <= 0) return result;
+
+        IntPtr descriptorAtIndex = ObjCRuntime.sel_registerName("descriptorAtIndex:");
+        IntPtr fileURLValue = ObjCRuntime.sel_registerName("fileURLValue");
+
+        // AEDesc lists are 1-indexed.
+        for (long i = 1; i <= count; i++)
+        {
+            IntPtr item = ObjCRuntime.objc_msgSend_index(list, descriptorAtIndex, i);
+            if (item == IntPtr.Zero) continue;
+
+            IntPtr url = ObjCRuntime.objc_msgSend(item, fileURLValue);
+            string path = ObjCRuntime.NSUrlToPath(url);
+            if (!string.IsNullOrEmpty(path))
+                result.Add(path);
+        }
+
+        return result;
+    }
+
+}

--- a/StoryCADLib/Services/MacInterop/ObjCRuntime.cs
+++ b/StoryCADLib/Services/MacInterop/ObjCRuntime.cs
@@ -1,11 +1,11 @@
 using System.Runtime.InteropServices;
 
-namespace StoryCADLib.Services.MacMenuBar;
+namespace StoryCADLib.Services.MacInterop;
 
 /// <summary>
 /// Low-level P/Invoke declarations for the Objective-C runtime on macOS.
-/// Used to create native NSMenu/NSMenuItem objects for the macOS menu bar.
-/// All public entry points are guarded by OperatingSystem.IsMacOS().
+/// Shared primitive consumed by the macOS menu bar, print dialog, and file-association
+/// services. All public entry points are guarded by OperatingSystem.IsMacOS().
 /// </summary>
 internal static class ObjCRuntime
 {
@@ -43,6 +43,10 @@ internal static class ObjCRuntime
     [DllImport(ObjCLib, EntryPoint = "objc_msgSend")]
     internal static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2, IntPtr arg3);
 
+    // For addObserver:selector:name:object: — 4 pointer-sized args.
+    [DllImport(ObjCLib, EntryPoint = "objc_msgSend")]
+    internal static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2, IntPtr arg3, IntPtr arg4);
+
     [DllImport(ObjCLib, EntryPoint = "objc_msgSend")]
     internal static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector, bool arg1);
 
@@ -64,11 +68,50 @@ internal static class ObjCRuntime
     [DllImport(ObjCLib, EntryPoint = "objc_msgSend")]
     internal static extern byte objc_msgSend_bool(IntPtr receiver, IntPtr selector);
 
+    // For methods returning int (e.g. -[NSAppleEventDescriptor numberOfItems])
+    [DllImport(ObjCLib, EntryPoint = "objc_msgSend")]
+    internal static extern int objc_msgSend_int(IntPtr receiver, IntPtr selector);
+
+    // For -[NSAppleEventDescriptor descriptorAtIndex:] (1-based)
+    [DllImport(ObjCLib, EntryPoint = "objc_msgSend")]
+    internal static extern IntPtr objc_msgSend_index(IntPtr receiver, IntPtr selector, long index);
+
+    // For -[NSAppleEventDescriptor paramDescriptorForKeyword:] where keyword is a FourCharCode (uint)
+    [DllImport(ObjCLib, EntryPoint = "objc_msgSend")]
+    internal static extern IntPtr objc_msgSend_fourcc(IntPtr receiver, IntPtr selector, uint keyword);
+
+    // For -[NSAppleEventManager setEventHandler:andSelector:forEventClass:andEventID:]
+    [DllImport(ObjCLib, EntryPoint = "objc_msgSend")]
+    internal static extern void objc_msgSend_setEventHandler(
+        IntPtr receiver, IntPtr selector,
+        IntPtr handler, IntPtr selArg,
+        uint eventClass, uint eventId);
+
     // For loading frameworks (e.g. Quartz.framework for PDFKit)
     [DllImport("libdl.dylib")]
     internal static extern IntPtr dlopen(string path, int mode);
 
     internal const int RTLD_LAZY = 1;
+
+    // FourCharCode helpers (Apple Event manager uses packed big-endian ASCII).
+    internal static uint FourCharCode(string code)
+    {
+        if (code == null || code.Length != 4)
+            throw new ArgumentException("FourCharCode must be exactly 4 ASCII characters.", nameof(code));
+        return ((uint)code[0] << 24) | ((uint)code[1] << 16) | ((uint)code[2] << 8) | (uint)code[3];
+    }
+
+    /// <summary>
+    /// Loads Cocoa.framework (AppKit + Foundation) if not already loaded.
+    /// NSApplication typically loads it at launch, but this is a safe explicit hook
+    /// for code paths that depend on AppKit/Foundation symbols being resolved.
+    /// </summary>
+    private static IntPtr _cocoaHandle;
+    internal static void LoadCocoa()
+    {
+        if (_cocoaHandle != IntPtr.Zero) return;
+        _cocoaHandle = dlopen("/System/Library/Frameworks/Cocoa.framework/Cocoa", RTLD_LAZY);
+    }
 
     // --- Delegate type for ObjC action methods (target-action pattern) ---
 
@@ -215,6 +258,27 @@ internal static class ObjCRuntime
         if (nsString == IntPtr.Zero) return string.Empty;
         IntPtr utf8Ptr = objc_msgSend(nsString, sel_registerName("UTF8String"));
         return utf8Ptr == IntPtr.Zero ? string.Empty : Marshal.PtrToStringUTF8(utf8Ptr) ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Converts an NSString pointer to a managed string via its UTF8 representation.
+    /// </summary>
+    internal static string NSStringToUtf8(IntPtr nsString)
+    {
+        if (nsString == IntPtr.Zero) return string.Empty;
+        IntPtr utf8Ptr = objc_msgSend(nsString, sel_registerName("UTF8String"));
+        return utf8Ptr == IntPtr.Zero ? string.Empty : Marshal.PtrToStringUTF8(utf8Ptr) ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Given an NSURL pointer (file URL), returns its file-system path as a managed string.
+    /// Returns empty string if the URL is null or not a file URL.
+    /// </summary>
+    internal static string NSUrlToPath(IntPtr nsUrl)
+    {
+        if (nsUrl == IntPtr.Zero) return string.Empty;
+        IntPtr pathStr = objc_msgSend(nsUrl, sel_registerName("path"));
+        return NSStringToUtf8(pathStr);
     }
 
     /// <summary>

--- a/StoryCADLib/Services/MacMenuBar/MacMenuActionHandler.cs
+++ b/StoryCADLib/Services/MacMenuBar/MacMenuActionHandler.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using StoryCADLib.Services.Logging;
+using StoryCADLib.Services.MacInterop;
 
 namespace StoryCADLib.Services.MacMenuBar;
 

--- a/StoryCADLib/Services/MacMenuBar/MacMenuBarService.cs
+++ b/StoryCADLib/Services/MacMenuBar/MacMenuBarService.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using StoryCADLib.Services.Logging;
 using StoryCADLib.ViewModels;
-using static StoryCADLib.Services.MacMenuBar.ObjCRuntime;
+using static StoryCADLib.Services.MacInterop.ObjCRuntime;
 
 namespace StoryCADLib.Services.MacMenuBar;
 

--- a/StoryCADLib/ViewModels/Tools/PrintReportDialogVM.desktop.cs
+++ b/StoryCADLib/ViewModels/Tools/PrintReportDialogVM.desktop.cs
@@ -1,7 +1,7 @@
 using System.Runtime.InteropServices;
 using CommunityToolkit.Mvvm.Messaging;
 using StoryCADLib.Services.Messages;
-using static StoryCADLib.Services.MacMenuBar.ObjCRuntime;
+using static StoryCADLib.Services.MacInterop.ObjCRuntime;
 
 namespace StoryCADLib.ViewModels.Tools;
 


### PR DESCRIPTION
This PR fixes a macos limitation where the STBX File Association wasn't supported, now double clicking STBX files in macos finder now opens StoryCAD.

Fixes #963