### PR TITLE
#1420 Unit 1: Shell + OverviewPage AutomationProperties + convention tests

### DIFF
--- a/StoryCAD/Views/OverviewPage.xaml
+++ b/StoryCAD/Views/OverviewPage.xaml
@@ -108,7 +108,7 @@
                                                       IsSpellCheckEnabled="True"
                                                       TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
-                                                      AutomationProperties.AutomationId="PremiseRichEdit"
+                                                      AutomationProperties.AutomationId="OverviewPremiseRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                 </Grid>
                 </TabViewItem>
@@ -116,7 +116,7 @@
                 <TabViewItem Header="Structure" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
                              VerticalContentAlignment="Stretch"
-                             AutomationProperties.AutomationId="StructureTab">
+                             AutomationProperties.AutomationId="OverviewStructureTab">
                     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -161,7 +161,7 @@
                                   DisplayMemberPath="Name"
                                   SelectedItem="{x:Bind OverviewVm.SelectedViewpointCharacter, Mode=TwoWay}"
                                   ItemsSource="{x:Bind OverviewVm.Characters, Mode=OneWay}"
-                                  AutomationProperties.AutomationId="ViewpointCharacterCombo" />
+                                  AutomationProperties.AutomationId="OverviewViewpointCharacterCombo" />
                         <Grid Grid.Row="3" HorizontalAlignment="Stretch">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="2*" />

--- a/StoryCAD/Views/OverviewPage.xaml
+++ b/StoryCAD/Views/OverviewPage.xaml
@@ -11,16 +11,19 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBox Header="Title" Text="{x:Bind OverviewVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Header="Title" Text="{x:Bind OverviewVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                 AutomationProperties.AutomationId="TitleTextBox" />
         <TabView Grid.Row="1" TabWidthMode="Equal" CanDragTabs="False" CanReorderTabs="False" IsAddTabButtonVisible="False"
                  HorizontalAlignment="Stretch"
                  VerticalAlignment="Stretch"
                  HorizontalContentAlignment="Stretch"
-                 VerticalContentAlignment="Stretch">
+                 VerticalContentAlignment="Stretch"
+                 AutomationProperties.AutomationId="OverviewTabs">
             <TabView.TabItems>
                 <TabViewItem Header="Story Idea" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="StoryIdeaTab">
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>  <!-- Author -->
@@ -30,6 +33,7 @@
 
                     <TextBox Grid.Row="0"
                              Header="Author"
+                             AutomationProperties.AutomationId="AuthorTextBox"
                              Text="{x:Bind OverviewVm.Author, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
                     <Grid Grid.Row="1" ColumnSpacing="12">
@@ -38,8 +42,10 @@
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
                         <TextBox Grid.Column="0" Header="Date Created"
+                                 AutomationProperties.AutomationId="DateCreatedTextBox"
                                  Text="{x:Bind OverviewVm.DateCreated, Mode=TwoWay}"/>
                         <TextBox Grid.Column="1" Header="Last Changed"
+                                 AutomationProperties.AutomationId="LastChangedTextBox"
                                  Text="{x:Bind OverviewVm.DateModified, Mode=TwoWay}"/>
                     </Grid>
 
@@ -49,13 +55,15 @@
                                                       AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="StoryIdeaRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                 </Grid>
                 </TabViewItem>
 
                 <TabViewItem Header="Concept" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="ConceptTab">
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*"/>
@@ -70,13 +78,15 @@
                                                       IsSpellCheckEnabled="True"
                                                       TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="ConceptRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                 </Grid>
                 </TabViewItem>
 
                 <TabViewItem Header="Premise" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="PremiseTab">
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -88,6 +98,7 @@
                               MinWidth="300"
                               DisplayMemberPath="Name"
                               SelectedItem="{x:Bind OverviewVm.SelectedProblem, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="StoryProblemCombo"
                               ItemsSource="{x:Bind OverviewVm.Problems, Mode=OneWay}" />
                     <usercontrols:RichEditBoxExtended Grid.Row="1"
                                                       Header="Premise"
@@ -97,13 +108,15 @@
                                                       IsSpellCheckEnabled="True"
                                                       TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="PremiseRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                 </Grid>
                 </TabViewItem>
 
                 <TabViewItem Header="Structure" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="StructureTab">
                     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -121,10 +134,12 @@
                             </Grid.ColumnDefinitions>
                             <ComboBox Header="Type" Grid.Column="0" IsEditable="False" MinWidth="0" Margin="0,0,20,0"
                                       ItemsSource="{x:Bind OverviewVm.StoryTypeList}"
-                                      SelectedItem="{x:Bind OverviewVm.StoryType, Mode=TwoWay}" />
+                                      SelectedItem="{x:Bind OverviewVm.StoryType, Mode=TwoWay}"
+                                      AutomationProperties.AutomationId="OverviewTypeCombo" />
                             <ComboBox Header="Genre" Grid.Column="2" IsEditable="False" MinWidth="0"
                                       ItemsSource="{x:Bind OverviewVm.GenreList}"
-                                      SelectedItem="{x:Bind OverviewVm.StoryGenre, Mode=TwoWay}" />
+                                      SelectedItem="{x:Bind OverviewVm.StoryGenre, Mode=TwoWay}"
+                                      AutomationProperties.AutomationId="GenreCombo" />
                         </Grid>
                         <Grid Grid.Row="1" HorizontalAlignment="Stretch">
                             <Grid.ColumnDefinitions>
@@ -135,15 +150,18 @@
                             <ComboBox Header="Viewpoint" Grid.Column="0" IsEditable="False" MinWidth="0"
                                       Margin="0,0,20,0"
                                       ItemsSource="{x:Bind OverviewVm.ViewpointList}"
-                                      SelectedItem="{x:Bind OverviewVm.Viewpoint, Mode=TwoWay}" BorderThickness="1" />
+                                      SelectedItem="{x:Bind OverviewVm.Viewpoint, Mode=TwoWay}" BorderThickness="1"
+                                      AutomationProperties.AutomationId="ViewpointCombo" />
                             <ComboBox Header="Literary Technique" IsEditable="False" Grid.Column="2" MinWidth="0"
                                       ItemsSource="{x:Bind OverviewVm.LiteraryTechniqueList}"
-                                      SelectedItem="{x:Bind OverviewVm.LiteraryTechnique, Mode=TwoWay}" />
+                                      SelectedItem="{x:Bind OverviewVm.LiteraryTechnique, Mode=TwoWay}"
+                                      AutomationProperties.AutomationId="LiteraryTechniqueCombo" />
                         </Grid>
                         <ComboBox Header="Viewpoint Character" Grid.Row="2" IsEditable="False" MinWidth="300"
                                   DisplayMemberPath="Name"
                                   SelectedItem="{x:Bind OverviewVm.SelectedViewpointCharacter, Mode=TwoWay}"
-                                  ItemsSource="{x:Bind OverviewVm.Characters, Mode=OneWay}" />
+                                  ItemsSource="{x:Bind OverviewVm.Characters, Mode=OneWay}"
+                                  AutomationProperties.AutomationId="ViewpointCharacterCombo" />
                         <Grid Grid.Row="3" HorizontalAlignment="Stretch">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="2*" />
@@ -152,10 +170,12 @@
                             </Grid.ColumnDefinitions>
                             <ComboBox Header="Voice" Grid.Column="0" IsEditable="False" MinWidth="0" Margin="0,0,20,0"
                                       ItemsSource="{x:Bind OverviewVm.VoiceList}"
-                                      SelectedItem="{x:Bind OverviewVm.Voice, Mode=TwoWay}" />
+                                      SelectedItem="{x:Bind OverviewVm.Voice, Mode=TwoWay}"
+                                      AutomationProperties.AutomationId="VoiceCombo" />
                             <ComboBox Header="Tense" Grid.Column="2" IsEditable="False" MinWidth="0"
                                       ItemsSource="{x:Bind OverviewVm.TenseList}"
-                                      SelectedItem="{x:Bind OverviewVm.Tense, Mode=TwoWay}" />
+                                      SelectedItem="{x:Bind OverviewVm.Tense, Mode=TwoWay}"
+                                      AutomationProperties.AutomationId="TenseCombo" />
                         </Grid>
                         <Grid Grid.Row="4" HorizontalAlignment="Stretch">
                             <Grid.ColumnDefinitions>
@@ -165,23 +185,27 @@
                             </Grid.ColumnDefinitions>
                             <ComboBox Header="Style" Grid.Column="0" IsEditable="False" MinWidth="0" Margin="0,0,20,0"
                                       ItemsSource="{x:Bind OverviewVm.StyleList}"
-                                      SelectedItem="{x:Bind OverviewVm.Style, Mode=TwoWay}" />
+                                      SelectedItem="{x:Bind OverviewVm.Style, Mode=TwoWay}"
+                                      AutomationProperties.AutomationId="StyleCombo" />
                             <ComboBox Header="Tone" Grid.Column="2" IsEditable="False" MinWidth="0"
                                       ItemsSource="{x:Bind OverviewVm.ToneList}"
-                                      SelectedItem="{x:Bind OverviewVm.Tone, Mode=TwoWay}" />
+                                      SelectedItem="{x:Bind OverviewVm.Tone, Mode=TwoWay}"
+                                      AutomationProperties.AutomationId="ToneCombo" />
                         </Grid>
                         <usercontrols:RichEditBoxExtended Header="Structure Notes" Grid.Row="5"
                                                           RtfText="{x:Bind OverviewVm.StructureNotes, Mode=TwoWay}"
                                                           AcceptsReturn="True"
                                                           IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                           VerticalAlignment="Stretch"
+                                                          AutomationProperties.AutomationId="StructureNotesRichEdit"
                                                           ScrollViewer.VerticalScrollBarVisibility="Auto" />
                     </Grid>
                 </TabViewItem>
 
                 <TabViewItem Header="Notes" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="OverviewNotesTab">
                     <usercontrols:RichEditBoxExtended
                         Header="Notes"
                         RtfText="{x:Bind OverviewVm.Notes, Mode=TwoWay}"
@@ -189,6 +213,7 @@
                         IsSpellCheckEnabled="True"
                         TextWrapping="Wrap"
                         VerticalAlignment="Stretch"
+                        AutomationProperties.AutomationId="OverviewNotesRichEdit"
                         ScrollViewer.VerticalScrollBarVisibility="Auto" />
                 </TabViewItem>
             </TabView.TabItems>

--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -21,6 +21,7 @@
             <CommandBarFlyout x:Key="AddStoryElementFlyout" Placement="Right">
                 <CommandBarFlyout.SecondaryCommands>
                     <AppBarButton Icon="Add" Label="Add Elements"
+                                  AutomationProperties.AutomationId="AddElementsButton"
                                   Visibility="{x:Bind ShellVm.AddButtonVisibility, Mode=OneWay}">
                         <AppBarButton.Flyout>
                             <MenuFlyout>
@@ -32,44 +33,63 @@
                                 <MenuFlyoutItem Icon="Folder"
                                                 Command="{x:Bind ShellVm.AddFolderCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
+                                                AutomationProperties.AutomationId="ContextAddFolderMenuItem"
+                                                AutomationProperties.Name="Add Folder"
                                                 win:Text="Add Folder         Alt+F" skia:Text="Add Folder         ⌥F" />
                                 <MenuFlyoutItem Icon="Folder"
                                                 Command="{x:Bind ShellVm.AddSectionCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.NarratorVisibility, Mode=OneWay}"
+                                                AutomationProperties.AutomationId="ContextAddSectionMenuItem"
+                                                AutomationProperties.Name="Add Section"
                                                 win:Text="Add Section        Alt+A" skia:Text="Add Section        ⌥A" />
                                 <MenuFlyoutItem Icon="Help"
                                                 Command="{x:Bind ShellVm.AddProblemCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
+                                                AutomationProperties.AutomationId="ContextAddProblemMenuItem"
+                                                AutomationProperties.Name="Add Problem"
                                                 win:Text="Add Problem      Alt+P" skia:Text="Add Problem      ⌥P" />
                                 <MenuFlyoutItem Icon="Contact"
                                                 Command="{x:Bind ShellVm.AddCharacterCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
+                                                AutomationProperties.AutomationId="ContextAddCharacterMenuItem"
+                                                AutomationProperties.Name="Add Character"
                                                 win:Text="Add Character    Alt+C" skia:Text="Add Character    ⌥C" />
                                 <MenuFlyoutItem Icon="Globe"
                                                 Command="{x:Bind ShellVm.AddSettingCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
+                                                AutomationProperties.AutomationId="ContextAddSettingMenuItem"
+                                                AutomationProperties.Name="Add Setting"
                                                 win:Text="Add Setting        Alt+L" skia:Text="Add Setting        ⌥L" />
                                 <MenuFlyoutItem Icon="AllApps"
                                                 Command="{x:Bind ShellVm.AddSceneCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
+                                                AutomationProperties.AutomationId="ContextAddSceneMenuItem"
+                                                AutomationProperties.Name="Add Scene"
                                                 win:Text="Add Scene          Alt+S" skia:Text="Add Scene          ⌥S" />
                                 <MenuFlyoutItem Icon="TwoPage"
                                                 Command="{x:Bind ShellVm.AddNotesCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
+                                                AutomationProperties.AutomationId="ContextAddNotesMenuItem"
+                                                AutomationProperties.Name="Add Notes"
                                                 win:Text="Add Notes          Alt+N" skia:Text="Add Notes          ⌥N" />
                                 <MenuFlyoutItem Icon="PreviewLink"
                                                 Command="{x:Bind ShellVm.AddWebCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
+                                                AutomationProperties.AutomationId="ContextAddWebsiteMenuItem"
+                                                AutomationProperties.Name="Add Website"
                                                 win:Text="Add Website      Alt+W" skia:Text="Add Website      ⌥W" />
                                 <MenuFlyoutItem Icon="Map"
                                                 Command="{x:Bind ShellVm.AddStoryWorldCommand, Mode=OneWay}"
                                                 Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
+                                                AutomationProperties.AutomationId="ContextAddStoryWorldMenuItem"
+                                                AutomationProperties.Name="Add StoryWorld"
                                                 win:Text="Add StoryWorld  Alt+B" skia:Text="Add StoryWorld  ⌥B" />
                             </MenuFlyout>
                         </AppBarButton.Flyout>
                     </AppBarButton>
                     <AppBarSeparator />
                     <AppBarButton Icon="Delete" Label="Delete element"
+                                  AutomationProperties.AutomationId="DeleteElementButton"
                                   Command="{x:Bind ShellVm.RemoveStoryElementCommand, Mode=OneWay}"
                                   Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}">
                         <ToolTipService.ToolTip>
