### PR TITLE
Replace ROADMAP.md with user-facing version (#1398)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,85 +1,111 @@
 # StoryCAD Roadmap
 
-> Last updated: 2026-02-18
->
-> Working document for prioritization across the StoryBuilder org.
-> Issues are tracked in [StoryCAD](https://github.com/storybuilder-org/StoryCAD/issues),
-> [Collaborator](https://github.com/storybuilder-org/Collaborator/issues), and
-> [StoryCADAPI](https://github.com/storybuilder-org/StoryCADAPI/issues).
-> For prior releases see the [GitHub Releases](https://github.com/storybuilder-org/StoryCAD/releases) tab.
+Where StoryCAD is going, how the team plans new features, and how you can suggest or vote on what gets built next. Plain English; no GitHub experience required.
 
 ---
 
-## Release 4.0 — UNO Platform migration, macOS support
+## The short version
 
-| Issue | Repo | Summary |
-|-------|------|---------|
-| [#1284](https://github.com/storybuilder-org/StoryCAD/issues/1284) | StoryCAD | Release 4.0 macOS Testing Plan |
-
-## Release 4.1 — Subscription tiers
-
-| Issue | Repo | Summary |
-|-------|------|---------|
-| [#1297](https://github.com/storybuilder-org/StoryCAD/issues/1297) | StoryCAD | Implement subscription tiers for StoryCAD 4.0 |
-|TBA|StoryCAD|Code Cleanup|
-
-## Release 4.2 — API guidance and Prompt Generator
-
-| Issue | Repo | Summary | Status |
-|-------|------|---------|--------|
-| [#1246](https://github.com/storybuilder-org/StoryCAD/issues/1246) | StoryCAD | Update and release new samples and API guidance | |
-| [#61](https://github.com/storybuilder-org/Collaborator/issues/61) | Collaborator | Fiction Prompt Generator for StoryCAD | In Progress |
-
-> **Cross-repo**: The Fiction Prompt Generator spans StoryCAD [#1302](https://github.com/storybuilder-org/StoryCAD/issues/1302) and Collaborator [#61](https://github.com/storybuilder-org/Collaborator/issues/61).
-
-## Release 4.3 — Collaborator
-
-| Issue | Repo | Summary | Status |
-|-------|------|---------|--------|
-| [#1136](https://github.com/storybuilder-org/StoryCAD/issues/1136) | StoryCAD | Implement Cloudflare Worker proxy for Collaborator LLM APIs | Backlog |
-| [#1135](https://github.com/storybuilder-org/StoryCAD/issues/1135) | StoryCAD | Collaborator plug-in for macOS | Out of Scope (UNO) |
-| [#30](https://github.com/storybuilder-org/Collaborator/issues/30) | Collaborator | Bundle Collaborator with StoryCAD for Store Distribution | Backlog |
-| [#59](https://github.com/storybuilder-org/Collaborator/issues/59) | Collaborator | World-Type-Aware Worldbuilding Workflows | |
-| [#53](https://github.com/storybuilder-org/Collaborator/issues/53) | Collaborator | Review abbreviated prompts — add examples | Backlog |
-| [#49](https://github.com/storybuilder-org/Collaborator/issues/49) | Collaborator | ApplySettings() needs precision improvements | Backlog |
+- StoryCAD is currently at version **4.0.2**. The next public release is **4.1**.
+- After 4.1, the team is planning **4.2** and **4.3**; both already have work assigned.
+- All public planning lives on **GitHub**: <https://github.com/storybuilder-org/StoryCAD>.
+- Releases ship when they're ready. There is **no fixed calendar** for any version, by design.
 
 ---
 
-## Backlog (unmilestoned)
+## Where to see what's planned
 
-### Platform Expansion
+StoryCAD groups work into **releases**. Each release has a list of issues: bugs, feature requests, and improvements that the team plans to include. The full list of releases is here:
 
-| Issue | Repo | Summary | Status |
-|-------|------|---------|--------|
-| [#1301](https://github.com/storybuilder-org/StoryCAD/issues/1301) | StoryCAD | iPadOS Support? | |
-| [#1300](https://github.com/storybuilder-org/StoryCAD/issues/1300) | StoryCAD | Linux Support? | |
+**<https://github.com/storybuilder-org/StoryCAD/milestones>**
 
-### Collaborator / AI
+Click any release to see the issues in it. Closed issues are done; open issues are still in progress or planned. The mix of open vs. closed gives you a feel for how far along that release is.
 
-| Issue | Repo | Summary | Status |
-|-------|------|---------|--------|
-| [#1302](https://github.com/storybuilder-org/StoryCAD/issues/1302) | StoryCAD | Fiction Prompt Generator for StoryCAD | See Release 4.2 |
-| [#1233](https://github.com/storybuilder-org/StoryCAD/issues/1233) | StoryCAD | Dramatic Situations: Revise data model, UI, and add API support | |
+To see only the issues in a specific release, use a search like:
 
-### Core Features
+**<https://github.com/storybuilder-org/StoryCAD/issues?q=is%3Aissue+milestone%3A%22Release+4.1%22>**
 
-| Issue | Repo | Summary | Status |
-|-------|------|---------|--------|
-| [#1278](https://github.com/storybuilder-org/StoryCAD/issues/1278) | StoryCAD | Implement Theme Picker using existing motif/theme data | |
-| [#1174](https://github.com/storybuilder-org/StoryCAD/issues/1174) | StoryCAD | Cut and paste for story elements | |
-| [#1144](https://github.com/storybuilder-org/StoryCAD/issues/1144) | StoryCAD | Complete Scrivener Notes Preservation Feature | |
-| [#1257](https://github.com/storybuilder-org/StoryCAD/issues/1257) | StoryCAD | Mark Stuff as bindable | Out of Scope |
+Replace `Release+4.1` with `Release+4.2` or `Release+4.3` for future releases.
 
-### Infrastructure / Ops
-
-| Issue | Repo | Summary | Status |
-|-------|------|---------|--------|
-| [#1280](https://github.com/storybuilder-org/StoryCAD/issues/1280) | StoryCAD | Improve email address validation to reduce invalid entries | |
-| [#1138](https://github.com/storybuilder-org/StoryCAD/issues/1138) | StoryCAD | Convert to MailerLite | In Progress |
-| [#1147](https://github.com/storybuilder-org/StoryCAD/issues/1147) | StoryCAD | Update FAQ on website with beatsheet question | |
+You don't need a GitHub account to read any of this; everything in the StoryCAD repository is public.
 
 ---
 
-## StoryCADAPI
+## How features get on the roadmap
 
-No open issues. Tracked at [storybuilder-org/StoryCADAPI](https://github.com/storybuilder-org/StoryCADAPI/issues).
+The team picks what goes into a release based on three sources of input, in roughly this order of formality.
+
+### 1. File a GitHub issue (anyone)
+
+Best for clearly-defined bug reports or feature requests. Go to <https://github.com/storybuilder-org/StoryCAD/issues> and click **New issue**. You'll need a free GitHub account.
+
+Be specific: describe what you want, what problem it solves, and (for bugs) the steps to reproduce. If a maintainer agrees the idea is worth pursuing, they'll assign it to a release milestone. That's when it joins the public roadmap.
+
+### 2. Post in `#feature-suggestions` on Discord (anyone)
+
+Best for half-formed ideas, "wouldn't it be cool if...", or just gauging whether anyone else wants the same thing before going through the trouble of writing a proper issue.
+
+The StoryBuilder Discord server is at <https://discord.gg/bpCyAQnWCa>. The `feature-suggestions` channel under StoryCAD Support is open to everyone, free members included. Post your idea and react to others' ideas with emoji to signal what you'd like to see.
+
+The team reads this channel and uses it to spot patterns: ideas that get a lot of reactions are candidates for becoming proper GitHub issues and getting on a release.
+
+### 3. Vote in `#feature-voting` (StoryCAD Pro members, quarterly)
+
+Once per quarter, the team picks 4–6 candidate features from the GitHub backlog and posts a poll in the `feature-voting` channel. **The winning feature gets added to the roadmap**, with a comment posted on the corresponding GitHub issue noting the community vote.
+
+This channel is part of the **StoryCAD Pro** subscription tier ($2.99/month via Discord Server Subscriptions). Pro members get a direct, binding vote in what the team prioritizes next. Free members can still influence the roadmap through paths 1 and 2, but a Pro vote is the only mechanism that the team is committed to honoring on a fixed cadence.
+
+This is one of the seven perks that come with Pro; see the Discord server for the full list and how to subscribe.
+
+The 'how' of a production release is an internal decision for the development team and StoryBuilder Foundation's board. We fix bugs, we have things we need to update to remain current, and we even have improvements of our own we'd like to see.
+
+But we believe the 'what' of a release, the features that it contains, should be user-driven as much as possible, and particularly for the features that enhance StoryCAD for you its users. Feature voting is our attempt at putting control of the product (as much as is practical) in your hands.
+
+In case you might ask, the reason we restrict feature voting to StoryCAD Pro users is to make sure you have some skin in the game.  We don't think this is onerous: a StoryCAD Pro subscription costs less than a cup of coffee.
+
+---
+
+## Why no release dates
+
+You'll notice none of the milestones have due dates set. This is deliberate. StoryCAD is built primarily by volunteers; commercial-software-style ship dates would be set up to disappoint. The team prefers to ship a release when the issues in it are actually done, rather than rush to hit a calendar.
+
+If you want to know roughly when something might land, the best signal is the open-vs.-closed issue count on the milestone page. A release with mostly closed issues is close; one with mostly open issues is further out.
+
+---
+
+## Why some details aren't public
+
+The public StoryCAD GitHub repository holds the high-level picture, showing feature release targets and ongoing work. The StoryBuilder Foundation keeps the detailed planning (task breakdowns, prioritization spreadsheets, internal release boards) on private GitHub Project boards. Because the StoryBuilder Foundation is small (one paid system administrator and a four-person volunteer board), we believe over-promising features that slip is worse than under-communicating.
+
+If a feature isn't on the public roadmap yet, it doesn't mean nobody is thinking about it; it usually means the team isn't ready to commit to a release for it.
+
+---
+
+## Following along without checking constantly
+
+Three options:
+
+1. **Watch the StoryCAD repo on GitHub.** Click the **Watch** button at <https://github.com/storybuilder-org/StoryCAD> and choose **Releases only**. You'll get an email when a new version ships.
+2. **Follow the announcements channel on Discord.** We announce new releases there and include notes on what changed.
+3. **Check the production user manual occasionally.** New features land in the manual at <https://manual.storybuilder.org/> when they ship.
+
+---
+
+## A note on Collaborator
+
+StoryCAD has an optional AI plugin called **Collaborator** that, when it's released will ship separately. It has its own roadmap on GitHub (also organized by Release 4.3) but the repository itself is private; you won't see its issues directly. Coverage of Collaborator features will appear on the StoryCAD roadmap when they reach the user-facing surface.
+
+---
+
+## Quick reference
+
+| What you want | Where to go |
+|---|---|
+| All planned releases | <https://github.com/storybuilder-org/StoryCAD/milestones> |
+| What's in 4.1 specifically | <https://github.com/storybuilder-org/StoryCAD/milestone/4> |
+| File a bug or feature request | <https://github.com/storybuilder-org/StoryCAD/issues/new> |
+| Suggest an idea informally | `#feature-suggestions` on Discord |
+| Vote on quarterly priorities (Pro) | `#feature-voting` on Discord |
+| Read the current user manual | <https://manual.storybuilder.org/> |
+| Discord server | <https://discord.gg/bpCyAQnWCa> |
+| Foundation's main site | <https://storybuilder.org/> |


### PR DESCRIPTION
Closes #1398.

Replaces the existing `ROADMAP.md` (a maintainer-facing tracking table) with a plain-English, user-facing roadmap. The previous file's release issue lists are already covered by GitHub's milestone pages, which the new doc points to.

## What's in the new doc

- Where to see what's planned (milestones page + filtered search)
- Three input paths: GitHub issue, `#feature-suggestions` (free), `#feature-voting` (Pro, quarterly)
- Why no release dates (volunteer-built, ship-when-ready)
- Why some details aren't public (private Project boards)
- Following along (Watch repo, Discord announcements, manual)
- Note on Collaborator
- Quick-reference table

## Companion change (already live)

Issue #1399 has been created and pinned as a "Roadmap" navigation aid on the repo home page, with comments locked. The README's existing `[Roadmap]` link in line 1 already points to this file.

## Out of scope

- Adding due dates to milestones (intentional, see "Why no release dates")
- Making private GitHub Projects public
- User manual / website / blog post placement (tracked separately)