### PR TITLE
#1420: Exit menu accessible name is "Quit" (founder ruling)

### DIFF
--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -265,7 +265,7 @@
                             </MenuFlyoutItem>
                             <MenuFlyoutItem win:Text="Exit                            Ctrl+Q" skia:Text="Quit                            ⌘Q" Command="{x:Bind ShellVm.ExitCommand, Mode=OneWay}"
                                             AutomationProperties.AutomationId="ExitMenuItem"
-                                            AutomationProperties.Name="Exit">
+                                            AutomationProperties.Name="Quit">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE106;" />
                                 </MenuFlyoutItem.Icon>


### PR DESCRIPTION
Applies the founder ruling on the Exit/Quit question flagged in #1443: the accessible name for the Exit menu item is "Quit". One attribute value changed in Shell.xaml; the AutomationId stays ExitMenuItem, matching ExitCommand. Windows Narrator will announce "Quit" under the visible "Exit" label; macOS VoiceOver announces "Quit" matching its visible label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)