@@ -77,6 +97,7 @@
                         </ToolTipService.ToolTip>
                     </AppBarButton>
                     <AppBarButton Icon="Refresh" Label="Restore Element"
+                                  AutomationProperties.AutomationId="RestoreElementButton"
                                   Command="{x:Bind ShellVm.RestoreStoryElementCommand, Mode=OneWay}"
                                   Visibility="{x:Bind ShellVm.TrashButtonVisibility, Mode=OneWay}">
                         <ToolTipService.ToolTip>
@@ -84,6 +105,7 @@
                         </ToolTipService.ToolTip>
                     </AppBarButton>
                     <AppBarButton Icon="Switch" Label="Add to Narrative"
+                                  AutomationProperties.AutomationId="AddToNarrativeButton"
                                   Command="{x:Bind ShellVm.AddToNarrativeCommand, Mode=OneWay}"
                                   Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}">
                         <ToolTipService.ToolTip>
@@ -91,6 +113,7 @@
                         </ToolTipService.ToolTip>
                     </AppBarButton>
                     <AppBarButton Icon="Switch" Label="Remove from narrative"
+                                  AutomationProperties.AutomationId="RemoveFromNarrativeButton"
                                   Command="{x:Bind ShellVm.RemoveFromNarrativeCommand, Mode=OneWay}"
                                   Visibility="{x:Bind ShellVm.NarratorVisibility, Mode=OneWay}">
                         <ToolTipService.ToolTip>
@@ -98,12 +121,15 @@
                         </ToolTipService.ToolTip>
                     </AppBarButton>
                     <AppBarButton Icon="Switch" Label="Convert to Scene"
+                                  AutomationProperties.AutomationId="ConvertToSceneButton"
                                   Command="{x:Bind ShellVm.ConvertToSceneCommand, Mode=OneWay}"
                                   Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}" />
                     <AppBarButton Icon="Switch" Label="Convert to Problem"
+                                  AutomationProperties.AutomationId="ConvertToProblemButton"
                                   Command="{x:Bind ShellVm.ConvertToProblemCommand, Mode=OneWay}"
                                   Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}" />
                     <AppBarButton Icon="Print" Label="Print node"
+                                  AutomationProperties.AutomationId="PrintNodeButton"
                                   Command="{x:Bind ShellVm.PrintNodeCommand, Mode=OneWay}"
                                   Visibility="{x:Bind ShellVm.PrintNodeVisibility, Mode=OneWay}">
                         <ToolTipService.ToolTip>
@@ -111,12 +137,13 @@
                         </ToolTipService.ToolTip>
                     </AppBarButton>
                     <AppBarButton Icon="Cancel" Label="Empty Trash"
+                                  AutomationProperties.AutomationId="EmptyTrashButton"
                                   Visibility="{x:Bind ShellVm.TrashButtonVisibility, Mode=OneWay}">
                         <ToolTipService.ToolTip>
                             <ToolTip Content="Empty trash" />
                         </ToolTipService.ToolTip>
                         <AppBarButton.Flyout>
-                            <Flyout x:Name="EmptyTrashFlyout">
+                            <Flyout x:Name="EmptyTrashFlyout" AutomationProperties.AutomationId="EmptyTrashFlyout">
                                 <Flyout.FlyoutPresenterStyle>
                                     <Style TargetType="FlyoutPresenter">
                                         <Setter Property="Margin" Value="-16,0,0,0"/>
