### PR TITLE
Issue #1385: Fix inverted retry condition in BackendService.StartupRecording

### DIFF
--- a/StoryCADLib/Services/Backend/BackendService.cs
+++ b/StoryCADLib/Services/Backend/BackendService.cs
@@ -72,7 +72,7 @@ public class BackendService
         {
             // If the previous attempt to communicate to the back-end server
             // or database failed, retry
-            if (_preferenceService.Model.RecordPreferencesStatus)
+            if (!_preferenceService.Model.RecordPreferencesStatus)
             {
                 await PostPreferences(_preferenceService.Model);
             }

--- a/StoryCADTests/Services/Backend/BackendServiceTests.cs
+++ b/StoryCADTests/Services/Backend/BackendServiceTests.cs
@@ -351,6 +351,81 @@ public class BackendTests
 
     #endregion
 
+    #region StartupRecording Retry Condition Tests
+
+    /// <summary>
+    ///     Verifies that StartupRecording does NOT re-post preferences when
+    ///     RecordPreferencesStatus is already true (last post succeeded).
+    ///
+    ///     Before the fix in issue #1385, the retry guard at BackendService.cs:75
+    ///     was missing a `!`, causing every launch after a successful post to
+    ///     re-invoke the DAL (spAddUser + spAddOrUpdatePreferences). This test
+    ///     pins the correct semantics: true = already posted, skip.
+    /// </summary>
+    [TestMethod]
+    public async Task StartupRecording_WhenPreferencesAlreadyPosted_DoesNotRepost()
+    {
+        // Arrange
+        var testLogger = new TestLogService();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var preferenceService = Ioc.Default.GetRequiredService<PreferenceService>();
+        var testSqlIo = new TestMySqlIo();
+        testSqlIo.SetConnectionString("fake");
+        var backendService = new BackendService(testLogger, appState, preferenceService, testSqlIo);
+
+        preferenceService.Model.RecordPreferencesStatus = true;   // last post succeeded
+        preferenceService.Model.PreferencesInitialized = false;   // disarms the version block
+
+        // Act
+        await backendService.StartupRecording();
+
+        // Assert — no DAL calls for the preferences path
+        Assert.AreEqual(0, testSqlIo.AddOrUpdateUserCalls.Count,
+            "Should not call spAddUser when preferences were already posted successfully");
+        Assert.AreEqual(0, testSqlIo.AddOrUpdatePreferencesCalls.Count,
+            "Should not call spAddOrUpdatePreferences when flag indicates success");
+    }
+
+    /// <summary>
+    ///     Verifies that StartupRecording DOES retry the preferences post when
+    ///     RecordPreferencesStatus is false (previous attempt failed or never happened).
+    ///
+    ///     This is the retry path the comment above BackendService.cs:75 describes
+    ///     ("if the previous attempt... failed, retry"). Before the issue #1385 fix
+    ///     the guard was inverted and this path never ran.
+    /// </summary>
+    [TestMethod]
+    public async Task StartupRecording_WhenPreferencesNotYetPosted_Reposts()
+    {
+        // Arrange
+        var testLogger = new TestLogService();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var preferenceService = Ioc.Default.GetRequiredService<PreferenceService>();
+        var testSqlIo = new TestMySqlIo();
+        testSqlIo.SetConnectionString("fake");
+        var backendService = new BackendService(testLogger, appState, preferenceService, testSqlIo);
+
+        preferenceService.Model.RecordPreferencesStatus = false;  // last post failed / never happened
+        preferenceService.Model.PreferencesInitialized = false;   // disarms the version block
+        preferenceService.Model.FirstName = "StoryCAD";
+        preferenceService.Model.LastName = "Tests";
+        preferenceService.Model.Email = "sysadmin@storybuilder.org";
+        preferenceService.Model.Version = "test";
+
+        // Act
+        await backendService.StartupRecording();
+
+        // Assert — DAL called once for each stored procedure
+        Assert.AreEqual(1, testSqlIo.AddOrUpdateUserCalls.Count,
+            "Should call spAddUser when the previous preferences post was not successful");
+        Assert.AreEqual(1, testSqlIo.AddOrUpdatePreferencesCalls.Count,
+            "Should call spAddOrUpdatePreferences when the previous preferences post was not successful");
+        Assert.IsTrue(preferenceService.Model.RecordPreferencesStatus,
+            "Flag should flip to true after a successful post");
+    }
+
+    #endregion
+
     #region Helper Methods
 
     /// <summary>
@@ -513,7 +588,7 @@ public class TestableBackendService : BackendService
         try
         {
             await Task.CompletedTask;
-            if (_testPreferenceService.Model.RecordPreferencesStatus)
+            if (!_testPreferenceService.Model.RecordPreferencesStatus)
             {
                 if (_exceptionToThrow != null)
                     throw _exceptionToThrow;

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Uno.Sdk": "6.5.31"
   },
   "sdk": {
-    "version": "10.0.200",
+    "version": "10.0.100",
     "rollForward": "latestPatch",
     "allowPrerelease": false
   },

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Uno.Sdk": "6.5.31"
   },
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.200",
     "rollForward": "latestPatch",
     "allowPrerelease": false
   },


### PR DESCRIPTION
Fixes #1385.

## Summary

- `BackendService.StartupRecording` had a missing `!` on the retry guard, causing every app launch after a successful preferences post to re-invoke the DAL. Also prevented the intended failure-retry path from ever running. Introduced in `fbefa036` during a rename refactor.
- One-line fix: `if (RecordPreferencesStatus)` → `if (!RecordPreferencesStatus)`
- Mirrored bug fixed in `TestableBackendService` so the test double matches production semantics.
- Bumps `global.json` SDK version to `10.0.200` so WSL MSBuild/vstest invocation accepts installed SDK `10.0.202` via `rollForward: latestPatch`. Same change already present on telemetry (`63dc0051`); separated here from the Tmds.DBus pin which is telemetry-scoped.

## Commits

- `d0a5e5b3` — Bump global.json SDK to 10.0.200 for rollForward match
- `621266cd` — Issue #1385: Fix inverted retry condition in StartupRecording

## TDD evidence

**RED** (before fix):
```
Failed StartupRecording_WhenPreferencesAlreadyPosted_DoesNotRepost
  Expected:<0>. Actual:<1>. Should not call spAddUser when preferences were already posted successfully
Failed StartupRecording_WhenPreferencesNotYetPosted_Reposts
  Expected:<1>. Actual:<0>. Should call spAddUser when the previous preferences post was not successful
```

**GREEN** (after fix): both new tests pass; full `BackendTests` class 16/16.

## Scope

- Target: `dev` → ships with **Release 4.1**.
- Cherry-pick to `main` **deferred** per issue plan — CPU spikes are infrequent, no hotfix warranted.
- Telemetry branch inherits the fix on its next sync from dev.

## Test plan

- [x] Two regression tests added (pin the correct `true`=skip / `false`=retry semantics)
- [x] Full `BackendTests` class passes (16/16) after fix
- [x] Build clean on both `net10.0-desktop` and `net10.0-windows10.0.22621` targets
- [x] Reviewer runs `BackendTests` locally and confirms all green