### PR TITLE
Add feature to disable menubar (shell) in macos.

### DIFF
--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -416,7 +416,8 @@
                     </AppBarButton.Icon>
                 </AppBarButton>
                 <AppBarButton Width="50" IsCompact="True" Label="Report Feedback"
-                              ToolTipService.ToolTip="Report Feedback" Click="ButtonBase_OnClick">
+                              ToolTipService.ToolTip="Report Feedback"
+                              Command="{x:Bind ShellVm.ReportFeedbackCommand, Mode=OneWay}">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xED15;" />
                     </AppBarButton.Icon>

--- a/StoryCAD/Views/Shell.xaml.cs
+++ b/StoryCAD/Views/Shell.xaml.cs
@@ -126,6 +126,13 @@ public sealed partial class Shell : Page
         // Initialize native macOS menu bar (no-op on Windows)
         Ioc.Default.GetRequiredService<MacMenuBarService>().Initialize();
 
+        // macOS-only: hide the in-window Shell CommandBar when the user has
+        // opted to rely on the native Mac menu bar instead.
+        if (OperatingSystem.IsMacOS() && Preferences.HideShellCommandBarOnMac)
+        {
+            ShellCommandBar.Visibility = Visibility.Collapsed;
+        }
+
         ShellVm.ShowHomePage();
         ShellVm.ShowConnectionStatus();
         Windowing.UpdateWindowTitle();
@@ -319,22 +326,6 @@ public sealed partial class Shell : Page
         }
 
         ShellVm.LastClickedTreeviewItem = (TreeViewItem)sender;
-    }
-
-    private async void ButtonBase_OnClick(object sender, RoutedEventArgs e)
-    {
-        var result = await Ioc.Default.GetRequiredService<Windowing>().ShowContentDialog(new ContentDialog
-        {
-            Content = new FeedbackDialog(),
-            PrimaryButtonText = "Submit Feedback",
-            SecondaryButtonText = "Discard",
-            Title = "Submit"
-        });
-
-        if (result == ContentDialogResult.Primary)
-        {
-            Ioc.Default.GetRequiredService<FeedbackViewModel>().CreateFeedback();
-        }
     }
 
     private void ShellPage_SizeChanged(object sender, SizeChangedEventArgs e)

--- a/StoryCADLib/Models/Tools/PreferencesModel.cs
+++ b/StoryCADLib/Models/Tools/PreferencesModel.cs
@@ -50,6 +50,7 @@ public class PreferencesModel : ObservableObject
         ShowStartupDialog = true;
         ShowFilePickerOnStartup = true;
         UseBetaDocumentation = AppState.IsBetaDistribution;
+        HideShellCommandBarOnMac = false;
     }
 
     #endregion
@@ -281,6 +282,15 @@ public class PreferencesModel : ObservableObject
     [JsonInclude]
     [JsonPropertyName("UseBetaDocumentation")]
     public bool UseBetaDocumentation { get; set; }
+
+    /// <summary>
+    ///     macOS only. When true, hides the in-window Shell CommandBar (search +
+    ///     menu buttons) since those are redundant with the native Mac menu bar.
+    ///     Takes effect on next launch.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("HideShellCommandBarOnMac")]
+    public bool HideShellCommandBarOnMac { get; set; }
 
     #endregion
 }

--- a/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
@@ -90,6 +90,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -115,14 +116,21 @@
                               Content="Use beta documentation" Margin="8"
                               IsChecked="{x:Bind PreferencesVm.UseBetaDocumentation, Mode=TwoWay}" />
 
-                    <ComboBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="4" Width="300"
+                    <CheckBox Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Center"
+                              Content="Hide in-window toolbar"
+                              ToolTipService.ToolTip="Hides the in-window search and menu buttons; use the native macOS menu bar instead. Takes effect on next launch."
+                              Margin="8"
+                              Visibility="{x:Bind PreferencesVm.MacOnlyVisibility}"
+                              IsChecked="{x:Bind PreferencesVm.HideShellCommandBarOnMac, Mode=TwoWay}" />
+
+                    <ComboBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="5" Width="300"
                               Header="Preferred Theme" HorizontalAlignment="Stretch"
                               SelectedIndex="{x:Bind PreferencesVm.PreferredThemeIndex, Mode=TwoWay}" Margin="8">
                         <ComboBoxItem Content="Use system theme" />
                         <ComboBoxItem Content="Light Theme" />
                         <ComboBoxItem Content="Dark Theme" />
                     </ComboBox>
-                    <ComboBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="5" Width="300"
+                    <ComboBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="6" Width="300"
                               Header="Preferred Search Engine" HorizontalAlignment="Stretch"
                               Name="SearchEngine" SelectedIndex="{x:Bind PreferencesVm.SearchEngineIndex, Mode=TwoWay}"
                               Margin="0,4,0,0">