@@ -126,6 +153,7 @@
                                     <TextBlock Text="Are you sure you want to empty the trash?"
                                                HorizontalAlignment="Center" Margin="0,0,0,10" />
                                     <Button Command="{x:Bind ShellVm.EmptyTrashCommand, Mode=OneWay}" Content="Empty"
+                                            AutomationProperties.AutomationId="EmptyTrashConfirmButton"
                                             HorizontalAlignment="Center" />
                                 </StackPanel>
                             </Flyout>
@@ -184,45 +212,60 @@
                 <StackPanel Orientation="Horizontal">
                     <AutoSuggestBox PlaceholderText="Enter text to search for here" QueryIcon="Find" Width="335"
                                     Margin="0,8" Padding="0,0"
+                                    AutomationProperties.AutomationId="ShellSearchBox"
+                                    AutomationProperties.Name="Search"
                                     QuerySubmitted="Search" TextChanged="ClearNodes"
                                     Text="{x:Bind ShellVm.FilterText, Mode=TwoWay}" VerticalAlignment="Center" />
                 </StackPanel>
             </CommandBar.Content>
             <CommandBar.PrimaryCommands>
                 <AppBarButton Width="50" IsCompact="True" Icon="GlobalNavigationButton" Label="Show"
+                              AutomationProperties.AutomationId="TogglePaneButton"
                               ToolTipService.ToolTip="Show/Hide Navigation Pane"
                               Command="{x:Bind ShellVm.TogglePaneCommand, Mode=OneWay}" />
                 <AppBarButton IsCompact="True" Icon="Document" Label="File" ToolTipService.ToolTip="File Menu"
+                              AutomationProperties.AutomationId="FileMenuButton"
                               Width="50">
                     <AppBarButton.Flyout>
                         <MenuFlyout>
-                            <MenuFlyoutItem win:Text="Open/Create file                Ctrl+O" skia:Text="Open/Create file                ⌘O" Command="{x:Bind ShellVm.OpenFileOpenMenuCommand}">
+                            <MenuFlyoutItem win:Text="Open/Create file                Ctrl+O" skia:Text="Open/Create file                ⌘O" Command="{x:Bind ShellVm.OpenFileOpenMenuCommand}"
+                                            AutomationProperties.AutomationId="OpenCreateFileMenuItem"
+                                            AutomationProperties.Name="Open/Create file">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8F4;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem win:Text="Save Story                      Ctrl+S" skia:Text="Save Story                      ⌘S" Command="{x:Bind ShellVm.SaveFileCommand, Mode=OneWay}">
+                            <MenuFlyoutItem win:Text="Save Story                      Ctrl+S" skia:Text="Save Story                      ⌘S" Command="{x:Bind ShellVm.SaveFileCommand, Mode=OneWay}"
+                                            AutomationProperties.AutomationId="SaveStoryMenuItem"
+                                            AutomationProperties.Name="Save Story">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE74E;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem win:Text="Save Story As                   Ctrl+Shift+S" skia:Text="Save Story As                   ⇧⌘S" Command="{x:Bind ShellVm.SaveAsCommand, Mode=OneWay}">
+                            <MenuFlyoutItem win:Text="Save Story As                   Ctrl+Shift+S" skia:Text="Save Story As                   ⇧⌘S" Command="{x:Bind ShellVm.SaveAsCommand, Mode=OneWay}"
+                                            AutomationProperties.AutomationId="SaveStoryAsMenuItem"
+                                            AutomationProperties.Name="Save Story As">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE792;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
                             <MenuFlyoutItem win:Text="Create Backup                   Ctrl+B" skia:Text="Create Backup                   ⌘B"
-                                            Command="{x:Bind ShellVm.CreateBackupCommand, Mode=OneWay}">
+                                            Command="{x:Bind ShellVm.CreateBackupCommand, Mode=OneWay}"
+                                            AutomationProperties.AutomationId="CreateBackupMenuItem"
+                                            AutomationProperties.Name="Create Backup">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xe838;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Text="Close Story" Command="{x:Bind ShellVm.CloseCommand, Mode=OneWay}">
+                            <MenuFlyoutItem Text="Close Story" Command="{x:Bind ShellVm.CloseCommand, Mode=OneWay}"
+                                            AutomationProperties.AutomationId="CloseStoryMenuItem">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE127;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem win:Text="Exit                            Ctrl+Q" skia:Text="Quit                            ⌘Q" Command="{x:Bind ShellVm.ExitCommand, Mode=OneWay}">
+                            <MenuFlyoutItem win:Text="Exit                            Ctrl+Q" skia:Text="Quit                            ⌘Q" Command="{x:Bind ShellVm.ExitCommand, Mode=OneWay}"
+                                            AutomationProperties.AutomationId="ExitMenuItem"
+                                            AutomationProperties.Name="Exit">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE106;" />
                                 </MenuFlyoutItem.Icon>
@@ -231,6 +274,7 @@
                     </AppBarButton.Flyout>
                 </AppBarButton>
                 <AppBarButton IsCompact="True" Label="Add" ToolTipService.ToolTip="Add/Remove Story Elements"
+                              AutomationProperties.AutomationId="AddMenuButton"
                               Width="50">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE710;" />
@@ -239,30 +283,44 @@
                         <MenuFlyout>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddFolderCommand, Mode=OneWay}" Icon="Folder"
+                                            AutomationProperties.AutomationId="AddFolderMenuItem"
+                                            AutomationProperties.Name="Add folder"
                                             win:Text="Add folder         Alt+F" skia:Text="Add folder         ⌥F">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.NarratorVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddSectionCommand, Mode=OneWay}" Icon="Folder"
+                                            AutomationProperties.AutomationId="AddSectionMenuItem"
+                                            AutomationProperties.Name="Add section"
                                             win:Text="Add section        Alt+A" skia:Text="Add section        ⌥A">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddProblemCommand, Mode=OneWay}" Icon="Help"
+                                            AutomationProperties.AutomationId="AddProblemMenuItem"
+                                            AutomationProperties.Name="Add problem"
                                             win:Text="Add problem      Alt+P" skia:Text="Add problem      ⌥P">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddCharacterCommand, Mode=OneWay}" Icon="Contact"
+                                            AutomationProperties.AutomationId="AddCharacterMenuItem"
+                                            AutomationProperties.Name="Add character"
                                             win:Text="Add character    Alt+C" skia:Text="Add character    ⌥C">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddSettingCommand, Mode=OneWay}" Icon="Globe"
+                                            AutomationProperties.AutomationId="AddSettingMenuItem"
+                                            AutomationProperties.Name="Add setting"
                                             win:Text="Add setting        Alt+L" skia:Text="Add setting        ⌥L">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddSceneCommand, Mode=OneWay}" Icon="AllApps"
+                                            AutomationProperties.AutomationId="AddSceneMenuItem"
+                                            AutomationProperties.Name="Add scene"
                                             win:Text="Add scene          Alt+S" skia:Text="Add scene          ⌥S">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddWebCommand, Mode=OneWay}"
+                                            AutomationProperties.AutomationId="AddWebNodeMenuItem"
+                                            AutomationProperties.Name="Add Web node"
                                             win:Text="Add Web node     Alt+W" skia:Text="Add Web node     ⌥W">
                                 <MenuFlyoutItem.Icon>
                                     <SymbolIcon Symbol="PreviewLink" />
@@ -270,6 +328,8 @@
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddNotesCommand,Mode=OneWay}"
+                                            AutomationProperties.AutomationId="AddNotesNodeMenuItem"
+                                            AutomationProperties.Name="Add Notes node"
                                             win:Text="Add Notes node   Alt+N" skia:Text="Add Notes node   ⌥N">
                                 <MenuFlyoutItem.Icon>
                                     <SymbolIcon Symbol="TwoPage" />
@@ -277,6 +337,8 @@
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddStoryWorldCommand, Mode=OneWay}"
+                                            AutomationProperties.AutomationId="AddStoryWorldMenuItem"
+                                            AutomationProperties.Name="Add StoryWorld"
                                             win:Text="Add StoryWorld  Alt+B" skia:Text="Add StoryWorld  ⌥B">
                                 <MenuFlyoutItem.Icon>
                                     <SymbolIcon Symbol="Map" />
