### PR TITLE
#1420 Unit 2: ProblemPage + CharacterPage AutomationProperties

### DIFF
--- a/StoryCAD/Views/CharacterPage.xaml
+++ b/StoryCAD/Views/CharacterPage.xaml
@@ -14,16 +14,19 @@
         </Grid.RowDefinitions>
         <TextBox Header="Name" Text="{x:Bind CharVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                  viewModels:TextBoxFocus.IsFocused="{x:Bind CharVm.IsTextBoxFocused, Mode=TwoWay}"
-                 Margin="10,10,10,0" HorizontalAlignment="Stretch" />
+                 Margin="10,10,10,0" HorizontalAlignment="Stretch"
+                 AutomationProperties.AutomationId="CharacterNameTextBox" />
         <TabView Grid.Row="1" TabWidthMode="Equal" CanDragTabs="False" CanReorderTabs="False" IsAddTabButtonVisible="False"
                  HorizontalAlignment="Stretch"
                  VerticalAlignment="Stretch"
                  HorizontalContentAlignment="Stretch"
-                 VerticalContentAlignment="Stretch">
+                 VerticalContentAlignment="Stretch"
+                 AutomationProperties.AutomationId="CharacterTabs">
             <TabView.TabItems>
                 <TabViewItem Header="Role" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="RoleTab">
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -33,24 +36,29 @@
                     </Grid.RowDefinitions>
                     <ComboBox IsEditable="True" Header="Role" Grid.Row="0" MinWidth="200"
                               ItemsSource="{x:Bind CharVm.RoleList}" Text="{x:Bind CharVm.Role, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind CharVm.Role, Mode=TwoWay}" />
+                              PlaceholderText="{x:Bind CharVm.Role, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="CharacterRoleCombo" />
                     <ComboBox Header="Story Role" Grid.Row="1" IsEditable="False" MinWidth="200"
                               ItemsSource="{x:Bind CharVm.StoryRoleList}"
-                              SelectedItem="{x:Bind CharVm.StoryRole, Mode=TwoWay}" />
+                              SelectedItem="{x:Bind CharVm.StoryRole, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="StoryRoleCombo" />
                     <ComboBox Header="Archetype" Grid.Row="2" IsEditable="False" MinWidth="200"
                               ItemsSource="{x:Bind CharVm.ArchetypeList}"
-                              SelectedItem="{x:Bind CharVm.Archetype, Mode=TwoWay}" />
+                              SelectedItem="{x:Bind CharVm.Archetype, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="ArchetypeCombo" />
                     <usercontrols:RichEditBoxExtended Header="Character Sketch" Grid.Row="3"
                                                       RtfText="{x:Bind CharVm.Description, Mode=TwoWay}"
                                                       AcceptsReturn="True" IsSpellCheckEnabled="True"
                                                       TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="CharacterSketchRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                 </Grid>
                 </TabViewItem>
                 <TabViewItem Header="Physical" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="PhysicalTab">
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -69,10 +77,12 @@
                         </Grid.ColumnDefinitions>
                         <TextBox Header="Age" Grid.Column="0" MinWidth="0" Margin="0,0,12,0"
                                  Text="{x:Bind CharVm.Age, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                 HorizontalAlignment="Stretch" />
+                                 HorizontalAlignment="Stretch"
+                                 AutomationProperties.AutomationId="AgeTextBox" />
                         <TextBox Header="Sex" Grid.Column="2" MinWidth="0"
                                  Text="{x:Bind CharVm.Sex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                 HorizontalAlignment="Stretch" />
+                                 HorizontalAlignment="Stretch"
+                                 AutomationProperties.AutomationId="SexTextBox" />
                     </Grid>
                     <Grid Grid.Row="1" HorizontalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
@@ -82,10 +92,12 @@
                         </Grid.ColumnDefinitions>
                         <TextBox Header="Height" Grid.Column="0" MinWidth="0" Margin="0,0,12,0"
                                  Text="{x:Bind CharVm.CharHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                 HorizontalAlignment="Stretch" />
+                                 HorizontalAlignment="Stretch"
+                                 AutomationProperties.AutomationId="HeightTextBox" />
                         <TextBox Header="Weight" Grid.Column="2" MinWidth="0"
                                  Text="{x:Bind CharVm.Weight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                 HorizontalAlignment="Stretch" />
+                                 HorizontalAlignment="Stretch"
+                                 AutomationProperties.AutomationId="WeightTextBox" />
                     </Grid>
                     <Grid Grid.Row="2" HorizontalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
@@ -96,11 +108,13 @@
                         <ComboBox IsEditable="True" Header="Eye Color" Grid.Column="0" MinWidth="0" Margin="0,0,12,0"
                                   ItemsSource="{x:Bind CharVm.EyesList}"
                                   Text="{x:Bind CharVm.Eyes, Mode=TwoWay}"