--- a/StoryCADLib/Services/MacMenuBar/MacMenuBarService.cs
+++ b/StoryCADLib/Services/MacMenuBar/MacMenuBarService.cs
@@ -69,7 +69,7 @@ public class MacMenuBarService
             // Build each top-level menu
             AddAppMenu(mainMenu);
             AddFileMenu(mainMenu);
-            AddEditMenu(mainMenu);
+            AddSearchMenu(mainMenu);
             AddStoryMenu(mainMenu);
             AddMoveMenu(mainMenu);
             AddToolsMenu(mainMenu);
@@ -183,13 +183,45 @@ public class MacMenuBarService
         AddItemToMenu(fileMenu, closeItem);
     }
 
-    private void AddEditMenu(IntPtr mainMenu)
+    private void AddSearchMenu(IntPtr mainMenu)
     {
-        IntPtr editMenu = CreateMenu("Edit");
-        SetAutoenablesItems(editMenu, false);
-        IntPtr editMenuItem = CreateMenuItem("Edit", IntPtr.Zero, "");
-        SetSubmenu(editMenuItem, editMenu);
-        AddItemToMenu(mainMenu, editMenuItem);
+        // Top-level "Search" menu. Opening it reveals an NSSearchField embedded
+        // as the submenu's sole item. Typing + Enter updates ShellVm.FilterText
+        // and runs the same SearchNodes() call that the Shell AutoSuggestBox uses.
+        IntPtr searchMenu = CreateMenu("Search");
+        SetAutoenablesItems(searchMenu, false);
+        IntPtr searchMenuItem = CreateMenuItem("Search", IntPtr.Zero, "");
+        SetSubmenu(searchMenuItem, searchMenu);
+        AddItemToMenu(mainMenu, searchMenuItem);
+
+        // Padded container view so the search field doesn't sit flush against
+        // the menu edges. The item's height is driven by the container frame.
+        const double padX = 14;
+        const double padY = 10;
+        const double fieldW = 320;
+        const double fieldH = 26;
+        IntPtr container = CreateView(fieldW + padX * 2, fieldH + padY * 2);
+
+        // Search field positioned inside the container with padding on all sides.
+        IntPtr searchField = CreateSearchField(padX, padY, fieldW, fieldH);
+        SetPlaceholderString(searchField, "Enter text to search for here");
+        AddSubview(container, searchField);
+
+        // The action fires when the user presses Enter in the search field.
+        // Capture `searchField` in the closure so we can read its current value.
+        IntPtr searchSel = _actionHandler.RegisterAction("menuBarSearch:", () =>
+        {
+            string query = GetStringValue(searchField);
+            _shellVm.FilterText = query;
+            _shellVm.OutlineManager.SearchNodes();
+        });
+        SetTarget(searchField, _actionHandler.Instance);
+        SetAction(searchField, searchSel);
+
+        // Wrap the container in a menu item via setView:.
+        IntPtr searchFieldItem = CreateMenuItem("", IntPtr.Zero, "");
+        SetView(searchFieldItem, container);
+        AddItemToMenu(searchMenu, searchFieldItem);
     }
 
     private void AddStoryMenu(IntPtr mainMenu)
@@ -361,6 +393,10 @@ public class MacMenuBarService
         IntPtr helpMenuItem = CreateMenuItem("Help", IntPtr.Zero, "");
         SetSubmenu(helpMenuItem, helpMenu);
         AddItemToMenu(mainMenu, helpMenuItem);
+
+        // Report Feedback
+        AddActionItem(helpMenu, "Report Feedback...", "reportFeedback:", "",
+            0, () => _shellVm.ReportFeedbackCommand.Execute(null));
 
         // StoryCAD Help
         AddActionItem(helpMenu, "StoryCAD Help", "showHelp:", "",

--- a/StoryCADLib/Services/MacMenuBar/ObjCRuntime.cs
+++ b/StoryCADLib/Services/MacMenuBar/ObjCRuntime.cs
@@ -251,14 +251,34 @@ internal static class ObjCRuntime
     internal static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector, CGRect arg1);
 
     /// <summary>
-    /// Creates an NSSearchField with the given frame.
+    /// Creates an NSSearchField positioned at (x, y) with the given width and height.
     /// </summary>
