### PR TITLE
Retry outline writes on transient IO collisions

### DIFF
--- a/StoryCADLib/DAL/StoryIO.cs
+++ b/StoryCADLib/DAL/StoryIO.cs
@@ -39,9 +39,6 @@ public class StoryIO
         var parent = Path.GetDirectoryName(output_path);
         Directory.CreateDirectory(parent!);
 
-        var folder = await StorageFolder.GetFolderFromPathAsync(parent);
-        var output =
-            await folder.CreateFileAsync(Path.GetFileName(output_path), CreationCollisionOption.ReplaceExisting);
         _logService.Log(LogLevel.Info, $"Saving Model to disk as {output_path}  " +
                                        $"Elements: {model.StoryElements.StoryElementGuids.Count}");
 
@@ -53,7 +50,38 @@ public class StoryIO
         _logService.Log(LogLevel.Trace, $"Serialised as {json}");
 
         //Save file to disk
-        await FileIO.WriteTextAsync(output, json);
+        await WriteFileWithRetryAsync(output_path, json);
+    }
+
+    /// <summary>
+    ///     Writes <paramref name="json"/> to <paramref name="path"/>, retrying briefly
+    ///     on IOException. Another process (scanner, indexer, sync client) can hold a
+    ///     handle on the outline for a few milliseconds after a preceding write; without
+    ///     the retry that collision fails a user save outright (issue #1437).
+    /// </summary>
+    private async Task WriteFileWithRetryAsync(string path, string json)
+    {
+        const int maxAttempts = 3;
+        for (int attempt = 1; ; attempt++)
+        {
+            try
+            {
+                await File.WriteAllTextAsync(path, json);
+                return;
+            }
+            catch (IOException ex) when (attempt < maxAttempts)
+            {
+                _logService.Log(LogLevel.Warn,
+                    $"Save attempt {attempt} of {maxAttempts} failed (0x{ex.HResult:X8}): {ex.Message}; retrying");
+                await Task.Delay(100 * attempt);
+            }
+            catch (IOException ex)
+            {
+                _logService.Log(LogLevel.Error,
+                    $"Save failed after {maxAttempts} attempts (0x{ex.HResult:X8}): {ex.Message}");
+                throw;
+            }
+        }
     }
 
 

--- a/StoryCADTests/DAL/StoryIOTests.cs
+++ b/StoryCADTests/DAL/StoryIOTests.cs
@@ -274,6 +274,53 @@ public partial class StoryIOTests
         Assert.IsFalse(result, "Expected whitespace path to return false.");
     }
 
+    #region Write Retry Tests
+
+    /// <summary>Holds <paramref name="path"/> open with FileShare.None, the same
+    /// condition an external process (scanner, indexer, sync client) creates when
+    /// it briefly locks the outline between saves (issue #1437).</summary>
+    private static FileStream LockFile(string path) =>
+        new(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+
+    [TestMethod]
+    public async Task WriteStory_TargetLockedBriefly_RetriesAndSucceeds()
+    {
+        var filePath = Path.Combine(App.ResultsDir, "WriteRetryTransient.stbx");
+        var model = new StoryModel();
+        var overview = new OverviewModel("Retry Test", model, null);
+        model.ExplorerView.Add(overview.Node);
+
+        var holder = LockFile(filePath);
+        // Release the lock partway through the retry window (attempts run at
+        // roughly 0ms, 100ms, and 300ms).
+        var releaser = Task.Run(async () => { await Task.Delay(150); holder.Dispose(); });
+
+        await _storyIO.WriteStory(filePath, model);
+
+        await releaser;
+        var written = await File.ReadAllTextAsync(filePath);
+        StringAssert.Contains(written, "Retry Test", "Write must succeed once the lock is released.");
+        File.Delete(filePath);
+    }
+
+    [TestMethod]
+    public async Task WriteStory_TargetLockedPersistently_ThrowsIOException()
+    {
+        var filePath = Path.Combine(App.ResultsDir, "WriteRetryPersistent.stbx");
+        var model = new StoryModel();
+        var overview = new OverviewModel("Retry Test", model, null);
+        model.ExplorerView.Add(overview.Node);
+
+        using (LockFile(filePath))
+        {
+            await Assert.ThrowsExactlyAsync<IOException>(() => _storyIO.WriteStory(filePath, model));
+        }
+
+        File.Delete(filePath);
+    }
+
+    #endregion
+
     #region Migration Tests
 
     [TestMethod]


### PR DESCRIPTION
Fixes #1437.

## Diagnosis

A manual save threw \COMException\ from \StoryIO.WriteStory\ 1.7 seconds after a successful autosave of the same file; a retry 2.6 seconds later succeeded (session log on BRIGID, 2026-07-03 13:00:58 local). \FileIO.WriteTextAsync\ commits via a temp-file replace, which fails if any other process holds a handle on the target during a milliseconds-wide window. The culprit process is unidentified; it is not StoryCAD (saves are serialized by the async lock, BackupService was off). The exception's HRESULT and message were never captured because the NLog exception layout drops \x.Message\.

## Fix

- \StoryIO.WriteStory\ now writes with \System.IO.File.WriteAllTextAsync\ instead of the WinRT \StorageFolder\/\FileIO\ pair. Still fully async per ADR-006 ('OutlineService / StoryIO: pure async I/O'); precedent at \FileOpenVM.cs:85\ and \PrintReportDialogVM.cs:661\. In-place write removes the create-temp-and-replace commit that widened the collision surface.
- Bounded retry: 3 attempts, 100ms/200ms backoff, on \IOException\.
- Each failed attempt logs the HRESULT and message, so the next occurrence in the field is diagnosable from the local log (today's incident wasn't).

## Tests

Moving to \System.IO\ makes the failure deterministic to provoke: a test can hold the target with \FileShare.None\, which is the same condition an external process creates.

- \WriteStory_TargetLockedBriefly_RetriesAndSucceeds\ — lock released mid-retry-window; asserts the save recovers and the content lands.
- \WriteStory_TargetLockedPersistently_ThrowsIOException\ — lock held throughout; asserts a clean \IOException\ after all attempts.

Full suite: 1,127 tests, 1,113 passed, 14 skipped, 0 failed.

## Tradeoff noted

In-place write means a crash mid-write leaves a partial file. The old path had no crash-safety either: \CreateFileAsync(ReplaceExisting)\ truncated the target to zero bytes before the transacted content write, so a crash between the two lost the outline the same way. Real crash-safety (write-temp-then-\File.Replace\) reintroduces the replace collision this PR removes and is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)