@@ -285,32 +347,39 @@
                             <MenuFlyoutSeparator />
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.RemoveStoryElementCommand,Mode=OneWay}"
-                                            Icon="Delete" Text="Delete story element">
+                                            Icon="Delete" Text="Delete story element"
+                                            AutomationProperties.AutomationId="DeleteStoryElementMenuItem">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.TrashButtonVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.RestoreStoryElementCommand,Mode=OneWay}"
-                                            Icon="Refresh" Text="Restore Story element" />
+                                            Icon="Refresh" Text="Restore Story element"
+                                            AutomationProperties.AutomationId="RestoreStoryElementMenuItem" />
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.AddToNarrativeCommand,Mode=OneWay}" Icon="Switch"
-                                            Text="Add To Narrative" />
+                                            Text="Add To Narrative"
+                                            AutomationProperties.AutomationId="AddToNarrativeMenuItem" />
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.NarratorVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.RemoveFromNarrativeCommand,Mode=OneWay}"
-                                            Icon="Switch" Text="Remove from Narrative" />
+                                            Icon="Switch" Text="Remove from Narrative"
+                                            AutomationProperties.AutomationId="RemoveFromNarrativeMenuItem" />
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.ConvertToSceneCommand,Mode=OneWay}" Icon="Switch"
-                                            Text="Convert to Scene" />
+                                            Text="Convert to Scene"
+                                            AutomationProperties.AutomationId="ConvertToSceneMenuItem" />
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.ExplorerVisibility, Mode=OneWay}"
                                             Command="{x:Bind ShellVm.ConvertToProblemCommand,Mode=OneWay}"
-                                            Icon="Switch" Text="Convert to Problem" />
+                                            Icon="Switch" Text="Convert to Problem"
+                                            AutomationProperties.AutomationId="ConvertToProblemMenuItem" />
                         </MenuFlyout>
                     </AppBarButton.Flyout>
                 </AppBarButton>
-                <AppBarButton Width="50" IsCompact="True" Label="Move" ToolTipService.ToolTip="Move Story Elements">
+                <AppBarButton Width="50" IsCompact="True" Label="Move" ToolTipService.ToolTip="Move Story Elements"
+                              AutomationProperties.AutomationId="MoveMenuButton">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE759;" />
                     </AppBarButton.Icon>
                     <AppBarButton.Flyout>
-                        <Flyout>
+                        <Flyout AutomationProperties.AutomationId="MoveFlyout">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="40" />
@@ -325,18 +394,26 @@
                                 <Button ToolTipService.ToolTip="Move Left"
                                         FontFamily="{ThemeResource SymbolThemeFontFamily}" Content="&#xE76B;"
                                         Command="{x:Bind ShellVm.MoveLeftCommand, Mode=OneWay}"
+                                        AutomationProperties.AutomationId="MoveLeftButton"
+                                        AutomationProperties.Name="Move Left"
                                         Margin="0,5,0,5" Grid.Row="1" />
                                 <Button ToolTipService.ToolTip="Move Right"
                                         FontFamily="{ThemeResource SymbolThemeFontFamily}" Content="&#xE76C;"
                                         Command="{x:Bind ShellVm.MoveRightCommand, Mode=OneWay}"
+                                        AutomationProperties.AutomationId="MoveRightButton"
+                                        AutomationProperties.Name="Move Right"
                                         Margin="0,5,0,5" Grid.Row="1" Grid.Column="2" />
                                 <Button ToolTipService.ToolTip="Move Up"
                                         FontFamily="{ThemeResource SymbolThemeFontFamily}" Content="&#xE70E;"
                                         Command="{x:Bind ShellVm.MoveUpCommand, Mode=OneWay}"
+                                        AutomationProperties.AutomationId="MoveUpButton"
+                                        AutomationProperties.Name="Move Up"
                                         Margin="5,0,5,0" Grid.Row="0" Grid.Column="1" />
                                 <Button ToolTipService.ToolTip="Move Down"
                                         FontFamily="{ThemeResource SymbolThemeFontFamily}" Content="&#xE70D;"
                                         Command="{x:Bind ShellVm.MoveDownCommand, Mode=OneWay}"
+                                        AutomationProperties.AutomationId="MoveDownButton"
+                                        AutomationProperties.Name="Move Down"
                                         Margin="5,0,5,0" Grid.Column="1" Grid.Row="2" />
                             </Grid>
                         </Flyout>
@@ -344,13 +421,15 @@
                 </AppBarButton>
                 <AppBarButton Width="50" IsCompact="True" Label="Collaborator"
                               ToolTipService.ToolTip="Launch Collaborator"
+                              AutomationProperties.AutomationId="CollaboratorButton"
                               Visibility="{x:Bind ShellVm.CollaboratorVisibility, Mode=OneWay}"
                               Command="{x:Bind ShellVm.CollaboratorCommand, Mode=OneWay}">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE71B;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-                <AppBarButton Width="50" IsCompact="True" Label="Tools" ToolTipService.ToolTip="Tools Menu">
+                <AppBarButton Width="50" IsCompact="True" Label="Tools" ToolTipService.ToolTip="Tools Menu"
+                              AutomationProperties.AutomationId="ToolsMenuButton">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE90F;" />
                     </AppBarButton.Icon>
@@ -358,31 +437,45 @@
                         <MenuFlyout>
                             <MenuFlyoutItem win:Text="Open Narrative Editor         Ctrl+N" skia:Text="Open Narrative Editor         ⌘N"
                                             Command="{x:Bind ShellVm.NarrativeToolCommand, Mode=OneWay}"
+                                            AutomationProperties.AutomationId="OpenNarrativeEditorMenuItem"
+                                            AutomationProperties.Name="Open Narrative Editor"
                                             muxc:ToolTipService.ToolTip="Opens the narrative editor to build your story as its told">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem win:Text="Key Questions                   Ctrl+K" skia:Text="Key Questions                   ⌘K"
-                                            Command="{x:Bind ShellVm.KeyQuestionsCommand, Mode=OneWay}">
+                                            Command="{x:Bind ShellVm.KeyQuestionsCommand, Mode=OneWay}"
+                                            AutomationProperties.AutomationId="KeyQuestionsMenuItem"
+                                            AutomationProperties.Name="Key Questions">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem Text="Topic Information"
-                                            Command="{x:Bind ShellVm.TopicsCommand, Mode=OneWay}" />
+                                            Command="{x:Bind ShellVm.TopicsCommand, Mode=OneWay}"
+                                            AutomationProperties.AutomationId="TopicInformationMenuItem" />
                             <MenuFlyoutItem Text="Copy Elements to Another Outline"
                                             Command="{x:Bind ShellVm.CopyElementsCommand, Mode=OneWay}"
+                                            AutomationProperties.AutomationId="CopyElementsToAnotherOutlineMenuItem"
                                             ToolTipService.ToolTip="Copy story elements to another outline file" />
-                            <MenuFlyoutSubItem Text="Plotting Aids">
+                            <MenuFlyoutSubItem Text="Plotting Aids"
+                                               AutomationProperties.AutomationId="PlottingAidsMenuItem">
                                 <MenuFlyoutItem win:Text="Master Plots                Ctrl+M" skia:Text="Master Plots                ⌘M"
-                                                Command="{x:Bind ShellVm.MasterPlotsCommand, Mode=OneWay}">
+                                                Command="{x:Bind ShellVm.MasterPlotsCommand, Mode=OneWay}"
+                                                AutomationProperties.AutomationId="MasterPlotsMenuItem"
+                                                AutomationProperties.Name="Master Plots">
                                 </MenuFlyoutItem>
                                 <MenuFlyoutItem win:Text="Dramatic Situations         Ctrl+D" skia:Text="Dramatic Situations         ⌘D"
-                                                Command="{x:Bind ShellVm.DramaticSituationsCommand, Mode=OneWay}">
+                                                Command="{x:Bind ShellVm.DramaticSituationsCommand, Mode=OneWay}"
+                                                AutomationProperties.AutomationId="DramaticSituationsMenuItem"
+                                                AutomationProperties.Name="Dramatic Situations">
                                 </MenuFlyoutItem>
                                 <MenuFlyoutItem win:Text="Stock Scenes                Ctrl+L" skia:Text="Stock Scenes                ⌘L"
-                                                Command="{x:Bind ShellVm.StockScenesCommand, Mode=OneWay}">
+                                                Command="{x:Bind ShellVm.StockScenesCommand, Mode=OneWay}"
+                                                AutomationProperties.AutomationId="StockScenesMenuItem"
+                                                AutomationProperties.Name="Stock Scenes">
                                 </MenuFlyoutItem>
                             </MenuFlyoutSubItem>
                         </MenuFlyout>
                     </AppBarButton.Flyout>
                 </AppBarButton>
-                <AppBarButton Width="50" IsCompact="True" Label="Reports" ToolTipService.ToolTip="Reports Menu">
+                <AppBarButton Width="50" IsCompact="True" Label="Reports" ToolTipService.ToolTip="Reports Menu"
+                              AutomationProperties.AutomationId="ReportsMenuButton">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE9F9;" />
                     </AppBarButton.Icon>
@@ -390,19 +483,26 @@
                         <MenuFlyout>
                             <MenuFlyoutItem win:Text="Print Reports                   Ctrl+P"
                                             skia:Text="Print Reports                   ⌘⇧P"
-                                            Command="{x:Bind ShellVm.PrintReportsCommand, Mode=OneWay}">
+                                            Command="{x:Bind ShellVm.PrintReportsCommand, Mode=OneWay}"
+                                            AutomationProperties.AutomationId="PrintReportsMenuItem"
+                                            AutomationProperties.Name="Print Reports">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem win:Text="PDF Reports                     Ctrl+Shift+P" skia:Text="PDF Reports                     ⌘P"
-                                            Command="{x:Bind ShellVm.ExportReportsToPdfCommand, Mode=OneWay}">
+                                            Command="{x:Bind ShellVm.ExportReportsToPdfCommand, Mode=OneWay}"
+                                            AutomationProperties.AutomationId="PdfReportsMenuItem"
+                                            AutomationProperties.Name="PDF Reports">
                             </MenuFlyoutItem>
                             <MenuFlyoutItem win:Text="Scrivener Reports               Ctrl+R" skia:Text="Scrivener Reports               ⌘R"