-    internal static IntPtr CreateSearchField(double width)
+    internal static IntPtr CreateSearchField(double x, double y, double width, double height)
     {
         IntPtr nsSearchFieldClass = objc_getClass("NSSearchField");
         IntPtr alloc = objc_msgSend(nsSearchFieldClass, sel_registerName("alloc"));
-        CGRect frame = new(0, 0, width, 28);
+        CGRect frame = new(x, y, width, height);
         return objc_msgSend(alloc, sel_registerName("initWithFrame:"), frame);
+    }
+
+    /// <summary>
+    /// Creates a bare NSView with the given frame. Useful as a padded container
+    /// for other controls inside an NSMenuItem.
+    /// </summary>
+    internal static IntPtr CreateView(double width, double height)
+    {
+        IntPtr nsViewClass = objc_getClass("NSView");
+        IntPtr alloc = objc_msgSend(nsViewClass, sel_registerName("alloc"));
+        CGRect frame = new(0, 0, width, height);
+        return objc_msgSend(alloc, sel_registerName("initWithFrame:"), frame);
+    }
+
+    /// <summary>
+    /// Adds a child view as a subview of the parent.
+    /// </summary>
+    internal static void AddSubview(IntPtr parent, IntPtr child)
+    {
+        objc_msgSend(parent, sel_registerName("addSubview:"), child);
     }
 
     /// <summary>

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -158,6 +158,8 @@ public class ShellViewModel : ObservableRecipient
 
         PreferencesCommand = new RelayCommand(OpenPreferences, SerializationLock.CanExecuteCommands);
 
+        ReportFeedbackCommand = new RelayCommand(OpenReportFeedback, SerializationLock.CanExecuteCommands);
+
         PrintReportsCommand = new RelayCommand(OpenPrintMenu, SerializationLock.CanExecuteCommands);
         ExportReportsToPdfCommand = new RelayCommand(OpenExportPdfMenu, SerializationLock.CanExecuteCommands);
         ScrivenerReportsCommand = new RelayCommand(async () => await OutlineManager.GenerateScrivenerReports(),
@@ -390,6 +392,7 @@ public class ShellViewModel : ObservableRecipient
     public RelayCommand ExportReportsToPdfCommand { get; }
     public RelayCommand ScrivenerReportsCommand { get; }
     public RelayCommand PreferencesCommand { get; }
+    public RelayCommand ReportFeedbackCommand { get; }
 
     private Visibility _collaboratorVisibility;
 
@@ -975,6 +978,22 @@ public class ShellViewModel : ObservableRecipient
             default:
                 Messenger.Send(new StatusChangedMessage(new StatusMessage("Preferences closed", LogLevel.Info, true)));
                 break;
+        }
+    }
+
+    private async void OpenReportFeedback()
+    {
+        var result = await Window.ShowContentDialog(new ContentDialog
+        {
+            Content = new FeedbackDialog(),
+            PrimaryButtonText = "Submit Feedback",
+            SecondaryButtonText = "Discard",
+            Title = "Submit"
+        });
+
+        if (result == ContentDialogResult.Primary)
+        {
+            Ioc.Default.GetRequiredService<FeedbackViewModel>().CreateFeedback();
         }
     }
 

--- a/StoryCADLib/ViewModels/Tools/PreferencesViewModel.cs
+++ b/StoryCADLib/ViewModels/Tools/PreferencesViewModel.cs
@@ -242,6 +242,24 @@ public class PreferencesViewModel : ObservableValidator
         set => SetProperty(ref _ShowFilePickerOnStartup, value);
     }
 
+    // macOS only: hide the in-window Shell CommandBar (search + menus)
+    // because the native Mac menu bar already provides the same commands.
+    private bool _hideShellCommandBarOnMac;
+
+    public bool HideShellCommandBarOnMac
+    {
+        get => _hideShellCommandBarOnMac;
+        set => SetProperty(ref _hideShellCommandBarOnMac, value);
+    }
+
+    /// <summary>
+    /// Controls visibility of the mac-only preferences row in the dialog.
+    /// </summary>
+    public Microsoft.UI.Xaml.Visibility MacOnlyVisibility =>
+        OperatingSystem.IsMacOS()
+            ? Microsoft.UI.Xaml.Visibility.Visible
+            : Microsoft.UI.Xaml.Visibility.Collapsed;
+
     // Use beta documentation (BetaManual) instead of production manual.
     private bool _useBetaDocumentation;
 
@@ -291,6 +309,7 @@ public class PreferencesViewModel : ObservableValidator
         ShowStartupPage = CurrentModel.ShowStartupDialog;
         ShowFilePickerOnStartup = CurrentModel.ShowFilePickerOnStartup;
         UseBetaDocumentation = CurrentModel.UseBetaDocumentation;
+        HideShellCommandBarOnMac = CurrentModel.HideShellCommandBarOnMac;
     }
 
     internal void SaveModel()
@@ -328,6 +347,7 @@ public class PreferencesViewModel : ObservableValidator
         CurrentModel.ShowStartupDialog = ShowStartupPage;
         CurrentModel.ShowFilePickerOnStartup = ShowFilePickerOnStartup;
         CurrentModel.UseBetaDocumentation = UseBetaDocumentation;
+        CurrentModel.HideShellCommandBarOnMac = HideShellCommandBarOnMac;
     }
 
     /// <summary>


### PR DESCRIPTION
This PR updates the mac os menu bar:
 - The menubar now has feature parity with the shell one.
 - The shell menu bar can now be disabled
 - Some stuff was refactored to make this possible