### PR TITLE
Align user manual Discord invite with app invite (#1401)

### DIFF
--- a/docs/Front Matter/Getting_Help.md
+++ b/docs/Front Matter/Getting_Help.md
@@ -9,7 +9,7 @@ has_toc: false
 ## Getting Help
 We suggest you first use this manual to try to find the information you’re looking for.
 
-[The StoryBuilder Discord Server](https://discord.gg/g7jjtgBKsQ) contains a ‘frequently-asked-questions’ channel, and a ‘writers-chat’ channel.
+[The StoryBuilder Discord Server](https://discord.gg/bpCyAQnWCa) contains a ‘frequently-asked-questions’ channel, and a ‘writers-chat’ channel.
 
 Currently StoryCAD’s only direct support mechanism is to email support@storybuilder.org.
 You can email directly or use [this form](https://storybuilder.org/contact-us/), there's no difference.


### PR DESCRIPTION
Closes #1401.

`docs/Front Matter/Getting_Help.md` pointed at `discord.gg/g7jjtgBKsQ`. The app (Preferences/Initialization) and `CONTRIBUTING.md` use `discord.gg/bpCyAQnWCa`. This PR brings the manual in line so all four places agree.

## Verified after change

- `CONTRIBUTING.md` → `bpCyAQnWCa`
- `docs/Front Matter/Getting_Help.md` → `bpCyAQnWCa` (this PR)
- `StoryCAD/Views/PreferencesInitialization.xaml.cs` → `bpCyAQnWCa`
- `StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml.cs` → `bpCyAQnWCa`

## Discovered while

Working on #1398 (ROADMAP.md) — both invites surfaced when picking the live invite for the new roadmap doc.