-                                            Command="{x:Bind ShellVm.ScrivenerReportsCommand, Mode=OneWay}">
+                                            Command="{x:Bind ShellVm.ScrivenerReportsCommand, Mode=OneWay}"
+                                            AutomationProperties.AutomationId="ScrivenerReportsMenuItem"
+                                            AutomationProperties.Name="Scrivener Reports">
                             </MenuFlyoutItem>
 
                         </MenuFlyout>
                     </AppBarButton.Flyout>
                 </AppBarButton>
                 <AppBarButton Width="50" IsCompact="True" Label="Preferences" win:ToolTipService.ToolTip="Preferences (Ctrl+,)" skia:ToolTipService.ToolTip="Preferences (⌘,)"
+                              AutomationProperties.AutomationId="PreferencesButton"
                               Command="{x:Bind ShellVm.PreferencesCommand, Mode=OneWay}">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE713;" />
@@ -410,12 +510,14 @@
                 </AppBarButton>
                 <AppBarButton Width="50" IsCompact="True" Label="Report Feedback"
                               ToolTipService.ToolTip="Report Feedback"
+                              AutomationProperties.AutomationId="ReportFeedbackButton"
                               Command="{x:Bind ShellVm.ReportFeedbackCommand, Mode=OneWay}">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xED15;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
                 <AppBarButton Width="50" IsCompact="True" Label="Help" ToolTipService.ToolTip="Help (F1)"
+                              AutomationProperties.AutomationId="HelpButton"
                               Command="{x:Bind ShellVm.HelpCommand, Mode=OneWay}">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE897;" />
@@ -434,7 +536,8 @@
                 <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
                     <StackPanel>
                         <!-- Main Navigation Tree -->
-                        <ItemsRepeater ItemsSource="{x:Bind AppState.CurrentDocument.Model.CurrentView, Mode=TwoWay}">
+                        <ItemsRepeater ItemsSource="{x:Bind AppState.CurrentDocument.Model.CurrentView, Mode=TwoWay}"
+                                       AutomationProperties.AutomationId="NavigationTree">
                             <ItemsRepeater.ItemTemplate>
                                 <DataTemplate x:DataType="viewmodels:StoryNodeItem">
                                     <Grid DataContext="{x:Bind}">
@@ -446,7 +549,8 @@
                                         <!-- Shows the root node out of tree, prevents creating new roots. -->
                                         <TreeViewItem Tapped="RootClick" RightTapped="TreeViewItem_RightTapped"
                                                       HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                                      Background="Transparent" BorderBrush="Transparent">
+                                                      Background="Transparent" BorderBrush="Transparent"
+                                                      AutomationProperties.Name="{x:Bind Name, Mode=OneWay}">
                                             <StackPanel Orientation="Horizontal"
                                                         Background="{x:Bind Background, Mode=OneWay}"
                                                         BorderBrush="{x:Bind  boarderBrush, Mode=OneWay}"
@@ -475,7 +579,8 @@
                                                                        BorderThickness="1"
                                                                        RightTapped="TreeViewItem_RightTapped"
                                                                        IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}"
-                                                                       CanDrag="True">
+                                                                       CanDrag="True"
+                                                                       AutomationProperties.Name="{x:Bind Name, Mode=OneWay}">
                                                         <StackPanel Orientation="Horizontal">
                                                             <SymbolIcon Symbol="{x:Bind Symbol, Mode=OneWay}"
                                                                         Width="20" Height="20" />
@@ -499,13 +604,15 @@
                         <muxc:TreeView ItemsSource="{x:Bind AppState.CurrentDocument.Model.TrashView, Mode=TwoWay}"
                                        ItemInvoked="TreeViewItem_Invoked"
                                        CanDragItems="False" AllowDrop="False" CanReorderItems="False"
-                                       SelectionMode="Single">
+                                       SelectionMode="Single"
+                                       AutomationProperties.AutomationId="TrashTree">
                             <muxc:TreeView.ItemTemplate>
                                 <DataTemplate x:DataType="viewmodels:StoryNodeItem">
                                     <muxc:TreeViewItem ItemsSource="{x:Bind Children}"
                                                        RightTapped="TreeViewItem_RightTapped"
                                                        IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}"
-                                                       CanDrag="False">
+                                                       CanDrag="False"
+                                                       AutomationProperties.Name="{x:Bind Name, Mode=OneWay}">
                                         <StackPanel Orientation="Horizontal">
                                             <SymbolIcon Symbol="{x:Bind Symbol, Mode=OneWay}" Width="20" Height="20" />
                                             <TextBlock Text="{x:Bind Name, Mode=TwoWay}"
@@ -549,13 +656,17 @@
             <ComboBox Grid.Column="0" IsEditable="False" Width="200" Margin="10"
                       ItemsSource="{x:Bind ShellVm.ViewList}"
                       SelectionChanged="{x:Bind ShellVm.ViewChanged, Mode=OneWay}"
-                      SelectedItem="{x:Bind ShellVm.SelectedView, Mode=TwoWay}" />
+                      SelectedItem="{x:Bind ShellVm.SelectedView, Mode=TwoWay}"
+                      AutomationProperties.AutomationId="ViewSelectorCombo"
+                      AutomationProperties.Name="View selector" />
 
             <TextBlock Grid.Column="1" Text="{x:Bind ShellVm.StatusMessage, Mode=OneWay}"
                        Foreground="{x:Bind ShellVm.StatusColor, Mode=OneWay}"
                        Width="350" FontSize="14" Margin="10" FontFamily="Segoe UI" Padding="0,5" />
 
             <Button Grid.Column="2" Background="Transparent" Command="{x:Bind ShellVm.SaveFileCommand}"
+                    AutomationProperties.AutomationId="SaveStatusButton"
+                    AutomationProperties.Name="Save"
                     BorderBrush="Transparent">
                 <Button.Content>
                     <SymbolIcon Symbol="Edit" Height="36"
@@ -569,7 +680,9 @@
 
             <!-- Spacer in Column 3 -->
 
-            <Button Grid.Column="4" Background="Transparent" BorderBrush="Transparent" HorizontalAlignment="Right">
+            <Button Grid.Column="4" Background="Transparent" BorderBrush="Transparent" HorizontalAlignment="Right"
+                    AutomationProperties.AutomationId="AutosaveStatusButton"
+                    AutomationProperties.Name="Autosave">
                 <Button.Content>
                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE74E;" Height="36"
                               ToolTipService.ToolTip="This icon is green when AutoSave is active and working.">
@@ -581,6 +694,8 @@
             </Button>
 
             <Button Grid.Column="5" Background="Transparent" Command="{x:Bind ShellVm.CreateBackupCommand}"
+                    AutomationProperties.AutomationId="BackupStatusButton"
+                    AutomationProperties.Name="Backup"
                     BorderBrush="Transparent" HorizontalAlignment="Right">
                 <Button.Content>
                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE777;" Height="36"