-                                  PlaceholderText="{x:Bind CharVm.Eyes, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                                  PlaceholderText="{x:Bind CharVm.Eyes, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                                  AutomationProperties.AutomationId="EyeColorCombo" />
                         <ComboBox IsEditable="True" Header="Hair Color" Grid.Column="2" MinWidth="0"
                                   ItemsSource="{x:Bind CharVm.HairList}"
                                   Text="{x:Bind CharVm.Hair, Mode=TwoWay}"
-                                  PlaceholderText="{x:Bind CharVm.Hair, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                                  PlaceholderText="{x:Bind CharVm.Hair, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                                  AutomationProperties.AutomationId="HairColorCombo" />
                     </Grid>
                     <Grid Grid.Row="3" HorizontalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
@@ -111,12 +125,14 @@
                         <ComboBox IsEditable="True" Header="Build" Grid.Column="0" MinWidth="0" Margin="0,0,12,0"
                                   ItemsSource="{x:Bind CharVm.BuildList}"
                                   Text="{x:Bind CharVm.Build, Mode=TwoWay}"
-                                  PlaceholderText="{x:Bind CharVm.Build, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                                  PlaceholderText="{x:Bind CharVm.Build, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                                  AutomationProperties.AutomationId="BuildCombo" />
                         <ComboBox IsEditable="True" Header="Complexion" Grid.Column="2" MinWidth="0"
                                   ItemsSource="{x:Bind CharVm.SkinList}"
                                   Text="{x:Bind CharVm.Complexion, Mode=TwoWay}"
                                   PlaceholderText="{x:Bind CharVm.Complexion, Mode=TwoWay}"
-                                  HorizontalAlignment="Stretch" />
+                                  HorizontalAlignment="Stretch"
+                                  AutomationProperties.AutomationId="ComplexionCombo" />
                     </Grid>
                     <Grid Grid.Row="4" HorizontalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
@@ -127,26 +143,31 @@
                         <ComboBox IsEditable="True" Header="Race" Grid.Column="0" MinWidth="0" Margin="0,0,12,0"
                                   ItemsSource="{x:Bind CharVm.RaceList}"
                                   Text="{x:Bind CharVm.Race, Mode=TwoWay}"
-                                  PlaceholderText="{x:Bind CharVm.Race, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                                  PlaceholderText="{x:Bind CharVm.Race, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                                  AutomationProperties.AutomationId="RaceCombo" />
                         <ComboBox IsEditable="True" Header="Nationality" Grid.Column="2" MinWidth="0"
                                   ItemsSource="{x:Bind CharVm.NationalityList}"
                                   Text="{x:Bind CharVm.Nationality, Mode=TwoWay}"
-                                  PlaceholderText="{x:Bind CharVm.Nationality, Mode=TwoWay}" />
+                                  PlaceholderText="{x:Bind CharVm.Nationality, Mode=TwoWay}"
+                                  AutomationProperties.AutomationId="NationalityCombo" />
                     </Grid>
                     <TextBox Header="General Health" Grid.Row="5"
                              Text="{x:Bind CharVm.Health, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                             HorizontalAlignment="Stretch" />
+                             HorizontalAlignment="Stretch"
+                             AutomationProperties.AutomationId="GeneralHealthTextBox" />
                     <usercontrols:RichEditBoxExtended Header="Physical Notes" Grid.Row="6"
                                                       RtfText="{x:Bind CharVm.PhysNotes, Mode=TwoWay}"
                                                       AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="PhysicalNotesRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                 </Grid>
                 </TabViewItem>
                 <TabViewItem Header="Appearance" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="AppearanceTab">
                 <!-- Character appearance data -->
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Grid.RowDefinitions>
@@ -159,19 +180,22 @@
                                                       IsSpellCheckEnabled="True"
                                                       TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="AppearanceRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                 </Grid>
                 </TabViewItem>
                 <TabViewItem Header="Relationships" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="RelationshipsTab">
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <usercontrols:RelationshipView />
                 </Grid>
                 </TabViewItem>
                 <TabViewItem Header="Flaw" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="FlawTab">
                 <!-- Character flaw data (heights of RichEditBoxes were "110") -->
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Grid.RowDefinitions>
@@ -180,18 +204,21 @@
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
                     <Button Content="Flaw Builder" Grid.Row="0" HorizontalAlignment="Stretch" Margin="0,10,10,10"
-                            Command="{x:Bind CharVm.FlawCommand, Mode=OneWay}" />
+                            Command="{x:Bind CharVm.FlawCommand, Mode=OneWay}"
+                            AutomationProperties.AutomationId="FlawBuilderButton" />
                     <usercontrols:RichEditBoxExtended Grid.Row="2" Margin="0,10,0,0" Header="Flaw"
                                                       RtfText="{x:Bind CharVm.Flaw, Mode=TwoWay}" AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="FlawRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto"
                                                       PlaceholderText="The trauma, fear, lie or secret that sabotages your character." />
                 </Grid>
                 </TabViewItem>
                 <TabViewItem Header="Backstory" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="BackstoryTab">
                 <!-- Character notes data -->
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Grid.RowDefinitions>
@@ -204,12 +231,14 @@
                                                       IsSpellCheckEnabled="True"
                                                       TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="BackstoryRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                 </Grid>
                 </TabViewItem>
                 <TabViewItem Header="Social" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="SocialTab">
                 <!-- Character social data -->
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Grid.RowDefinitions>
@@ -223,30 +252,35 @@
                                                       AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="EconomicRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                     <usercontrols:RichEditBoxExtended Header="Education" Grid.Row="1"
                                                       RtfText="{x:Bind CharVm.Education, Mode=TwoWay}"
                                                       AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="EducationRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                     <usercontrols:RichEditBoxExtended Header="Ethnic" Grid.Row="2"
                                                       RtfText="{x:Bind CharVm.Ethnic, Mode=TwoWay}"
                                                       AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="EthnicRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                     <usercontrols:RichEditBoxExtended Header="Religion" Grid.Row="3"
                                                       RtfText="{x:Bind CharVm.Religion, Mode=TwoWay}"
                                                       AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="ReligionRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                 </Grid>
                 </TabViewItem>
                 <TabViewItem Header="Psychological" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="PsychologicalTab">
                 <!-- Character psychological data -->
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Grid.RowDefinitions>
@@ -258,7 +292,8 @@
                     <Grid Grid.Row="0" HorizontalAlignment="Stretch">
                         <ComboBox Header="Personality Type" IsEditable="False" Width="200"
                                   ItemsSource="{x:Bind CharVm.EnneagramList}"
-                                  SelectedValue="{x:Bind CharVm.Enneagram, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                                  SelectedValue="{x:Bind CharVm.Enneagram, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                                  AutomationProperties.AutomationId="PersonalityTypeCombo" />
                     </Grid>
                     <Grid Grid.Row="1" HorizontalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
@@ -269,11 +304,13 @@
                         <ComboBox IsEditable="True" Header="Intelligence" Grid.Column="0" Width="200" Margin="0,0,12,0"
                                   ItemsSource="{x:Bind CharVm.IntelligenceList}"
                                   Text="{x:Bind CharVm.Intelligence, Mode=TwoWay}"
-                                  PlaceholderText="{x:Bind CharVm.Intelligence, Mode=TwoWay}" />
+                                  PlaceholderText="{x:Bind CharVm.Intelligence, Mode=TwoWay}"
+                                  AutomationProperties.AutomationId="IntelligenceCombo" />
                         <ComboBox IsEditable="True" Header="Values" Grid.Column="2" Width="200"
                                   ItemsSource="{x:Bind CharVm.ValuesList}"
                                   Text="{x:Bind CharVm.Values, Mode=TwoWay}"
-                                  PlaceholderText="{x:Bind CharVm.Values, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                                  PlaceholderText="{x:Bind CharVm.Values, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                                  AutomationProperties.AutomationId="ValuesCombo" />
                     </Grid>
                     <Grid Grid.Row="2" HorizontalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
@@ -284,24 +321,28 @@
                         <ComboBox IsEditable="True" Header="Focus" Grid.Column="0" Width="200" Margin="0,0,12,0"
                                   ItemsSource="{x:Bind CharVm.FocusList}"
                                   Text="{x:Bind CharVm.Focus, Mode=TwoWay}"
-                                  PlaceholderText="{x:Bind CharVm.Focus, Mode=TwoWay}" />
+                                  PlaceholderText="{x:Bind CharVm.Focus, Mode=TwoWay}"
+                                  AutomationProperties.AutomationId="FocusCombo" />
                         <ComboBox IsEditable="True" Header="Abnormality" Grid.Column="2" Width="200"
                                   ItemsSource="{x:Bind CharVm.AbnormalityList}"
                                   Text="{x:Bind CharVm.Abnormality, Mode=TwoWay}"
                                   PlaceholderText="{x:Bind CharVm.Abnormality, Mode=TwoWay}"
-                                  HorizontalAlignment="Stretch" />
+                                  HorizontalAlignment="Stretch"
+                                  AutomationProperties.AutomationId="AbnormalityCombo" />
                     </Grid>
                     <usercontrols:RichEditBoxExtended Header="Psych Notes" Grid.Row="3"
                                                       RtfText="{x:Bind CharVm.PsychNotes, Mode=TwoWay}"
                                                       AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="PsychNotesRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                 </Grid>
                 </TabViewItem>
                 <TabViewItem Header="Inner Traits" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="InnerTraitsTab">
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="2*" />
@@ -320,58 +361,71 @@
                               ItemsSource="{x:Bind CharVm.AdventurousnessList}"
                               Text="{x:Bind CharVm.Adventurousness, Mode=TwoWay}"
                               PlaceholderText="{x:Bind CharVm.Adventurousness, Mode=TwoWay}"
-                              HorizontalAlignment="Stretch" />
+                              HorizontalAlignment="Stretch"
+                              AutomationProperties.AutomationId="AdventureousnessCombo" />
                     <ComboBox IsEditable="True" Header="Confidence" Grid.Column="0" Grid.Row="1" MinWidth="0"
                               ItemsSource="{x:Bind CharVm.ConfidenceList}"
                               Text="{x:Bind CharVm.Confidence, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind CharVm.Confidence, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                              PlaceholderText="{x:Bind CharVm.Confidence, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                              AutomationProperties.AutomationId="ConfidenceCombo" />
                     <ComboBox IsEditable="True" Header="Creativity" Grid.Column="0" Grid.Row="2" MinWidth="0"
                               ItemsSource="{x:Bind CharVm.CreativityList}"
                               Text="{x:Bind CharVm.Creativity, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind CharVm.Creativity, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                              PlaceholderText="{x:Bind CharVm.Creativity, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                              AutomationProperties.AutomationId="CreativityCombo" />
                     <ComboBox IsEditable="True" Header="Enthusiasm" Grid.Column="0" Grid.Row="3" MinWidth="0"
                               ItemsSource="{x:Bind CharVm.EnthusiasmList}"
                               Text="{x:Bind CharVm.Enthusiasm, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind CharVm.Enthusiasm, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                              PlaceholderText="{x:Bind CharVm.Enthusiasm, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                              AutomationProperties.AutomationId="EnthusiasmCombo" />
                     <ComboBox IsEditable="True" Header="Sensitivity" Grid.Column="0" Grid.Row="4" MinWidth="0"
                               ItemsSource="{x:Bind CharVm.SensitivityList}"
                               Text="{x:Bind CharVm.Sensitivity, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind CharVm.Sensitivity, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                              PlaceholderText="{x:Bind CharVm.Sensitivity, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                              AutomationProperties.AutomationId="SensitivityCombo" />
                     <ComboBox IsEditable="True" Header="Sociability" Grid.Column="0" Grid.Row="5" MinWidth="0"
                               Margin="0,0,12,0"
                               ItemsSource="{x:Bind CharVm.SociabilityList}"
                               Text="{x:Bind CharVm.Sociability, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind CharVm.Sociability, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                              PlaceholderText="{x:Bind CharVm.Sociability, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                              AutomationProperties.AutomationId="SociabilityCombo" />
                     <ComboBox IsEditable="True" Header="Aggression" Grid.Column="2" Grid.Row="0" MinWidth="0"
                               ItemsSource="{x:Bind CharVm.AggressionList}"
                               Text="{x:Bind CharVm.Aggression, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind CharVm.Aggression, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                              PlaceholderText="{x:Bind CharVm.Aggression, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                              AutomationProperties.AutomationId="AggressionCombo" />
                     <ComboBox IsEditable="True" Header="Conscientiousness" Grid.Column="2" Grid.Row="1" MinWidth="0"
                               ItemsSource="{x:Bind CharVm.ConscientiousnessList}"
                               Text="{x:Bind CharVm.Conscientiousness, Mode=TwoWay}"
                               PlaceholderText="{x:Bind CharVm.Conscientiousness, Mode=TwoWay}"
-                              HorizontalAlignment="Stretch" />
+                              HorizontalAlignment="Stretch"
+                              AutomationProperties.AutomationId="ConscientiousnessCombo" />
                     <ComboBox IsEditable="True" Header="Dominance" Grid.Column="2" Grid.Row="2" MinWidth="0"
                               ItemsSource="{x:Bind CharVm.DominanceList}"
                               Text="{x:Bind CharVm.Dominance, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind CharVm.Dominance, Mode=TwoWay}" />
+                              PlaceholderText="{x:Bind CharVm.Dominance, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="DominanceCombo" />
                     <ComboBox IsEditable="True" Header="Self Assurance" Grid.Column="2" Grid.Row="3" MinWidth="0"
                               ItemsSource="{x:Bind CharVm.AssuranceList}"
                               Text="{x:Bind CharVm.Assurance, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind CharVm.Assurance, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                              PlaceholderText="{x:Bind CharVm.Assurance, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                              AutomationProperties.AutomationId="SelfAssuranceCombo" />
                     <ComboBox IsEditable="True" Header="Shrewdness" Grid.Column="2" Grid.Row="4" MinWidth="0"
                               ItemsSource="{x:Bind CharVm.ShrewdnessList}"
                               Text="{x:Bind CharVm.Shrewdness, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind CharVm.Shrewdness, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                              PlaceholderText="{x:Bind CharVm.Shrewdness, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                              AutomationProperties.AutomationId="ShrewdnessCombo" />
                     <ComboBox IsEditable="True" Header="Stability" Grid.Column="2" Grid.Row="5" MinWidth="0"
                               ItemsSource="{x:Bind CharVm.StabilityList}"
                               Text="{x:Bind CharVm.Stability, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind CharVm.Stability, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                              PlaceholderText="{x:Bind CharVm.Stability, Mode=TwoWay}" HorizontalAlignment="Stretch"
+                              AutomationProperties.AutomationId="StabilityCombo" />
                 </Grid>
                 </TabViewItem>
                 <TabViewItem Header="Outer Traits" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="OuterTraitsTab">
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -379,11 +433,13 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <Button Content="Trait Builder" Grid.Row="0" HorizontalAlignment="Stretch" Margin="0,10,10,10"
-                            Command="{x:Bind CharVm.TraitCommand, Mode=OneWay}" />
+                            Command="{x:Bind CharVm.TraitCommand, Mode=OneWay}"
+                            AutomationProperties.AutomationId="TraitBuilderButton" />
                     <!-- Character traits -->
                     <ListView Header="Traits" Grid.Row="1" MinWidth="0" MinHeight="150"
                               ItemsSource="{x:Bind CharVm.CharacterTraits, Mode=TwoWay}"
-                              SelectedIndex="{x:Bind CharVm.ExistingTraitIndex, Mode=TwoWay}" />
+                              SelectedIndex="{x:Bind CharVm.ExistingTraitIndex, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="TraitsList" />
                     <Grid Grid.Row="2" HorizontalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="2*" />
@@ -394,15 +450,20 @@
                         </Grid.ColumnDefinitions>
                         <TextBox Header="Other Trait:" Grid.Column="0" MinWidth="0" Margin="0,0,12,0"
                                  Text="{x:Bind CharVm.NewTrait, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                 HorizontalAlignment="Stretch" />
+                                 HorizontalAlignment="Stretch"
+                                 AutomationProperties.AutomationId="OtherTraitTextBox" />
                         <Button Grid.Column="2" FontFamily="{ThemeResource SymbolThemeFontFamily}" Content="&#xE710;" Margin="0,0,12,0"
-                                Command="{x:Bind CharVm.AddTraitCommand, Mode=OneWay}">
+                                Command="{x:Bind CharVm.AddTraitCommand, Mode=OneWay}"
+                                AutomationProperties.AutomationId="AddTraitButton"
+                                AutomationProperties.Name="Add Trait">
                             <ToolTipService.ToolTip>
                                 <ToolTip Content="Add Trait" />
                             </ToolTipService.ToolTip>
                         </Button>
                         <Button Grid.Column="4" FontFamily="{ThemeResource SymbolThemeFontFamily}" Content="&#xE738;"
-                                Command="{x:Bind CharVm.RemoveTraitCommand, Mode=OneWay}">
+                                Command="{x:Bind CharVm.RemoveTraitCommand, Mode=OneWay}"
+                                AutomationProperties.AutomationId="RemoveTraitButton"
+                                AutomationProperties.Name="Remove Trait">
                             <ToolTipService.ToolTip>
                                 <ToolTip Content="Remove Trait" />
                             </ToolTipService.ToolTip>
@@ -412,7 +473,8 @@
                 </TabViewItem>
                 <TabViewItem Header="Notes" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="CharacterNotesTab">
                 <!-- Character likes data -->
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Grid.RowDefinitions>
@@ -425,13 +487,15 @@
                                                       IsSpellCheckEnabled="True"
                                                       TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="CharacterNotesRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                 </Grid>
                 </TabViewItem>
 
                 <TabViewItem Header="Images" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="CharacterImagesTab">
                     <usercontrols:ImageGalleryControl ItemsSource="{x:Bind CharVm.Images, Mode=OneWay}" />
                 </TabViewItem>
             </TabView.TabItems>

--- a/StoryCAD/Views/ProblemPage.xaml
+++ b/StoryCAD/Views/ProblemPage.xaml
@@ -318,6 +318,7 @@
 
                                 <ListView.ItemTemplate>
                                     <DataTemplate x:DataType="tools:StructureBeat">
+                                        <!-- Accessible name must bind inline here: WinUI 3 silently ignores bindings in Style Setters (Setter.Value docs; unoplatform/uno#4826). -->
                                         <Grid ColumnDefinitions="Auto,*"
                               VerticalAlignment="Center"
                               Margin="8,8,8,8"

--- a/StoryCAD/Views/ProblemPage.xaml
+++ b/StoryCAD/Views/ProblemPage.xaml
@@ -92,12 +92,12 @@
                               DisplayMemberPath="Name"
                               SelectedItem="{x:Bind ProblemVm.SelectedProtagonist, Mode=TwoWay}"
                               ItemsSource="{x:Bind ProblemVm.Characters, Mode=OneWay}"
-                              AutomationProperties.AutomationId="ProtagonistCombo" />
+                              AutomationProperties.AutomationId="ProblemProtagonistCombo" />
                         <ComboBox IsEditable="True" Header="Goal" Grid.Row="1"
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.GoalList}"
                               Text="{x:Bind ProblemVm.ProtGoal, Mode=TwoWay}"
                               PlaceholderText="{x:Bind ProblemVm.ProtGoal, Mode=TwoWay}"
-                              AutomationProperties.AutomationId="ProtagonistGoalCombo" />
+                              AutomationProperties.AutomationId="ProblemProtagonistGoalCombo" />
                         <ComboBox IsEditable="True" Header="Motivation" Grid.Row="2"
                               MinWidth="300" ItemsSource="{x:Bind ProblemVm.MotiveList}"
                               Text="{x:Bind ProblemVm.ProtMotive, Mode=TwoWay}"
@@ -132,12 +132,12 @@
                               SelectedItem="{x:Bind ProblemVm.SelectedAntagonist, Mode=TwoWay}"
                               SelectedValuePath="Uuid"
                               ItemsSource="{x:Bind ProblemVm.Characters, Mode=OneWay}"
-                              AutomationProperties.AutomationId="AntagonistCombo" />
+                              AutomationProperties.AutomationId="ProblemAntagonistCombo" />
                         <ComboBox IsEditable="True" Header="Goal" Grid.Row="1"
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.GoalList}"
                               Text="{x:Bind ProblemVm.AntagGoal, Mode=TwoWay}"
                               PlaceholderText="{x:Bind ProblemVm.AntagGoal, Mode=TwoWay}"
-                              AutomationProperties.AutomationId="AntagonistGoalCombo" />
+                              AutomationProperties.AutomationId="ProblemAntagonistGoalCombo" />
                         <ComboBox IsEditable="True" Header="Motivation" Grid.Row="2"
                               MinWidth="300" ItemsSource="{x:Bind ProblemVm.MotiveList}"
                               Text="{x:Bind ProblemVm.AntagMotive, Mode=TwoWay}"
@@ -170,7 +170,7 @@
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.OutcomeList}"
                               Text="{x:Bind ProblemVm.Outcome, Mode=TwoWay}"
                               PlaceholderText="{x:Bind ProblemVm.Outcome, Mode=TwoWay}"
-                              AutomationProperties.AutomationId="OutcomeCombo" />
+                              AutomationProperties.AutomationId="ProblemOutcomeCombo" />
                         <ComboBox IsEditable="True" Header="Method" Grid.Row="1"
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.MethodList}"
                               Text="{x:Bind ProblemVm.Method, Mode=TwoWay}"
@@ -246,7 +246,9 @@
                                             ItemsSource="{x:Bind BeatSheetsVm.ElementSource}"
                                             SelectedItem="{x:Bind BeatSheetsVm.SelectedElementSource, Mode=TwoWay}"
                                             MaxColumns="2"
-                                            VerticalAlignment="Center">
+                                            VerticalAlignment="Center"
+                                            AutomationProperties.AutomationId="StructureElementsRadios"
+                                            AutomationProperties.Name="Elements">
                                         </RadioButtons>
                                     </StackPanel>
 
@@ -311,8 +313,6 @@
                                                 Value="0,0,0,1" />
                                         <Setter Property="Padding"
                                                 Value="8,4,8,4" />
-                                        <Setter Property="AutomationProperties.Name"
-                                                Value="{Binding Title}" />
                                     </Style>
                                 </ListView.ItemContainerStyle>
 
@@ -322,7 +322,8 @@
                               VerticalAlignment="Center"
                               Margin="8,8,8,8"
                               RowDefinitions="Auto,Auto"
-                              Background="Transparent">
+                              Background="Transparent"
+                              AutomationProperties.Name="{x:Bind Title, Mode=OneWay}">
                                             <!-- Icon spans both rows -->
                                             <SymbolIcon Grid.Column="0"
                                         Grid.RowSpan="2"

--- a/StoryCAD/Views/ProblemPage.xaml
+++ b/StoryCAD/Views/ProblemPage.xaml
@@ -13,16 +13,19 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <TextBox Header="Name" Text="{x:Bind ProblemVm.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                 viewModels:TextBoxFocus.IsFocused="{x:Bind ProblemVm.IsTextBoxFocused, Mode=TwoWay}"/>
+                 viewModels:TextBoxFocus.IsFocused="{x:Bind ProblemVm.IsTextBoxFocused, Mode=TwoWay}"
+                 AutomationProperties.AutomationId="ProblemNameTextBox"/>
         <TabView Grid.Row="1" TabWidthMode="Equal" CanDragTabs="False" CanReorderTabs="False" IsAddTabButtonVisible="False"
                  HorizontalAlignment="Stretch"
                  VerticalAlignment="Stretch"
                  HorizontalContentAlignment="Stretch"
-                 VerticalContentAlignment="Stretch">
+                 VerticalContentAlignment="Stretch"
+                 AutomationProperties.AutomationId="ProblemTabs">
             <TabView.TabItems>
                 <TabViewItem Header="Problem" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="ProblemTab">
                     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -40,36 +43,43 @@
                             <ComboBox Grid.Column="0" IsEditable="True" Header="Problem Type" Grid.Row="0" MinWidth="200"
                                   ItemsSource="{x:Bind ProblemVm.ProblemTypeList}"
                                   Text="{x:Bind ProblemVm.ProblemType, Mode=TwoWay}"
-                                  PlaceholderText="{x:Bind ProblemVm.ProblemType, Mode=TwoWay}" />
+                                  PlaceholderText="{x:Bind ProblemVm.ProblemType, Mode=TwoWay}"
+                                  AutomationProperties.AutomationId="ProblemTypeCombo" />
                             <ComboBox Grid.Column="2" IsEditable="True" Header="Conflict Type" Grid.Row="0" MinWidth="200"
                                   Margin="20,0,0,0"
                                   ItemsSource="{x:Bind ProblemVm.ConflictTypeList}"
                                   Text="{x:Bind ProblemVm.ConflictType, Mode=TwoWay}"
-                                  PlaceholderText="{x:Bind ProblemVm.ConflictType, Mode=TwoWay}" />
+                                  PlaceholderText="{x:Bind ProblemVm.ConflictType, Mode=TwoWay}"
+                                  AutomationProperties.AutomationId="ConflictTypeCombo" />
                         </Grid>
                         <ComboBox IsEditable="True" Header="Problem Category" Grid.Row="1" MinWidth="300"
                               ItemsSource="{x:Bind ProblemVm.ProblemCategoryList}"
                               Text="{x:Bind ProblemVm.ProblemCategory, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind ProblemVm.ProblemCategory, Mode=TwoWay}" />
+                              PlaceholderText="{x:Bind ProblemVm.ProblemCategory, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="ProblemCategoryCombo" />
                         <ComboBox IsEditable="True" Header="Subject" Grid.Row="2" MinWidth="300"
                               ItemsSource="{x:Bind ProblemVm.SubjectList}"
                               Text="{x:Bind ProblemVm.Subject, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind ProblemVm.Subject, Mode=TwoWay}" />
+                              PlaceholderText="{x:Bind ProblemVm.Subject, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="SubjectCombo" />
                         <usercontrols:RichEditBoxExtended Header="Story Question" Grid.Row="3"
                                                       RtfText="{x:Bind ProblemVm.Description, Mode=TwoWay}"
                                                       AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="StoryQuestionRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                         <ComboBox IsEditable="True" Header="Problem Source" Grid.Row="4" MinWidth="300"
                               ItemsSource="{x:Bind ProblemVm.ProblemSourceList}"
                               Text="{x:Bind ProblemVm.ProblemSource, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind ProblemVm.ProblemSource, Mode=TwoWay}" />
+                              PlaceholderText="{x:Bind ProblemVm.ProblemSource, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="ProblemSourceCombo" />
                     </Grid>
                 </TabViewItem>
                 <TabViewItem Header="Protagonist" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="ProtagonistTab">
                     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -81,28 +91,34 @@
                         <ComboBox Header="Protagonist" Grid.Row="0" IsEditable="False" MinWidth="300"
                               DisplayMemberPath="Name"
                               SelectedItem="{x:Bind ProblemVm.SelectedProtagonist, Mode=TwoWay}"
-                              ItemsSource="{x:Bind ProblemVm.Characters, Mode=OneWay}" />
+                              ItemsSource="{x:Bind ProblemVm.Characters, Mode=OneWay}"
+                              AutomationProperties.AutomationId="ProtagonistCombo" />
                         <ComboBox IsEditable="True" Header="Goal" Grid.Row="1"
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.GoalList}"
                               Text="{x:Bind ProblemVm.ProtGoal, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind ProblemVm.ProtGoal, Mode=TwoWay}" />
+                              PlaceholderText="{x:Bind ProblemVm.ProtGoal, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="ProtagonistGoalCombo" />
                         <ComboBox IsEditable="True" Header="Motivation" Grid.Row="2"
                               MinWidth="300" ItemsSource="{x:Bind ProblemVm.MotiveList}"
                               Text="{x:Bind ProblemVm.ProtMotive, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind ProblemVm.ProtMotive, Mode=TwoWay}" />
+                              PlaceholderText="{x:Bind ProblemVm.ProtMotive, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="ProtagonistMotivationCombo" />
                         <Button Content="Conflict Builder" Grid.Row="3" HorizontalAlignment="Left" Margin="0,10,10,10"
-                            Command="{x:Bind ProblemVm.ConflictCommand, Mode=OneWay}" />
+                            Command="{x:Bind ProblemVm.ConflictCommand, Mode=OneWay}"
+                            AutomationProperties.AutomationId="ProtagonistConflictBuilderButton" />
                         <usercontrols:RichEditBoxExtended Header="Conflict" Grid.Row="4"
                                                       RtfText="{x:Bind ProblemVm.ProtConflict, Mode=TwoWay}"
                                                       AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="ProtagonistConflictRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                     </Grid>
                 </TabViewItem>
                 <TabViewItem Header="Antagonist" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="AntagonistTab">
                     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -115,28 +131,34 @@
                               DisplayMemberPath="Name"
                               SelectedItem="{x:Bind ProblemVm.SelectedAntagonist, Mode=TwoWay}"
                               SelectedValuePath="Uuid"
-                              ItemsSource="{x:Bind ProblemVm.Characters, Mode=OneWay}" />
+                              ItemsSource="{x:Bind ProblemVm.Characters, Mode=OneWay}"
+                              AutomationProperties.AutomationId="AntagonistCombo" />
                         <ComboBox IsEditable="True" Header="Goal" Grid.Row="1"
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.GoalList}"
                               Text="{x:Bind ProblemVm.AntagGoal, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind ProblemVm.AntagGoal, Mode=TwoWay}" />
+                              PlaceholderText="{x:Bind ProblemVm.AntagGoal, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="AntagonistGoalCombo" />
                         <ComboBox IsEditable="True" Header="Motivation" Grid.Row="2"
                               MinWidth="300" ItemsSource="{x:Bind ProblemVm.MotiveList}"
                               Text="{x:Bind ProblemVm.AntagMotive, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind ProblemVm.AntagMotive, Mode=TwoWay}" />
+                              PlaceholderText="{x:Bind ProblemVm.AntagMotive, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="AntagonistMotivationCombo" />
                         <Button Content="Conflict Builder" Grid.Row="3" HorizontalAlignment="Left" Margin="0,10,10,10"
-                            Command="{x:Bind ProblemVm.ConflictCommand, Mode=OneWay}" />
+                            Command="{x:Bind ProblemVm.ConflictCommand, Mode=OneWay}"
+                            AutomationProperties.AutomationId="AntagonistConflictBuilderButton" />
                         <usercontrols:RichEditBoxExtended Header="Conflict" Grid.Row="4"
                                                       RtfText="{x:Bind ProblemVm.AntagConflict, Mode=TwoWay}"
                                                       AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="AntagonistConflictRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                     </Grid>
                 </TabViewItem>
                 <TabViewItem Header="Resolution" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="ResolutionTab">
                     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -147,20 +169,24 @@
                         <ComboBox IsEditable="True" Header="Outcome" Grid.Row="0"
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.OutcomeList}"
                               Text="{x:Bind ProblemVm.Outcome, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind ProblemVm.Outcome, Mode=TwoWay}" />
+                              PlaceholderText="{x:Bind ProblemVm.Outcome, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="OutcomeCombo" />
                         <ComboBox IsEditable="True" Header="Method" Grid.Row="1"
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.MethodList}"
                               Text="{x:Bind ProblemVm.Method, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind ProblemVm.Method, Mode=TwoWay}" />
+                              PlaceholderText="{x:Bind ProblemVm.Method, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="MethodCombo" />
                         <ComboBox IsEditable="True" Header="Theme" Grid.Row="2"
                               MinWidth="400" ItemsSource="{x:Bind ProblemVm.ThemeList}"
                               Text="{x:Bind ProblemVm.Theme, Mode=TwoWay}"
-                              PlaceholderText="{x:Bind ProblemVm.Theme, Mode=TwoWay}" />
+                              PlaceholderText="{x:Bind ProblemVm.Theme, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="ThemeCombo" />
                         <usercontrols:RichEditBoxExtended Header="Premise" Grid.Row="3"
                                                       RtfText="{x:Bind ProblemVm.Premise, Mode=TwoWay}"
                                                       AcceptsReturn="True"
                                                       IsSpellCheckEnabled="True" TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="ProblemPremiseRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto"
                                                       PlaceholderText="A [character] in a situation [genre, setting] wants something [goal], which brings him into [conflict] with a second character [opposition]. After [a series of conflicts], the [final battle] erupts, and [the protagonist] finally [resolves] the conflict. " />
                     </Grid>
@@ -168,7 +194,8 @@
 
                 <TabViewItem Header="Structure" IsClosable="False"
              HorizontalContentAlignment="Stretch"
-             VerticalContentAlignment="Stretch">
+             VerticalContentAlignment="Stretch"
+             AutomationProperties.AutomationId="ProblemStructureTab">
                     <Grid HorizontalAlignment="Stretch"
           VerticalAlignment="Stretch"
           RowSpacing="8">
@@ -230,7 +257,9 @@
                               PlaceholderText="{x:Bind BeatSheetsVm.StructureModelTitle, Mode=OneWay}"
                               SelectedValue="{x:Bind BeatSheetsVm.StructureModelTitle, Mode=TwoWay}"
                               Text="{x:Bind BeatSheetsVm.StructureModelTitle, Mode=OneWay}"
-                              MinWidth="240" />
+                              MinWidth="240"
+                              AutomationProperties.AutomationId="BeatSheetCombo"
+                              AutomationProperties.Name="Beat Sheet" />
                                     <!-- Row 1, Col 1 left empty; Expander chevron will sit at far right -->
                                 </Grid>
                             </Expander.Header>
@@ -244,7 +273,8 @@
                     IsSpellCheckEnabled="False"
                     TextWrapping="Wrap"
                     ScrollViewer.VerticalScrollBarVisibility="Auto"
-                    HorizontalAlignment="Stretch" />
+                    HorizontalAlignment="Stretch"
+                    AutomationProperties.AutomationId="BeatSheetDescriptionRichEdit" />
                             </Expander.Content>
                         </Expander>
 
@@ -269,7 +299,8 @@
                       BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                       BorderThickness="1"
                       CornerRadius="4"
-                      HorizontalAlignment="Stretch">
+                      HorizontalAlignment="Stretch"
+                      AutomationProperties.AutomationId="BeatsList">
                                 <ListView.ItemContainerStyle>
                                     <Style TargetType="ListViewItem">
                                         <Setter Property="HorizontalContentAlignment"
@@ -280,6 +311,8 @@
                                                 Value="0,0,0,1" />
                                         <Setter Property="Padding"
                                                 Value="8,4,8,4" />
+                                        <Setter Property="AutomationProperties.Name"
+                                                Value="{Binding Title}" />
                                     </Style>
                                 </ListView.ItemContainerStyle>
 
@@ -324,13 +357,17 @@
                                 <Button x:Name="AssignButton"
                                         Width="44" Height="40"
                                         Command="{x:Bind BeatSheetsVm.AssignBeatCommand}"
-                                        ToolTipService.ToolTip="Assign element to beat">
+                                        ToolTipService.ToolTip="Assign element to beat"
+                                        AutomationProperties.AutomationId="AssignBeatButton"
+                                        AutomationProperties.Name="Assign Beat">
                                     <FontIcon Glyph="&#xE72B;" FontSize="18" FontWeight="SemiBold" />
                                 </Button>
                                 <Button x:Name="UnassignButton"
                                         Width="44" Height="40"
                                         Command="{x:Bind BeatSheetsVm.UnbindElementCommand}"
-                                        ToolTipService.ToolTip="Remove assignment">
+                                        ToolTipService.ToolTip="Remove assignment"
+                                        AutomationProperties.AutomationId="UnassignBeatButton"
+                                        AutomationProperties.Name="Unassign Beat">
                                     <FontIcon Glyph="&#xE72A;" FontSize="18" FontWeight="SemiBold" />
                                 </Button>
 
@@ -342,31 +379,41 @@
                                 <Button x:Name="AddBeatButton"
                                         Width="44" Height="40"
                                         Command="{x:Bind BeatSheetsVm.CreateBeatCommand}"
-                                        ToolTipService.ToolTip="Add a new beat">
+                                        ToolTipService.ToolTip="Add a new beat"
+                                        AutomationProperties.AutomationId="AddBeatButton"
+                                        AutomationProperties.Name="Add Beat">
                                     <FontIcon Glyph="&#xE710;" FontSize="18" FontWeight="SemiBold" />
                                 </Button>
                                 <Button x:Name="DeleteBeatButton"
                                         Width="44" Height="40"
                                         Command="{x:Bind BeatSheetsVm.DeleteBeatCommand}"
-                                        ToolTipService.ToolTip="Delete selected beat">
+                                        ToolTipService.ToolTip="Delete selected beat"
+                                        AutomationProperties.AutomationId="DeleteBeatButton"
+                                        AutomationProperties.Name="Delete Beat">
                                     <FontIcon Glyph="&#xE74D;" FontSize="18" FontWeight="SemiBold" />
                                 </Button>
                                 <Button x:Name="MoveUpButton"
                                         Width="44" Height="40"
                                         Command="{x:Bind BeatSheetsVm.MoveUpCommand}"
-                                        ToolTipService.ToolTip="Move beat up">
+                                        ToolTipService.ToolTip="Move beat up"
+                                        AutomationProperties.AutomationId="BeatMoveUpButton"
+                                        AutomationProperties.Name="Move Beat Up">
                                     <FontIcon Glyph="&#xE70E;" FontSize="18" FontWeight="SemiBold" />
                                 </Button>
                                 <Button x:Name="MoveDownButton"
                                         Width="44" Height="40"
                                         Command="{x:Bind BeatSheetsVm.MoveDownCommand}"
-                                        ToolTipService.ToolTip="Move beat down">
+                                        ToolTipService.ToolTip="Move beat down"
+                                        AutomationProperties.AutomationId="BeatMoveDownButton"
+                                        AutomationProperties.Name="Move Beat Down">
                                     <FontIcon Glyph="&#xE70D;" FontSize="18" FontWeight="SemiBold" />
                                 </Button>
                                 <Button x:Name="SaveBeatSheetButton"
                                         Width="44" Height="40"
                                         Command="{x:Bind BeatSheetsVm.SaveBeatSheetCommand}"
-                                        ToolTipService.ToolTip="Save beat sheet to file">
+                                        ToolTipService.ToolTip="Save beat sheet to file"
+                                        AutomationProperties.AutomationId="SaveBeatSheetButton"
+                                        AutomationProperties.Name="Save Beat Sheet">
                                     <FontIcon Glyph="&#xE74E;" FontSize="18" FontWeight="SemiBold" />
                                 </Button>
                             </StackPanel>
@@ -386,7 +433,8 @@
                           DisplayMemberPath="Name"
                           BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                           BorderThickness="1"
-                          CornerRadius="4" />
+                          CornerRadius="4"
+                          AutomationProperties.AutomationId="ElementsList" />
                             </Grid>
                         </Grid>
 
@@ -404,7 +452,8 @@
                      Text="{x:Bind BeatSheetsVm.SelectedBeatDescription, Mode=TwoWay}"
                      TextWrapping="Wrap"
                      HorizontalAlignment="Stretch"
-                     VerticalAlignment="Stretch" />
+                     VerticalAlignment="Stretch"
+                     AutomationProperties.AutomationId="BeatDescriptionTextBox" />
 
                             <!-- Element Description -->
                             <usercontrols:RichEditBoxExtended Grid.Column="1"
@@ -413,7 +462,8 @@
                                      IsReadOnly="True"
                                      TextWrapping="Wrap"
                                      HorizontalAlignment="Stretch"
-                                     VerticalAlignment="Stretch" />
+                                     VerticalAlignment="Stretch"
+                                     AutomationProperties.AutomationId="ElementDescriptionRichEdit" />
                         </Grid>
                     </Grid>
                 </TabViewItem>
@@ -421,7 +471,8 @@
 
                 <TabViewItem Header="Notes" IsClosable="False"
                              HorizontalContentAlignment="Stretch"
-                             VerticalContentAlignment="Stretch">
+                             VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="ProblemNotesTab">
                     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="*"/>
@@ -433,6 +484,7 @@
                                                       IsSpellCheckEnabled="True"
                                                       TextWrapping="Wrap"
                                                       VerticalAlignment="Stretch"
+                                                      AutomationProperties.AutomationId="ProblemNotesRichEdit"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
                     </Grid>
                 </TabViewItem>

--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -547,6 +547,7 @@
                                         </Grid.RowDefinitions>
 
                                         <!-- Shows the root node out of tree, prevents creating new roots. -->
+                                        <!-- Accessible name must bind inline here: WinUI 3 silently ignores bindings in Style Setters (Setter.Value docs; unoplatform/uno#4826). -->
                                         <TreeViewItem Tapped="RootClick" RightTapped="TreeViewItem_RightTapped"
                                                       HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
                                                       Background="Transparent" BorderBrush="Transparent"
@@ -573,6 +574,7 @@
 
                                             <muxc:TreeView.ItemTemplate>
                                                 <DataTemplate x:DataType="viewmodels:StoryNodeItem">
+                                                    <!-- Accessible name must bind inline here: WinUI 3 silently ignores bindings in Style Setters (Setter.Value docs; unoplatform/uno#4826). -->
                                                     <muxc:TreeViewItem ItemsSource="{x:Bind Children}"
                                                                        Background="{x:Bind Background, Mode=OneWay}"
                                                                        BorderBrush="{x:Bind boarderBrush, Mode=OneWay}"
@@ -608,6 +610,7 @@
                                        AutomationProperties.AutomationId="TrashTree">
                             <muxc:TreeView.ItemTemplate>
                                 <DataTemplate x:DataType="viewmodels:StoryNodeItem">
+                                    <!-- Accessible name must bind inline here: WinUI 3 silently ignores bindings in Style Setters (Setter.Value docs; unoplatform/uno#4826). -->
                                     <muxc:TreeViewItem ItemsSource="{x:Bind Children}"
                                                        RightTapped="TreeViewItem_RightTapped"
                                                        IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}"

--- a/StoryCADTests/Xaml/AutomationConventionTests.cs
+++ b/StoryCADTests/Xaml/AutomationConventionTests.cs
@@ -43,7 +43,7 @@ public class AutomationConventionTests
     private static readonly HashSet<string> InteractiveElementNames = new()
     {
         "Button", "AppBarButton", "HyperlinkButton", "MenuFlyoutItem", "MenuFlyoutSubItem",
-        "ComboBox", "TextBox", "CheckBox", "RadioButton", "ToggleSwitch", "NumberBox",
+        "ComboBox", "TextBox", "CheckBox", "RadioButton", "RadioButtons", "ToggleSwitch", "NumberBox",
         "AutoSuggestBox", "TabView", "TabViewItem", "TreeView", "ListView", "GridView",
         "Flyout", "RichEditBoxExtended", "BrowseTextBox",
     };
@@ -55,7 +55,8 @@ public class AutomationConventionTests
     ///     standing in for a TreeView because the real nested TreeView is templated);
     ///     "BrowseTextBox", "RadioButton", and "ToggleSwitch" fill gaps in the convention's
     ///     original suffix table (the test spec's interactive-element list includes all three,
-    ///     but the original table did not).
+    ///     but the original table did not). "RadioButtons" (the WinUI group control) was added
+    ///     in Unit 2 for ProblemPage's Elements source selector.
     /// </summary>
     private static readonly Dictionary<string, string> SuffixByElementName = new()
     {
@@ -69,6 +70,7 @@ public class AutomationConventionTests
         ["RichEditBoxExtended"] = "RichEdit",
         ["CheckBox"] = "Check",
         ["RadioButton"] = "Radio",   // added Unit 1: gap in original convention suffix table, see class remarks
+        ["RadioButtons"] = "Radios", // added Unit 2: RadioButtons group is an items host generating focusable children
         ["ToggleSwitch"] = "Toggle", // added Unit 1: gap in original convention suffix table, see class remarks
         ["NumberBox"] = "NumberBox",
         ["AutoSuggestBox"] = "SearchBox",

--- a/StoryCADTests/Xaml/AutomationConventionTests.cs
+++ b/StoryCADTests/Xaml/AutomationConventionTests.cs
@@ -351,4 +351,40 @@ public class AutomationConventionTests
         Assert.IsTrue(violations.Count == 0,
             $"{violations.Count} namespaced AutomationProperties attribute(s):\n{string.Join("\n", violations)}");
     }
+
+    /// <summary>
+    ///     No Style Setter may target an AutomationProperties.* property, in any scope file,
+    ///     whatever the Value. The Windows Runtime does not evaluate bindings in Setter.Value
+    ///     (Setter class docs; unoplatform/uno#4826), so a bound Name silently never gets set;
+    ///     a literal Value would name every realized item identically. Both are always wrong:
+    ///     bind Name inline on the template element instead.
+    /// </summary>
+    [TestMethod]
+    public void SetterSafety_AllFiles_NoAutomationPropertiesInStyleSetters()
+    {
+        var violations = new List<string>();
+
+        foreach (var relPath in ScopeFiles())
+        {
+            var doc = LoadXaml(relPath);
+            foreach (var element in doc.Descendants())
+            {
+                if (element.Name.LocalName != "Setter")
+                {
+                    continue;
+                }
+
+                var property = element.Attributes()
+                    .FirstOrDefault(a => a.Name.LocalName == "Property")
+                    ?.Value;
+                if (property != null && property.StartsWith("AutomationProperties.", StringComparison.Ordinal))
+                {
+                    violations.Add($"{relPath}:{LineOf(element)} <Setter Property=\"{property}\"> sets AutomationProperties via a Style Setter (bindings in Setter.Value are never evaluated; a literal names every item identically)");
+                }
+            }
+        }
+
+        Assert.IsTrue(violations.Count == 0,
+            $"{violations.Count} AutomationProperties Style Setter(s):\n{string.Join("\n", violations)}");
+    }
 }

--- a/StoryCADTests/Xaml/AutomationConventionTests.cs
+++ b/StoryCADTests/Xaml/AutomationConventionTests.cs
@@ -22,6 +22,8 @@ public class AutomationConventionTests
     {
         "StoryCAD/Views/Shell.xaml",
         "StoryCAD/Views/OverviewPage.xaml",
+        "StoryCAD/Views/ProblemPage.xaml",
+        "StoryCAD/Views/CharacterPage.xaml",
     };
 
     /// <summary>

--- a/devdocs/automation_naming_convention.md
+++ b/devdocs/automation_naming_convention.md
@@ -29,6 +29,7 @@ Every interactive control gets `AutomationProperties.AutomationId`.
 | GridView | `GridView` | `ImagesGridView` *(plan-stage addition; needed for `ImageGalleryControl`)* |
 | Flyout | `Flyout` | `EmptyTrashFlyout` |
 | RadioButton | `Radio` | *(added Unit 1)* |
+| RadioButtons | `Radios` | `StructureElementsRadios` *(added Unit 2)* |
 | ToggleSwitch | `Toggle` | *(added Unit 1)* |
 | BrowseTextBox | `TextBox` | *(added Unit 1)* |
 | ItemsRepeater | `Tree` | `NavigationTree` *(added Unit 1; exists for the Shell navigation tree stand-in; revisit if a non-tree ItemsRepeater ever needs annotation)* |

--- a/devdocs/automation_naming_convention.md
+++ b/devdocs/automation_naming_convention.md
@@ -57,6 +57,7 @@ Every interactive control gets `AutomationProperties.AutomationId`.
 - Never put AutomationId inside a `DataTemplate`; every realized item would report the same id. The scan test enforces this across all files from day one.
 - Annotate the items control itself (`NavigationTree`, `TrashTree`, `ElementsList`, `ImagesGridView`).
 - Inside templates, bind `AutomationProperties.Name` to the item's display property (`{x:Bind Name}`) so each realized item is announced. Tests locate items by container AutomationId plus item Name.
+- Bind Name inline on the template element itself, never via an `ItemContainerStyle`/Style `Setter`: the Windows Runtime does not evaluate bindings in `Setter.Value`, so the name silently never gets set (no error, no warning). *(added Unit 2)*
 - Static TabViewItems are not templated; each gets a `Tab`-suffixed AutomationId.
 - A composite user control (`Traits`, `RelationshipView`, `Conflict`, `Flaw`, `BrowseTextBox`, `ImageGalleryControl`) carries AutomationIds on its internal controls. If a composite is ever instantiated inside a repeater, treat it like a DataTemplate: internal ids stay, tests scope by the repeating parent's id plus a bound Name.
 

--- a/devdocs/issue_1420_implementation_plan.md
+++ b/devdocs/issue_1420_implementation_plan.md
@@ -7,6 +7,7 @@ Written 2026-07-03 for founder review. Executes the design approved 2026-07-03 (
 - Base branch is `dev`. Every unit branches from current `dev` as `issue-1420-batch{N}-{slug}` and PRs back to `dev`.
 - Diffs are XAML attributes plus test code only. No behavior, logic, layout, or ViewModel changes. If a unit surfaces a code problem (for example an MVVM gap in a dialog), file a new issue; do not fix it in the batch PR.
 - The convention document is law. Where it is silent, propose the resolution in the PR description rather than inventing silently.
+- Where an annotation exists in a particular form because of a non-obvious platform constraint, put a one-line comment at the code site stating the constraint; the convention doc carries the full rule.
 - Every unit ends with: solution builds, full test suite green, Accessibility Insights FastPass on the touched views recorded in the PR description.
 
 ### Build and test commands (Windows, PowerShell)

--- a/devdocs/issue_1420_implementation_plan.md
+++ b/devdocs/issue_1420_implementation_plan.md
@@ -84,7 +84,7 @@ Same cycle every time: branch from `dev`; extend `AnnotatedFiles` (red); annotat
 
 ### Optional spike (time-boxed, alongside Unit 2): scripted scans
 
-Accessibility Insights' scan engine ships separately as Axe.Windows with a CLI (`AxeWindowsCLI`, NuGet). A script that launches StoryCAD, scans the process, and emits results would automate the recurring per-batch bar; manual FastPass stays authoritative per the approved design, and the audit under umbrella #1441 stays manual regardless. If the spike works in under a session, add `devdocs/tools/axe_scan.ps1` and use it from Unit 3 on; if not, drop it without ceremony.
+Accessibility Insights' scan engine ships separately as Axe.Windows with a CLI (`AxeWindowsCLI`, distributed as an MSI installer or self-contained zip from the microsoft/axe-windows GitHub releases, not as a NuGet dotnet tool; spike confirmed v2.4.2 of both). A script that launches StoryCAD, scans the process, and emits results would automate the recurring per-batch bar; manual FastPass stays authoritative per the approved design, and the audit under umbrella #1441 stays manual regardless. If the spike works in under a session, add `devdocs/tools/axe_scan.ps1` and use it from Unit 3 on; if not, drop it without ceremony.
 
 ## Naming decision procedure (for the implementing agent)
 


### PR DESCRIPTION
Unit 2 of the #1420 annotation pass: ProblemPage and CharacterPage, per `devdocs/issue_1420_implementation_plan.md`. Six files: the two views, the convention tests, both devdocs, and three comment lines in Shell.xaml (disclosed below).

## What's in the diff

- **104 AutomationIds + 1**: ProblemPage 43 (42 interactive controls + the `StructureElementsRadios` group added during review), CharacterPage 62.
- **12 accessible Names**: seven icon-only beat-sheet buttons (named by function from their tooltips), the header-less `BeatSheetCombo` ("Beat Sheet"), the `RadioButtons` group ("Elements"), add/remove trait buttons, and one `{x:Bind Title}` binding on the beat template root so each beat row announces its title.
- **Convention tests grow to seven**: the ratchet now covers four files, and a new `SetterSafety` test fails any `<Setter Property="AutomationProperties.*">` in scope — see the review finding below.

## TDD and verification

Red phase: 104 violations (ProblemPage 42, CharacterPage 62), plus a one-failure red interlude when `RadioButtons` joined the interactive set. Green: 7/7 convention tests. Full suite: **1,136 tests, 0 failed** (up one for the new test). Build clean.

## Review round trip

Independent agent review returned request-changes; both blockers are fixed in `fcf2fac8`/`153f9a13`:

1. **Style-Setter binding no-op.** The beat-row accessible name was first bound via an `ItemContainerStyle` Setter — legal-looking XAML that WinUI 3 silently never evaluates (Setter.Value docs; unoplatform/uno#4826). Every beat row would have announced nothing, invisible to static tests. Fixed with an inline template binding; the constraint now has a one-line comment at all four template-binding sites (this page + Shell's three tree templates — the three Shell comment lines are the only Shell diff), a convention-doc bullet, and the `SetterSafety` test so the pattern can't return.
2. **Five cross-page collisions.** `ProtagonistCombo`, `ProtagonistGoalCombo`, `AntagonistCombo`, `AntagonistGoalCombo`, `OutcomeCombo` collide with identical ScenePage headers arriving in Unit 3; all now `Problem`-prefixed. Grep confirmed the rest of the Protagonist/Antagonist family has no colliders in scope and stays bare.

Diff purity was mechanically verified by the reviewer (attribute-strip + `XNode.DeepEquals` = identical to base; zero x:Name changes) before the fix commits; fix commits follow the same rules.

## Disclosures

- `AssignBeatButton`/`UnassignBeatButton` intentionally diverge from their `x:Name`s (`AssignButton`/`UnassignButton`): not collision-forced, chosen for descriptive parity with `AddBeatButton`/`DeleteBeatButton`. The verbatim-reuse default was knowingly not applied to these two.
- Convention doc gains the `RadioButtons → Radios` suffix row "(added Unit 2)" and the inline-template-binding rule.
- Plan doc corrections: AxeWindowsCLI ships as MSI/zip from GitHub releases, not NuGet (spike #1445 finding); new ground-rule line — non-obvious platform constraints get a one-line comment at the code site.
- Pre-existing findings during this unit: the "Adventureousness" trait misspelling is filed as #1446 (the derived `AdventureousnessCombo` id follows the label verbatim and renames with the fix); the shared Conflict Builder command was verified as by-design (the dialog itself offers Copy to Protagonist/Antagonist).

## Pre-merge GUI verification (needs the running app)

- [x] **FastPass** ProblemPage and CharacterPage; record finding counts here. Pass bar: zero missing-name findings on annotated controls.
- [x] **Beat rows announce their titles** (Accessibility Insights Inspect or Narrator on the Structure tab's beat list) — this is the exact failure mode the Setter bug would have caused and static tests cannot see.
- [x] Reminder: the Unit 1 header-exposure check (`RichEditBoxExtended`/`BrowseTextBox` in Inspect) is still unrecorded from #1443; the five OverviewPage RichEdit Names and the ProblemPage/CharacterPage RichEdit Names all stay deferred until it's done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
