### PR TITLE
Set model.Changed in AddCastMember and AddRelationship

### DIFF
--- a/StoryCADLib/Services/Outline/OutlineService.cs
+++ b/StoryCADLib/Services/Outline/OutlineService.cs
@@ -462,6 +462,7 @@ public class OutlineService
 
         RelationshipModel relationship = new(recipient, desc);
         sourceCharacter.RelationshipList.Add(relationship);
+        Model.Changed = true;
 
         if (mirror)
         {
@@ -530,6 +531,7 @@ public class OutlineService
         }
 
         ((SceneModel)source).CastMembers.Add(castMember);
+        Model.Changed = true;
         _log.Log(LogLevel.Info, $"AddCastMember completed for cast member {castMember}.");
         return true;
     }

--- a/StoryCADTests/Services/Outline/OutlineServiceTests.cs
+++ b/StoryCADTests/Services/Outline/OutlineServiceTests.cs
@@ -1823,6 +1823,41 @@ public class OutlineServiceTests
         Assert.AreEqual(1, char1Model.RelationshipList.Count, "Should only have 1 relationship (no duplicates)");
     }
 
+    [TestMethod]
+    public async Task AddRelationship_NewRelationship_MarksModelChanged()
+    {
+        // Arrange
+        var model = await _outlineService.CreateModel("Test Story", "Test Author", 0);
+        var overview = model.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var character1 = _outlineService.AddStoryElement(model, StoryItemType.Character, overview.Node);
+        var character2 = _outlineService.AddStoryElement(model, StoryItemType.Character, overview.Node);
+        model.Changed = false;
+
+        // Act
+        _outlineService.AddRelationship(model, character1.Uuid, character2.Uuid, "Friends");
+
+        // Assert - issue #1436: an unset flag lets autosave skip the mutation
+        Assert.IsTrue(model.Changed, "Adding a relationship should mark the model changed.");
+    }
+
+    [TestMethod]
+    public async Task AddRelationship_DuplicateRelationship_DoesNotMarkModelChanged()
+    {
+        // Arrange
+        var model = await _outlineService.CreateModel("Test Story", "Test Author", 0);
+        var overview = model.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var character1 = _outlineService.AddStoryElement(model, StoryItemType.Character, overview.Node);
+        var character2 = _outlineService.AddStoryElement(model, StoryItemType.Character, overview.Node);
+        _outlineService.AddRelationship(model, character1.Uuid, character2.Uuid, "Friends");
+        model.Changed = false;
+
+        // Act - duplicate add is a no-op
+        _outlineService.AddRelationship(model, character1.Uuid, character2.Uuid, "Friends");
+
+        // Assert
+        Assert.IsFalse(model.Changed, "A no-op duplicate add must not mark the model changed.");
+    }
+
     #endregion
 
     #region AddCastMember Tests
@@ -1870,6 +1905,41 @@ public class OutlineServiceTests
         Assert.IsTrue(result, "Should return true for duplicate");
         var sceneModel = (SceneModel)scene;
         Assert.AreEqual(1, sceneModel.CastMembers.Count, "Should not add duplicate cast member");
+    }
+
+    [TestMethod]
+    public async Task AddCastMember_NewMember_MarksModelChanged()
+    {
+        // Arrange
+        var model = await _outlineService.CreateModel("Test Story", "Test Author", 0);
+        var overview = model.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var scene = _outlineService.AddStoryElement(model, StoryItemType.Scene, overview.Node);
+        var character = _outlineService.AddStoryElement(model, StoryItemType.Character, overview.Node);
+        model.Changed = false;
+
+        // Act
+        _outlineService.AddCastMember(model, scene, character.Uuid);
+
+        // Assert - issue #1436: an unset flag lets autosave skip the mutation
+        Assert.IsTrue(model.Changed, "Adding a cast member should mark the model changed.");
+    }
+
+    [TestMethod]
+    public async Task AddCastMember_DuplicateCastMember_DoesNotMarkModelChanged()
+    {
+        // Arrange
+        var model = await _outlineService.CreateModel("Test Story", "Test Author", 0);
+        var overview = model.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var scene = _outlineService.AddStoryElement(model, StoryItemType.Scene, overview.Node);
+        var character = _outlineService.AddStoryElement(model, StoryItemType.Character, overview.Node);
+        _outlineService.AddCastMember(model, scene, character.Uuid);
+        model.Changed = false;
+
+        // Act - duplicate add is a no-op
+        _outlineService.AddCastMember(model, scene, character.Uuid);
+
+        // Assert
+        Assert.IsFalse(model.Changed, "A no-op duplicate add must not mark the model changed.");
     }
 
     [TestMethod]


### PR DESCRIPTION
Fixes #1436.

## Change

\OutlineService.AddCastMember\ and \OutlineService.AddRelationship\ now set \Model.Changed = true\ after their mutations. Both previously mutated the model without the flag, so an API consumer whose only mutation was one of these calls got no autosave (\AutoSaveService.cs:117\ skips when \Changed\ is false), no unsaved-changes indicator, and no close prompt; the mutation was silently discarded on close. Every other \OutlineService\ mutator (\UpdateStoryElement\, \RemoveUuidReferences\, \MoveToTrash\, \RestoreFromTrash\, \EmptyTrash\) and all four generic API mutators already set it.

The no-op paths (duplicate cast member; duplicate relationship) return early and leave the flag untouched, matching the rule the image methods established on \dev\ (PR #1435).

## Tests

Four new tests in \OutlineServiceTests.cs\:
- \AddCastMember_NewMember_MarksModelChanged\
- \AddCastMember_DuplicateCastMember_DoesNotMarkModelChanged\
- \AddRelationship_NewRelationship_MarksModelChanged\
- \AddRelationship_DuplicateRelationship_DoesNotMarkModelChanged\

Full suite on this branch: 1,052 tests, 1,033 passed, 19 skipped, 0 failed.

## Note for dev

The same two methods on \dev\ have the same gap; when \main\ next merges into \dev\ this fix carries over. The image mutators added by #1435 on \dev\ already set the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)