--- a/StoryCADTests/Xaml/AutomationConventionTests.cs
+++ b/StoryCADTests/Xaml/AutomationConventionTests.cs
@@ -1,0 +1,299 @@
+using System.Xml;
+using System.Xml.Linq;
+
+namespace StoryCADTests.Xaml;
+
+/// <summary>
+///     Static XAML-scanning fitness function for issue #1420 (AutomationProperties annotation pass).
+///     Parses the convention-scope XAML files as plain XML (no UI, no [UITestMethod]) and checks
+///     them against devdocs/automation_naming_convention.md. See devdocs/issue_1420_implementation_plan.md
+///     for the TDD cycle these tests drive.
+/// </summary>
+[TestClass]
+public class AutomationConventionTests
+{
+    /// <summary>
+    ///     Files whose interactive controls must be fully annotated. Grows by one batch per unit
+    ///     (see the implementation plan's Units table) until Unit 9 replaces this with "all scope
+    ///     files", at which point <see cref="Coverage_AnnotatedFiles_EveryInteractiveControlHasAutomationId"/>
+    ///     becomes the permanent fitness function.
+    /// </summary>
+    private static readonly string[] AnnotatedFiles =
+    {
+        "StoryCAD/Views/Shell.xaml",
+        "StoryCAD/Views/OverviewPage.xaml",
+    };
+
+    /// <summary>
+    ///     Directories that make up the full convention scope (devdocs/automation_naming_convention.md
+    ///     "Scope" section). Scanned recursively at test time so newly added XAML is caught automatically
+    ///     rather than by re-surveying; StoryCADLib/Services/Dialogs recursion also covers its Tools subfolder.
+    /// </summary>
+    private static readonly string[] ScopeDirectories =
+    {
+        "StoryCAD/Views",
+        "StoryCADLib/Controls",
+        "StoryCADLib/Services/Dialogs",
+        "StoryCADLib/Collaborator/Views",
+    };
+
+    /// <summary>Local (namespace-ignored) element names that require an AutomationId when outside a DataTemplate.</summary>
+    private static readonly HashSet<string> InteractiveElementNames = new()
+    {
+        "Button", "AppBarButton", "HyperlinkButton", "MenuFlyoutItem", "MenuFlyoutSubItem",
+        "ComboBox", "TextBox", "CheckBox", "RadioButton", "ToggleSwitch", "NumberBox",
+        "AutoSuggestBox", "TabView", "TabViewItem", "TreeView", "ListView", "GridView",
+        "Flyout", "RichEditBoxExtended", "BrowseTextBox",
+    };
+
+    /// <summary>
+    ///     AutomationId suffix required per element local name, per the convention's suffix table.
+    ///     Two rows are Unit 1 proposed additions (not yet in the convention doc; see this unit's
+    ///     PR/report for the resolution): "ItemsRepeater" covers Shell's NavigationTree root-node
+    ///     container (an ItemsRepeater standing in for a TreeView because the real nested TreeView
+    ///     is templated), and "BrowseTextBox" fills a gap in the convention's own suffix table (the
+    ///     test spec's interactive-element list includes BrowseTextBox, but the suffix table does not).
+    /// </summary>
+    private static readonly Dictionary<string, string> SuffixByElementName = new()
+    {
+        ["Button"] = "Button",
+        ["AppBarButton"] = "Button",
+        ["HyperlinkButton"] = "Button",
+        ["MenuFlyoutItem"] = "MenuItem",
+        ["MenuFlyoutSubItem"] = "MenuItem",
+        ["ComboBox"] = "Combo",
+        ["TextBox"] = "TextBox",
+        ["RichEditBoxExtended"] = "RichEdit",
+        ["CheckBox"] = "Check",
+        ["RadioButton"] = "Radio",
+        ["ToggleSwitch"] = "Toggle",
+        ["NumberBox"] = "NumberBox",
+        ["AutoSuggestBox"] = "SearchBox",
+        ["TabViewItem"] = "Tab",
+        ["TabView"] = "Tabs",
+        ["TreeView"] = "Tree",
+        ["ListView"] = "List",
+        ["GridView"] = "GridView",
+        ["Flyout"] = "Flyout",
+        ["BrowseTextBox"] = "TextBox", // proposed: gap in convention suffix table, see class remarks
+        ["ItemsRepeater"] = "Tree",    // proposed: Unit 1, see class remarks
+    };
+
+    private const string AutomationIdAttribute = "AutomationProperties.AutomationId";
+
+    private static string? _repoRoot;
+
+    private static string RepoRoot
+    {
+        get
+        {
+            if (_repoRoot != null)
+            {
+                return _repoRoot;
+            }
+
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StoryCAD.sln")))
+            {
+                dir = dir.Parent;
+            }
+
+            Assert.IsNotNull(dir, $"Could not locate StoryCAD.sln by walking up from {AppContext.BaseDirectory}");
+            _repoRoot = dir!.FullName;
+            return _repoRoot;
+        }
+    }
+
+    /// <summary>Enumerates every XAML file under the convention scope directories, relative to the repo root.</summary>
+    private static IEnumerable<string> ScopeFiles()
+    {
+        foreach (var relDir in ScopeDirectories)
+        {
+            var absDir = Path.Combine(RepoRoot, relDir.Replace('/', Path.DirectorySeparatorChar));
+            Assert.IsTrue(Directory.Exists(absDir), $"Convention scope directory not found: {absDir}");
+
+            foreach (var file in Directory.EnumerateFiles(absDir, "*.xaml", SearchOption.AllDirectories))
+            {
+                yield return Path.GetRelativePath(RepoRoot, file).Replace('\\', '/');
+            }
+        }
+    }
+
+    private static XDocument LoadXaml(string relativePath)
+    {
+        var absPath = Path.Combine(RepoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Assert.IsTrue(File.Exists(absPath), $"XAML file not found: {absPath}");
+        return XDocument.Load(absPath, LoadOptions.SetLineInfo);
+    }
+
+    private static bool IsInsideDataTemplate(XElement element) =>
+        element.Ancestors().Any(a => a.Name.LocalName == "DataTemplate");
+
+    private static string? GetAttributeValue(XElement element, string attributeLocalName) =>
+        element.Attributes().FirstOrDefault(a => a.Name.LocalName == attributeLocalName)?.Value;
+
+    private static int LineOf(XElement element) => ((IXmlLineInfo)element).LineNumber;
+
+    /// <summary>
+    ///     Every interactive element outside a DataTemplate, in every file listed in
+    ///     <see cref="AnnotatedFiles"/>, must carry a non-empty AutomationId.
+    /// </summary>
+    [TestMethod]
+    public void Coverage_AnnotatedFiles_EveryInteractiveControlHasAutomationId()
+    {
+        var violations = new List<string>();
+
+        foreach (var relPath in AnnotatedFiles)
+        {
+            var doc = LoadXaml(relPath);
+            foreach (var element in doc.Descendants())
+            {
+                if (!InteractiveElementNames.Contains(element.Name.LocalName))
+                {
+                    continue;
+                }
+
+                if (IsInsideDataTemplate(element))
+                {
+                    continue;
+                }
+
+                var id = GetAttributeValue(element, AutomationIdAttribute);
+                if (string.IsNullOrEmpty(id))
+                {
+                    violations.Add($"{relPath}:{LineOf(element)} <{element.Name.LocalName}> is missing AutomationProperties.AutomationId");
+                }
+            }
+        }
+
+        Assert.IsTrue(violations.Count == 0,
+            $"{violations.Count} interactive control(s) missing AutomationId:\n{string.Join("\n", violations)}");
+    }
+
+    /// <summary>No element with a DataTemplate ancestor may carry an AutomationId, in any scope file.</summary>
+    [TestMethod]
+    public void TemplateSafety_AllFiles_NoAutomationIdInsideDataTemplate()
+    {
+        var violations = new List<string>();
+
+        foreach (var relPath in ScopeFiles())
+        {
+            var doc = LoadXaml(relPath);
+            foreach (var element in doc.Descendants())
+            {
+                var id = GetAttributeValue(element, AutomationIdAttribute);
+                if (string.IsNullOrEmpty(id))
+                {
+                    continue;
+                }
+
+                if (IsInsideDataTemplate(element))
+                {
+                    violations.Add($"{relPath}:{LineOf(element)} <{element.Name.LocalName}> AutomationId=\"{id}\" is inside a DataTemplate");
+                }
+            }
+        }
+
+        Assert.IsTrue(violations.Count == 0,
+            $"{violations.Count} AutomationId(s) found inside a DataTemplate:\n{string.Join("\n", violations)}");
+    }
+
+    /// <summary>Every AutomationId, anywhere in scope, must end with the suffix mapped to its element type.</summary>
+    [TestMethod]
+    public void Suffix_AllFiles_AutomationIdEndsWithRoleSuffix()
+    {
+        var violations = new List<string>();
+
+        foreach (var relPath in ScopeFiles())
+        {
+            var doc = LoadXaml(relPath);
+            foreach (var element in doc.Descendants())
+            {
+                var id = GetAttributeValue(element, AutomationIdAttribute);
+                if (string.IsNullOrEmpty(id))
+                {
+                    continue;
+                }
+
+                var localName = element.Name.LocalName;
+                if (!SuffixByElementName.TryGetValue(localName, out var suffix))
+                {
+                    violations.Add($"{relPath}:{LineOf(element)} <{localName}> AutomationId=\"{id}\" has no suffix mapping in the convention table (propose one)");
+                    continue;
+                }
+
+                if (!id.EndsWith(suffix, StringComparison.Ordinal))
+                {
+                    violations.Add($"{relPath}:{LineOf(element)} <{localName}> AutomationId=\"{id}\" does not end with required suffix \"{suffix}\"");
+                }
+            }
+        }
+
+        Assert.IsTrue(violations.Count == 0,
+            $"{violations.Count} AutomationId(s) with wrong or missing suffix:\n{string.Join("\n", violations)}");
+    }
+
+    /// <summary>Every AutomationId value, anywhere in scope, must be globally unique.</summary>
+    [TestMethod]
+    public void Uniqueness_AllFiles_AutomationIdsGloballyUnique()
+    {
+        var occurrences = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (var relPath in ScopeFiles())
+        {
+            var doc = LoadXaml(relPath);
+            foreach (var element in doc.Descendants())
+            {
+                var id = GetAttributeValue(element, AutomationIdAttribute);
+                if (string.IsNullOrEmpty(id))
+                {
+                    continue;
+                }
+
+                if (!occurrences.TryGetValue(id, out var locations))
+                {
+                    locations = new List<string>();
+                    occurrences[id] = locations;
+                }
+
+                locations.Add($"{relPath}:{LineOf(element)} <{element.Name.LocalName}>");
+            }
+        }
+
+        var duplicates = occurrences.Where(kv => kv.Value.Count > 1).ToList();
+        var violations = duplicates
+            .Select(kv => $"\"{kv.Key}\" used {kv.Value.Count} times: {string.Join(", ", kv.Value)}")
+            .ToList();
+
+        Assert.IsTrue(violations.Count == 0,
+            $"{violations.Count} duplicate AutomationId value(s):\n{string.Join("\n", violations)}");
+    }
+
+    /// <summary>Every AutomationId value, anywhere in scope, must be a literal ASCII letters/digits string (no bindings).</summary>
+    [TestMethod]
+    public void Literalness_AllFiles_AutomationIdIsLiteral()
+    {
+        var violations = new List<string>();
+
+        foreach (var relPath in ScopeFiles())
+        {
+            var doc = LoadXaml(relPath);
+            foreach (var element in doc.Descendants())
+            {
+                var id = GetAttributeValue(element, AutomationIdAttribute);
+                if (string.IsNullOrEmpty(id))
+                {
+                    continue;
+                }
+
+                if (id.Contains('{') || !id.All(c => c is >= 'a' and <= 'z' or >= 'A' and <= 'Z' or >= '0' and <= '9'))
+                {
+                    violations.Add($"{relPath}:{LineOf(element)} <{element.Name.LocalName}> AutomationId=\"{id}\" is not a literal ASCII letters/digits string");
+                }
+            }
+        }
+
+        Assert.IsTrue(violations.Count == 0,
+            $"{violations.Count} non-literal AutomationId value(s):\n{string.Join("\n", violations)}");
+    }
+}

--- a/StoryCADTests/Xaml/AutomationConventionTests.cs
+++ b/StoryCADTests/Xaml/AutomationConventionTests.cs
@@ -48,11 +48,12 @@ public class AutomationConventionTests
 
     /// <summary>
     ///     AutomationId suffix required per element local name, per the convention's suffix table.
-    ///     Two rows are Unit 1 proposed additions (not yet in the convention doc; see this unit's
-    ///     PR/report for the resolution): "ItemsRepeater" covers Shell's NavigationTree root-node
-    ///     container (an ItemsRepeater standing in for a TreeView because the real nested TreeView
-    ///     is templated), and "BrowseTextBox" fills a gap in the convention's own suffix table (the
-    ///     test spec's interactive-element list includes BrowseTextBox, but the suffix table does not).
+    ///     Four rows were added in Unit 1 (marked "(added Unit 1)" in the convention doc):
+    ///     "ItemsRepeater" covers Shell's NavigationTree root-node container (an ItemsRepeater
+    ///     standing in for a TreeView because the real nested TreeView is templated);
+    ///     "BrowseTextBox", "RadioButton", and "ToggleSwitch" fill gaps in the convention's
+    ///     original suffix table (the test spec's interactive-element list includes all three,
+    ///     but the original table did not).
     /// </summary>
     private static readonly Dictionary<string, string> SuffixByElementName = new()
     {
@@ -65,8 +66,8 @@ public class AutomationConventionTests
         ["TextBox"] = "TextBox",
         ["RichEditBoxExtended"] = "RichEdit",
         ["CheckBox"] = "Check",
-        ["RadioButton"] = "Radio",
-        ["ToggleSwitch"] = "Toggle",
+        ["RadioButton"] = "Radio",   // added Unit 1: gap in original convention suffix table, see class remarks
+        ["ToggleSwitch"] = "Toggle", // added Unit 1: gap in original convention suffix table, see class remarks
         ["NumberBox"] = "NumberBox",
         ["AutoSuggestBox"] = "SearchBox",
         ["TabViewItem"] = "Tab",
@@ -75,8 +76,8 @@ public class AutomationConventionTests
         ["ListView"] = "List",
         ["GridView"] = "GridView",
         ["Flyout"] = "Flyout",
-        ["BrowseTextBox"] = "TextBox", // proposed: gap in convention suffix table, see class remarks
-        ["ItemsRepeater"] = "Tree",    // proposed: Unit 1, see class remarks
+        ["BrowseTextBox"] = "TextBox", // added Unit 1: gap in original convention suffix table, see class remarks
+        ["ItemsRepeater"] = "Tree",    // added Unit 1, see class remarks
     };
 
     private const string AutomationIdAttribute = "AutomationProperties.AutomationId";
@@ -129,8 +130,17 @@ public class AutomationConventionTests
     private static bool IsInsideDataTemplate(XElement element) =>
         element.Ancestors().Any(a => a.Name.LocalName == "DataTemplate");
 
+    /// <summary>
+    ///     Returns the value of an *unconditional* attribute (no namespace prefix). A namespaced
+    ///     variant such as win:AutomationProperties.AutomationId deliberately does not match:
+    ///     the convention requires AutomationProperties attributes to be unconditional (ADR-001),
+    ///     and <see cref="Unconditional_AllFiles_NoNamespacedAutomationProperties"/> fails any
+    ///     namespaced AutomationProperties.* attribute outright.
+    /// </summary>
     private static string? GetAttributeValue(XElement element, string attributeLocalName) =>
-        element.Attributes().FirstOrDefault(a => a.Name.LocalName == attributeLocalName)?.Value;
+        element.Attributes()
+            .FirstOrDefault(a => a.Name.Namespace == XNamespace.None && a.Name.LocalName == attributeLocalName)
+            ?.Value;
 
     private static int LineOf(XElement element) => ((IXmlLineInfo)element).LineNumber;
 
@@ -269,7 +279,11 @@ public class AutomationConventionTests
             $"{violations.Count} duplicate AutomationId value(s):\n{string.Join("\n", violations)}");
     }
 
-    /// <summary>Every AutomationId value, anywhere in scope, must be a literal ASCII letters/digits string (no bindings).</summary>
+    /// <summary>
+    ///     Every AutomationId value, anywhere in scope, must be a non-empty literal ASCII
+    ///     letters/digits string (no bindings). A present-but-empty attribute is a violation,
+    ///     not a skip.
+    /// </summary>
     [TestMethod]
     public void Literalness_AllFiles_AutomationIdIsLiteral()
     {
@@ -281,8 +295,14 @@ public class AutomationConventionTests
             foreach (var element in doc.Descendants())
             {
                 var id = GetAttributeValue(element, AutomationIdAttribute);
-                if (string.IsNullOrEmpty(id))
+                if (id == null)
                 {
+                    continue; // attribute absent; coverage test owns that case
+                }
+
+                if (id.Length == 0)
+                {
+                    violations.Add($"{relPath}:{LineOf(element)} <{element.Name.LocalName}> has an empty AutomationProperties.AutomationId");
                     continue;
                 }
 
@@ -294,6 +314,37 @@ public class AutomationConventionTests
         }
 
         Assert.IsTrue(violations.Count == 0,
-            $"{violations.Count} non-literal AutomationId value(s):\n{string.Join("\n", violations)}");
+            $"{violations.Count} non-literal or empty AutomationId value(s):\n{string.Join("\n", violations)}");
+    }
+
+    /// <summary>
+    ///     AutomationProperties attributes must be unconditional (ADR-001): no win:/skia:/other
+    ///     namespace prefix on any AutomationProperties.* attribute in any scope file. A prefixed
+    ///     attribute would give Windows and macOS different identifiers and slip past the
+    ///     namespace-filtered lookup the other tests use.
+    /// </summary>
+    [TestMethod]
+    public void Unconditional_AllFiles_NoNamespacedAutomationProperties()
+    {
+        var violations = new List<string>();
+
+        foreach (var relPath in ScopeFiles())
+        {
+            var doc = LoadXaml(relPath);
+            foreach (var element in doc.Descendants())
+            {
+                foreach (var attribute in element.Attributes())
+                {
+                    if (attribute.Name.LocalName.StartsWith("AutomationProperties.", StringComparison.Ordinal)
+                        && attribute.Name.Namespace != XNamespace.None)
+                    {
+                        violations.Add($"{relPath}:{LineOf(element)} <{element.Name.LocalName}> {attribute.Name.LocalName} carries namespace \"{attribute.Name.NamespaceName}\" (must be unconditional)");
+                    }
+                }
+            }
+        }
+
+        Assert.IsTrue(violations.Count == 0,
+            $"{violations.Count} namespaced AutomationProperties attribute(s):\n{string.Join("\n", violations)}");
     }
 }

--- a/devdocs/automation_naming_convention.md
+++ b/devdocs/automation_naming_convention.md
@@ -4,7 +4,7 @@ Approved by founder 2026-07-03 on issue #1420 (design comment plus the 2026-07-0
 
 ## Scope
 
-All XAML under `StoryCAD/Views` and `StoryCADLib` (`Controls`, `Services/Dialogs`, `Services/Dialogs/Tools`, `Collaborator/Views`): 40 files, ~586 declared interactive control tags as of 2026-07-03 on `dev`. XAML added after that date is caught by the convention scan test in `StoryCADTests`, not by re-surveying.
+All XAML under `StoryCAD/Views` and `StoryCADLib` (`Controls`, `Services/Dialogs`, `Services/Dialogs/Tools`, `Collaborator/Views`): 39 files, ~586 declared interactive control tags as of 2026-07-03 on `dev`. XAML added after that date is caught by the convention scan test in `StoryCADTests`, not by re-surveying.
 
 ## AutomationId
 
@@ -28,6 +28,10 @@ Every interactive control gets `AutomationProperties.AutomationId`.
 | ListView | `List` | `ElementsList` |
 | GridView | `GridView` | `ImagesGridView` *(plan-stage addition; needed for `ImageGalleryControl`)* |
 | Flyout | `Flyout` | `EmptyTrashFlyout` |
+| RadioButton | `Radio` | *(added Unit 1)* |
+| ToggleSwitch | `Toggle` | *(added Unit 1)* |
+| BrowseTextBox | `TextBox` | *(added Unit 1)* |
+| ItemsRepeater | `Tree` | `NavigationTree` *(added Unit 1; exists for the Shell navigation tree stand-in; revisit if a non-tree ItemsRepeater ever needs annotation)* |
 
 - A control type not in this table gets a proposed suffix in the PR description; the table row is added when the PR merges.
 - Values are literal strings: ASCII letters and digits, no spaces, no bindings, never a story element name, file path, date, or any other runtime value.

--- a/devdocs/issue_1420_implementation_plan.md
+++ b/devdocs/issue_1420_implementation_plan.md
@@ -32,19 +32,19 @@ What these tests cannot see, and what covers it instead: whether the accessible 
 
 All tests live in `AutomationConventionTests`. Follow the house test naming pattern (`MethodName_Scenario_ExpectedResult` adapted to `Rule_Scope_Expectation`).
 
-**Locating the XAML source**: at test run time, walk up from `AppContext.BaseDirectory` until a directory containing `StoryCAD.sln` is found; scan the 40 convention-scope files relative to that root. Fail with a clear message if the root is not found.
+**Locating the XAML source**: at test run time, walk up from `AppContext.BaseDirectory` until a directory containing `StoryCAD.sln` is found; scan the 39 convention-scope files relative to that root. Fail with a clear message if the root is not found.
 
 **Interactive element list** (local names, namespace prefixes ignored): `Button`, `AppBarButton`, `HyperlinkButton`, `MenuFlyoutItem`, `MenuFlyoutSubItem`, `ComboBox`, `TextBox`, `CheckBox`, `RadioButton`, `ToggleSwitch`, `NumberBox`, `AutoSuggestBox`, `TabView`, `TabViewItem`, `TreeView`, `ListView`, `GridView`, `Flyout`, `RichEditBoxExtended`, `BrowseTextBox`. Elements inside a `DataTemplate` (any ancestor) are excluded from the coverage requirement.
 
 | Test | Scope | Assertion |
 |---|---|---|
 | `Coverage_AnnotatedFiles_EveryInteractiveControlHasAutomationId` | files in `AnnotatedFiles` | every interactive element outside a DataTemplate has a non-empty `AutomationProperties.AutomationId`; failure message lists file, line, element |
-| `TemplateSafety_AllFiles_NoAutomationIdInsideDataTemplate` | all 40 files, from day one | no element with a DataTemplate ancestor carries AutomationId |
+| `TemplateSafety_AllFiles_NoAutomationIdInsideDataTemplate` | all 39 files, from day one | no element with a DataTemplate ancestor carries AutomationId |
 | `Suffix_AllFiles_AutomationIdEndsWithRoleSuffix` | any AutomationId present anywhere | value ends with the suffix mapped to its element type in the convention table |
 | `Uniqueness_AllFiles_AutomationIdsGloballyUnique` | any AutomationId present anywhere | no value appears twice across all scanned files |
 | `Literalness_AllFiles_AutomationIdIsLiteral` | any AutomationId present anywhere | value contains no `{` (no bindings), only ASCII letters and digits |
 
-`AnnotatedFiles` starts as `{ Shell.xaml, OverviewPage.xaml }` in Unit 1 and grows by one batch per unit. By Unit 9 it holds all 40 files and the list can be replaced by "all scope files"; the coverage test then becomes the permanent fitness function the approved design requires.
+`AnnotatedFiles` starts as `{ Shell.xaml, OverviewPage.xaml }` in Unit 1 and grows by one batch per unit. By Unit 9 it holds all 39 files and the list can be replaced by "all scope files"; the coverage test then becomes the permanent fitness function the approved design requires.
 
 ## Units of work
 
@@ -104,7 +104,7 @@ Accessibility Insights' scan engine ships separately as Axe.Windows with a CLI (
 
 ## Definition of done
 
-- All 40 scope files in the coverage test; suite green; the five convention tests permanent.
+- All 39 scope files in the coverage test; suite green; the five convention tests permanent.
 - ~586 controls annotated (actual count reported in the closing comment on #1420).
 - FastPass on every view and dialog: zero missing-name findings on annotated controls.
 - Narrator completes the Unit 1 spot-checks; the #1441 post-annotation audit is unblocked and its trigger noted there.


### PR DESCRIPTION
Unit 1 of the #1420 annotation pass, per `devdocs/issue_1420_implementation_plan.md`: convention test scaffolding plus Shell and OverviewPage annotations. Attribute-only XAML diff plus one new test file plus the two devdocs corrections noted below.

## What's in the diff

- **99 AutomationIds**: 74 on `Shell.xaml` (73 interactive controls + the `NavigationTree` container id on the root-node ItemsRepeater), 25 on `OverviewPage.xaml`.
- **43 Names on Shell**: 31 padded-shortcut menu items carrying clean command text, 4 Move arrow buttons, 3 icon-only status-bar buttons, the search box, the headerless view-selector combo, plus 3 `{x:Bind Name}` bindings on tree item template roots. Zero Names on OverviewPage: the five `RichEditBoxExtended` names wait on the header-exposure check below.
- **`StoryCADTests/Xaml/AutomationConventionTests.cs`**: six static XAML tests — ratcheting coverage (red at 98 before annotation), template safety, suffix conformance, global uniqueness, literalness (empty id = violation), and attribute unconditionality (no `win:`/`skia:`-prefixed `AutomationProperties.*` anywhere; mutation-verified).

## Verification

- Build Debug|x64 clean; full suite **1,135 tests, 0 failed**.
- Independent agent review: approve-with-fixes, all fixes applied in `309126c3` (three page-prefix renames on OverviewPage, namespace enforcement in the test lookup plus the sixth test, disclosure fix, empty-id hardening). Diff purity was proven mechanically: stripping all inserted attributes and comparing to `dev` with `XNode.DeepEquals` returned identical documents.

## Convention amendments riding in this PR

Per the convention doc's own amendment process (proposed suffix rows land with the PR):
- `RadioButton` → `Radio`, `ToggleSwitch` → `Toggle`, `BrowseTextBox` → `TextBox`, `ItemsRepeater` → `Tree` (the last exists for the Shell navigation tree stand-in; revisit if a non-tree repeater ever needs annotation).
- Scope count corrected: 39 files, not 40 (direct count on `dev`; the 40 was derived arithmetic).

## Founder decision flagged

**Exit vs Quit**: the menu item shows "Exit" on Windows, "Quit" on macOS, and the accessible name must be one unconditional string (ADR-001 bans conditional `Name`). Implementer and reviewer both recommend `Name="Exit"` (matches `ExitMenuItem` and `ExitCommand`); the cost is macOS VoiceOver announcing "Exit" under a visible "Quit" label. Applied as "Exit"; object here to change it.

## Judgment calls applied (reviewer-affirmed)

Context-flyout menu items prefixed `Context*` where they duplicate toolbar items; flyout-opening CommandBar buttons named `*MenuButton`, direct-command buttons plain `*Button`; `PdfReportsMenuItem` acronym casing per .NET guidelines; page prefixes on Overview's collision-prone fields (`OverviewNotesRichEdit`, `OverviewPremiseRichEdit`, `OverviewStructureTab`, `OverviewTypeCombo`, `OverviewViewpointCharacterCombo`).

## Pre-merge GUI verification (plan Unit 1 steps 6-8; needs the running app)

- [ ] **Header-exposure check** (Accessibility Insights Inspect): examine a `RichEditBoxExtended` (Overview Story Idea field) and a `BrowseTextBox` instance — does `Header` reach the Name property? If not: `RichEditBoxExtended` gets a two-line `AutomationProperties.SetName` in its constructor on this branch before merge; `BrowseTextBox` gets its Name in its own XAML in Unit 5. Record the result here.
- [ ] **Narrator spot-check**: navigation tree announces node names; the three status-bar buttons announce save / autosave / backup status.
- [ ] **FastPass** on Shell and OverviewPage: record finding counts here. Pass bar: zero missing-name findings on annotated controls.

Structural note for future units: Shell's navigation tree renders root nodes via an `ItemsRepeater` of `TreeViewItem`s with nested templated `TreeView`s for children; there is no single non-templated TreeView, so `NavigationTree` sits on the ItemsRepeater and item announcements come from the template `Name` bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
