### PR TITLE
#1420 Unit 7: annotate PreferencesDialog + PrintReportsDialog; per-instance BrowseTextBox ids

### DIFF
--- a/StoryCADLib/Controls/BrowseTextBox.xaml
+++ b/StoryCADLib/Controls/BrowseTextBox.xaml
@@ -3,13 +3,15 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <!-- BrowseTextBox is instantiated at multiple call sites app-wide (PreferencesInitialization,
-         PreferencesDialog, SaveAsDialog, BackupNow). The ids below are declared once here and reused
-         verbatim from the existing x:Name values per convention rule 4, but every instance shares
-         the same literal id at runtime since a UserControl has no per-instance identity to bind
-         from without a new bindable property (out of scope: attribute-only diff). Callers that place
-         more than one BrowseTextBox on the same screen must give the outer <BrowseTextBox> tag its
-         own AutomationId/Name (see PreferencesInitialization.xaml) to stay distinguishable. -->
+    <!-- BrowseTextBox is instantiated at six call sites app-wide (PreferencesInitialization x2,
+         PreferencesDialog x2, SaveAsDialog, BackupNow). The literal ids below satisfy the Coverage
+         test (non-empty literal AutomationId required in XAML) and the Literalness test (no "{",
+         so an x:Bind here is not an option), but every instance would otherwise share the same
+         two ids at runtime, which is not unique in the UIA tree. Fixed in Unit 7 (#1420):
+         BrowseTextBox.xaml.cs reads the outer control's own AutomationId (set per call site; every
+         call site already carries one) once Loaded, and if non-empty, overrides these two literal
+         ids with ones derived from it ({outerId}PathTextBox / {outerId}BrowseButton), which keeps
+         the required role suffix at the end while making every instance's internal ids unique. -->
     <StackPanel Orientation="Horizontal">
         <TextBox
             x:Name="PathTextBox"

--- a/StoryCADLib/Controls/BrowseTextBox.xaml.cs
+++ b/StoryCADLib/Controls/BrowseTextBox.xaml.cs
@@ -1,3 +1,4 @@
+using Microsoft.UI.Xaml.Automation;
 using Windows.Storage.Pickers;
 using WinRT.Interop;
 
@@ -34,6 +35,20 @@ public sealed partial class BrowseTextBox : UserControl
     public BrowseTextBox()
     {
         InitializeComponent();
+
+        // Per-instance internal ids (issue #1420, Unit 7): the outer AutomationId isn't applied
+        // by the host XAML until after this constructor returns, so read it on Loaded rather than
+        // here. Every call site sets one (Coverage test requires it), so PathTextBox/BrowseButton's
+        // shared literal ids get overridden with ids unique to this instance.
+        Loaded += (_, _) =>
+        {
+            var outerId = AutomationProperties.GetAutomationId(this);
+            if (!string.IsNullOrEmpty(outerId))
+            {
+                AutomationProperties.SetAutomationId(PathTextBox, outerId + "PathTextBox");
+                AutomationProperties.SetAutomationId(BrowseButton, outerId + "BrowseButton");
+            }
+        };
     }
 
     public string Path

--- a/StoryCADLib/Services/Dialogs/FeedbackDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/FeedbackDialog.xaml
@@ -23,7 +23,8 @@
         <InfoBar Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
                  Severity="Informational" HorizontalAlignment="Stretch"
                  Title="Detailed feedback is addressed quicker"
-                 IsOpen="True" IsClosable="False" Margin="10,0,10,10" />
+                 IsOpen="True" IsClosable="False" Margin="10,0,10,10"
+                 AutomationProperties.AutomationId="FeedbackTipInfoBar" />
 
         <TextBox Grid.Row="1" Grid.Column="1" Header="Issue Title"
                  Margin="10,0,0,0"

--- a/StoryCADLib/Services/Dialogs/FileOpenMenu.xaml
+++ b/StoryCADLib/Services/Dialogs/FileOpenMenu.xaml
@@ -83,7 +83,8 @@
 
             <InfoBar Grid.Row="1" IsOpen="{x:Bind FileOpenVM.ShowWarning, Mode=TwoWay}" Severity="Warning"
                      IsClosable="False"
-                     Message="{x:Bind FileOpenVM.WarningText, Mode=TwoWay}" HorizontalAlignment="Center" />
+                     Message="{x:Bind FileOpenVM.WarningText, Mode=TwoWay}" HorizontalAlignment="Center"
+                     AutomationProperties.AutomationId="FileOpenWarningInfoBar" />
 
             <ScrollView Grid.Row="2" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Auto" BorderThickness="0" Background="Transparent">
                 <Grid Background="Transparent" BorderThickness="0">

--- a/StoryCADLib/Services/Dialogs/HelpPage.xaml
+++ b/StoryCADLib/Services/Dialogs/HelpPage.xaml
@@ -16,7 +16,8 @@
 
         <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
             <StackPanel>
-                <InfoBar Severity="Informational" IsOpen="True" IsClosable="False">
+                <InfoBar Severity="Informational" IsOpen="True" IsClosable="False"
+                         AutomationProperties.AutomationId="HelpVideoNoteInfoBar">
                     <TextBlock
                         Text="The videos below refer to StoryCAD as StoryBuilder,
 however are still a good place to get started"

--- a/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
@@ -209,9 +209,10 @@
                                      NavigateUri="https://github.com/StoryBuilder-org/StoryCAD/graphs/contributors"
                                      Margin="5" FontSize="13"
                                      AutomationProperties.AutomationId="PreferencesContributorsButton" />
-                    <!-- Content is bound but resolves to plain text at runtime, same as a literal
-                         Content value; reaches the UIA Name without an explicit Name (FeedbackDialog
-                         bound-Header precedent). -->
+                    <!-- No explicit Name, like the literal-Content PreferencesContributorsButton
+                         above: the OneTime-bound Content resolves to a plain string before the
+                         AutomationPeer reads it, so the framework derives the UIA Name the same
+                         way. Subject to live confirmation at founder review. -->
                     <HyperlinkButton Content="{x:Bind PreferencesVm.AppStoreReviewButtonText, Mode=OneTime}" HorizontalAlignment="Center"
                                      Click="{x:Bind PreferencesVm.ShowRatingPrompt}" Margin="5" FontSize="13"
                                      AutomationProperties.AutomationId="PreferencesAppStoreReviewButton" />

--- a/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml
@@ -6,31 +6,38 @@
 
     <StackPanel Width="500" Height="410">
         <TabView Name="PivotView" Height="381" Width="500" VerticalAlignment="Stretch"
-                 TabWidthMode="Equal" CanDragTabs="False" CanReorderTabs="False" IsAddTabButtonVisible="False">
+                 TabWidthMode="Equal" CanDragTabs="False" CanReorderTabs="False" IsAddTabButtonVisible="False"
+                 AutomationProperties.AutomationId="PreferencesTabs">
             <TabView.TabItems>
-                <TabViewItem Header="Account" IsClosable="False" VerticalContentAlignment="Stretch" VerticalAlignment="Center">
+                <TabViewItem Header="Account" IsClosable="False" VerticalContentAlignment="Stretch" VerticalAlignment="Center"
+                             AutomationProperties.AutomationId="PreferencesAccountTab">
                 <StackPanel>
                     <TextBox Header="Your first name:" PlaceholderText="Put the first name want to publish under here"
                              HorizontalAlignment="Center" Margin="8" Width="300"
-                             Text="{x:Bind PreferencesVm.FirstName, Mode=TwoWay}" />
+                             Text="{x:Bind PreferencesVm.FirstName, Mode=TwoWay}"
+                             AutomationProperties.AutomationId="PreferencesFirstNameTextBox" />
                     <TextBox Header="Your surname:" PlaceholderText="Put the surname want to publish under here"
                              HorizontalAlignment="Center" Margin="8" Width="300"
-                             Text="{x:Bind PreferencesVm.LastName, Mode=TwoWay}" />
+                             Text="{x:Bind PreferencesVm.LastName, Mode=TwoWay}"
+                             AutomationProperties.AutomationId="PreferencesLastNameTextBox" />
                     <TextBox Header="Your email:" PlaceholderText="Put your email here" Margin="8" Width="300"
-                             Text="{x:Bind PreferencesVm.Email, Mode=TwoWay}" />
+                             Text="{x:Bind PreferencesVm.Email, Mode=TwoWay}"
+                             AutomationProperties.AutomationId="PreferencesEmailTextBox" />
                     <Button Content="Delete My Data"
                             Foreground="Red"
                             HorizontalAlignment="Center"
-                            Margin="8,16,8,8">
+                            Margin="8,16,8,8"
+                            AutomationProperties.AutomationId="PreferencesDeleteMyDataButton">
                         <Button.Flyout>
-                            <Flyout>
+                            <Flyout AutomationProperties.AutomationId="PreferencesDeleteConfirmFlyout">
                                 <StackPanel MaxWidth="300" Spacing="8">
                                     <TextBlock TextWrapping="Wrap"
                                                Text="This will permanently delete your account, error reporting preferences, and version tracking history from our servers. Your local story files will NOT be deleted. This does not automatically remove you from our email list. To stop receiving product or marketing emails, use the 'Unsubscribe' link included in the footer of any email we send you. StoryCAD will close after deletion." />
                                     <Button Content="Yes, Delete My Data"
                                             Foreground="Red"
                                             HorizontalAlignment="Center"
-                                            Click="DeleteMyData_Confirmed" />
+                                            Click="DeleteMyData_Confirmed"
+                                            AutomationProperties.AutomationId="PreferencesConfirmDeleteButton" />
                                 </StackPanel>
                             </Flyout>
                         </Button.Flyout>
@@ -42,15 +49,19 @@
                                MaxWidth="300" />
                 </StackPanel>
                 </TabViewItem>
-                <TabViewItem Header="Save Locations" IsClosable="False" VerticalContentAlignment="Center" VerticalAlignment="Center">
+                <TabViewItem Header="Save Locations" IsClosable="False" VerticalContentAlignment="Center" VerticalAlignment="Center"
+                             AutomationProperties.AutomationId="PreferencesSaveLocationsTab">
                 <StackPanel>
+                    <!-- Header is set, so it reaches the internal TextBox's UIA Name (BackupNow/
+                         SaveAsDialog precedent); no explicit outer Name needed. -->
                     <controls:BrowseTextBox
                         HorizontalAlignment="Center"
                         Header="Project directory:"
                         PlaceholderText="Where do you want to store your stories?"
                         Path="{x:Bind PreferencesVm.ProjectDirectory, Mode=TwoWay}"
                         BrowseMode="Folder"
-                        PathSelected="OnProjectPathSelected" />
+                        PathSelected="OnProjectPathSelected"
+                        AutomationProperties.AutomationId="PreferencesProjectDirTextBox" />
                     <controls:BrowseTextBox
                         x:Name="BackupDirBrowse2"
                         HorizontalAlignment="Center"
@@ -58,38 +69,51 @@
                         PlaceholderText="Where do you want to store your backups?"
                         Path="{x:Bind PreferencesVm.BackupDirectory, Mode=TwoWay}"
                         BrowseMode="Folder"
-                        PathSelected="OnBackupPathSelected" />
+                        PathSelected="OnBackupPathSelected"
+                        AutomationProperties.AutomationId="PreferencesBackupDirTextBox" />
                 </StackPanel>
                 </TabViewItem>
-                <TabViewItem Header="Backup" IsClosable="False" VerticalAlignment="Stretch" VerticalContentAlignment="Center">
+                <TabViewItem Header="Backup" IsClosable="False" VerticalAlignment="Stretch" VerticalContentAlignment="Center"
+                             AutomationProperties.AutomationId="PreferencesBackupTab">
                 <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                     <StackPanel Orientation="Horizontal">
                         <CheckBox Content="Automatically Save every"
                                   IsChecked="{x:Bind PreferencesVm.AutoSave, Mode=TwoWay}" HorizontalAlignment="Left"
-                                  Margin="4" />
+                                  Margin="4"
+                                  AutomationProperties.AutomationId="PreferencesAutoSaveCheck" />
+                        <!-- PlaceholderText only, no Header: explicit Name required. -->
                         <NumberBox Minimum="15" Maximum="60" IsEnabled="{x:Bind PreferencesVm.AutoSave, Mode=TwoWay}"
                                    PlaceholderText="Enter a value (Seconds)" HorizontalAlignment="Left" Margin="8"
-                                   Value="{x:Bind PreferencesVm.AutoSaveInterval, Mode=TwoWay}" />
+                                   Value="{x:Bind PreferencesVm.AutoSaveInterval, Mode=TwoWay}"
+                                   AutomationProperties.AutomationId="PreferencesAutoSaveIntervalNumberBox"
+                                   AutomationProperties.Name="Autosave interval in seconds" />
                         <TextBlock Text="Seconds" VerticalAlignment="Center" HorizontalAlignment="Center" />
                     </StackPanel>
                     <CheckBox Content="Make a backup of the story when opened" Margin="4" HorizontalAlignment="Left"
-                              IsChecked="{x:Bind PreferencesVm.BackupOnOpen, Mode=TwoWay}" />
+                              IsChecked="{x:Bind PreferencesVm.BackupOnOpen, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="PreferencesBackupOnOpenCheck" />
                     <CheckBox Content="Make timed backups" Margin="4" HorizontalAlignment="Left"
-                              IsChecked="{x:Bind PreferencesVm.TimedBackup, Mode=TwoWay}" />
+                              IsChecked="{x:Bind PreferencesVm.TimedBackup, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="PreferencesTimedBackupCheck" />
                     <NumberBox Header="How often should backups be made? (Minutes)" Maximum="300" Minimum="1"
                                Margin="4" Width="300" HorizontalAlignment="Left"
-                               Value="{x:Bind PreferencesVm.TimedBackupInterval, Mode=TwoWay}" />
+                               Value="{x:Bind PreferencesVm.TimedBackupInterval, Mode=TwoWay}"
+                               AutomationProperties.AutomationId="PreferencesTimedBackupIntervalNumberBox" />
                 </StackPanel>
                 </TabViewItem>
-                <TabViewItem Header="Privacy" IsClosable="False" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
+                <TabViewItem Header="Privacy" IsClosable="False" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="PreferencesPrivacyTab">
                 <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                     <CheckBox Content="Send error logs" Margin="8"
                               HorizontalAlignment="Left"
-                              IsChecked="{x:Bind PreferencesVm.ErrorCollectionConsent, Mode=TwoWay}" />
+                              IsChecked="{x:Bind PreferencesVm.ErrorCollectionConsent, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="PreferencesErrorLogsCheck" />
                     <StackPanel Orientation="Horizontal" Margin="8"
                                 HorizontalAlignment="Left" VerticalAlignment="Center">
                         <CheckBox Content="Send anonymous usage statistics"
-                                  IsChecked="{x:Bind PreferencesVm.UsageStatsConsent, Mode=TwoWay}" />
+                                  IsChecked="{x:Bind PreferencesVm.UsageStatsConsent, Mode=TwoWay}"
+                                  AutomationProperties.AutomationId="PreferencesUsageStatsCheck" />
+                        <!-- Content is "?", not real label text: Name states the function. -->
                         <HyperlinkButton Content="?"
                                          Width="22" Height="22" MinWidth="22" MinHeight="22"
                                          Padding="0" FontSize="12"
@@ -99,17 +123,22 @@
                                          Margin="6,0,0,0"
                                          VerticalAlignment="Center"
                                          NavigateUri="{x:Bind PreferencesVm.UsageStatsHelpUrl, Mode=OneWay}"
-                                         ToolTipService.ToolTip="Learn what's collected" />
+                                         ToolTipService.ToolTip="Learn what's collected"
+                                         AutomationProperties.AutomationId="PreferencesUsageStatsInfoButton"
+                                         AutomationProperties.Name="Learn what's collected" />
                     </StackPanel>
                     <CheckBox Content="Send me StoryCAD newsletters" Margin="8"
                               HorizontalAlignment="Left"
-                              IsChecked="{x:Bind PreferencesVm.Newsletter, Mode=TwoWay}" />
+                              IsChecked="{x:Bind PreferencesVm.Newsletter, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="PreferencesNewsletterCheck" />
                     <CheckBox Content="Advanced logging" Margin="8"
                               HorizontalAlignment="Left"
-                              IsChecked="{x:Bind PreferencesVm.AdvancedLogging, Mode=TwoWay}" />
+                              IsChecked="{x:Bind PreferencesVm.AdvancedLogging, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="PreferencesAdvancedLoggingCheck" />
                 </StackPanel>
                 </TabViewItem>
-                <TabViewItem Header="Other" IsClosable="False" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
+                <TabViewItem Header="Other" IsClosable="False" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch"
+                             AutomationProperties.AutomationId="PreferencesOtherTab">
                 <Grid HorizontalAlignment="Center">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -125,27 +154,33 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <CheckBox Grid.Row="0" Grid.Column="0" Content="Wrap node names" Margin="8"
-                              HorizontalAlignment="Left" Click="ToggleWrapping" Name="TextWrap" />
+                              HorizontalAlignment="Left" Click="ToggleWrapping" Name="TextWrap"
+                              AutomationProperties.AutomationId="PreferencesWrapNodeNamesCheck" />
                     <CheckBox Grid.Row="0" Grid.Column="1" Content="Show startup page" Margin="8"
                               HorizontalAlignment="Left"
-                              IsChecked="{x:Bind PreferencesVm.ShowStartupPage, Mode=TwoWay}" />
+                              IsChecked="{x:Bind PreferencesVm.ShowStartupPage, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="PreferencesShowStartupPageCheck" />
                     <CheckBox Grid.Row="1" Grid.Column="0" Content="Show file picker on startup" Margin="8"
                               HorizontalAlignment="Left"
-                              IsChecked="{x:Bind PreferencesVm.ShowFilePickerOnStartup, Mode=TwoWay}" />
+                              IsChecked="{x:Bind PreferencesVm.ShowFilePickerOnStartup, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="PreferencesShowFilePickerCheck" />
                     <CheckBox Grid.Row="1" Grid.Column="1" Content="Use beta documentation" Margin="8"
                               HorizontalAlignment="Left"
-                              IsChecked="{x:Bind PreferencesVm.UseBetaDocumentation, Mode=TwoWay}" />
+                              IsChecked="{x:Bind PreferencesVm.UseBetaDocumentation, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="PreferencesUseBetaDocsCheck" />
 
                     <CheckBox Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Center"
                               Content="Hide in-window toolbar"
                               ToolTipService.ToolTip="Hides the in-window search and menu buttons; use the native macOS menu bar instead. Takes effect on next launch."
                               Margin="8"
                               Visibility="{x:Bind PreferencesVm.MacOnlyVisibility}"
-                              IsChecked="{x:Bind PreferencesVm.HideShellCommandBarOnMac, Mode=TwoWay}" />
+                              IsChecked="{x:Bind PreferencesVm.HideShellCommandBarOnMac, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="PreferencesHideToolbarCheck" />
 
                     <ComboBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="5" Width="300"
                               Header="Preferred Theme" HorizontalAlignment="Stretch"
-                              SelectedIndex="{x:Bind PreferencesVm.PreferredThemeIndex, Mode=TwoWay}" Margin="8">
+                              SelectedIndex="{x:Bind PreferencesVm.PreferredThemeIndex, Mode=TwoWay}" Margin="8"
+                              AutomationProperties.AutomationId="PreferencesThemeCombo">
                         <ComboBoxItem Content="Use system theme" />
                         <ComboBoxItem Content="Light Theme" />
                         <ComboBoxItem Content="Dark Theme" />
@@ -153,7 +188,8 @@
                     <ComboBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="6" Width="300"
                               Header="Preferred Search Engine" HorizontalAlignment="Stretch"
                               Name="SearchEngine" SelectedIndex="{x:Bind PreferencesVm.SearchEngineIndex, Mode=TwoWay}"
-                              Margin="0,4,0,0">
+                              Margin="0,4,0,0"
+                              AutomationProperties.AutomationId="PreferencesSearchEngineCombo">
                         <ComboBoxItem Content="DuckDuckGo" />
                         <ComboBoxItem Content="Google" />
                         <ComboBoxItem Content="Bing" />
@@ -161,56 +197,78 @@
                     </ComboBox>
                 </Grid>
                 </TabViewItem>
-                <TabViewItem Header="About" IsClosable="False" VerticalContentAlignment="Center" VerticalAlignment="Stretch">
+                <TabViewItem Header="About" IsClosable="False" VerticalContentAlignment="Center" VerticalAlignment="Stretch"
+                             AutomationProperties.AutomationId="PreferencesAboutTab">
                 <StackPanel>
                     <TextBlock HorizontalAlignment="Center" Margin="5,0,0,20" Text="{x:Bind State.Version}" />
                     <Button Content="Open Logs folder" HorizontalAlignment="Center" Click="OpenLogFolder" Margin="20"
-                            Width="200" />
+                            Width="200"
+                            AutomationProperties.AutomationId="PreferencesOpenLogsButton" />
                     <HyperlinkButton Content="StoryCAD was created by Terry Cox, Jake Shaw and Contributors"
                                      HorizontalAlignment="Center"
                                      NavigateUri="https://github.com/StoryBuilder-org/StoryCAD/graphs/contributors"
-                                     Margin="5" FontSize="13" />
+                                     Margin="5" FontSize="13"
+                                     AutomationProperties.AutomationId="PreferencesContributorsButton" />
+                    <!-- Content is bound but resolves to plain text at runtime, same as a literal
+                         Content value; reaches the UIA Name without an explicit Name (FeedbackDialog
+                         bound-Header precedent). -->
                     <HyperlinkButton Content="{x:Bind PreferencesVm.AppStoreReviewButtonText, Mode=OneTime}" HorizontalAlignment="Center"
-                                     Click="{x:Bind PreferencesVm.ShowRatingPrompt}" Margin="5" FontSize="13" />
+                                     Click="{x:Bind PreferencesVm.ShowRatingPrompt}" Margin="5" FontSize="13"
+                                     AutomationProperties.AutomationId="PreferencesAppStoreReviewButton" />
                     <TextBlock Text="Keep up with StoryCAD news:" Margin="0,10" />
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Discord">
+                        <!-- Image-only Content, no text at all: explicit Name states the function. -->
+                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Discord"
+                                AutomationProperties.AutomationId="PreferencesDiscordButton"
+                                AutomationProperties.Name="Discord">
                             <Button.Content>
                                 <Image Source="/Assets/Icons/DiscordIcon.png" />
                             </Button.Content>
                         </Button>
 
-                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="FaceBook">
+                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="FaceBook"
+                                AutomationProperties.AutomationId="PreferencesFacebookButton"
+                                AutomationProperties.Name="Facebook">
                             <Button.Content>
                                 <Image Source="/Assets/Icons/FaceBookIcon.png" />
                             </Button.Content>
                         </Button>
 
-                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Twitter">
+                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Twitter"
+                                AutomationProperties.AutomationId="PreferencesTwitterButton"
+                                AutomationProperties.Name="Twitter">
                             <Button.Content>
                                 <Image Source="/Assets/Icons/TwitterIcon.png" />
                             </Button.Content>
                         </Button>
 
-                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Youtube">
+                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Youtube"
+                                AutomationProperties.AutomationId="PreferencesYoutubeButton"
+                                AutomationProperties.Name="YouTube">
                             <Button.Content>
                                 <Image Source="/Assets/Icons/YoutubeIcon.png" />
                             </Button.Content>
                         </Button>
 
-                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Mail">
+                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Mail"
+                                AutomationProperties.AutomationId="PreferencesEmailButton"
+                                AutomationProperties.Name="Email">
                             <Button.Content>
                                 <Image Source="/Assets/Icons/BootstrapEmailIcon.png" />
                             </Button.Content>
                         </Button>
 
-                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Github">
+                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Github"
+                                AutomationProperties.AutomationId="PreferencesGithubButton"
+                                AutomationProperties.Name="GitHub">
                             <Button.Content>
                                 <Image Source="/Assets/Icons/GithubIcon.png" />
                             </Button.Content>
                         </Button>
 
-                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Website">
+                        <Button Width="50" Height="50" Margin="5" Click="OpenURL" Tag="Website"
+                                AutomationProperties.AutomationId="PreferencesWebsiteButton"
+                                AutomationProperties.Name="Website">
                             <Button.Content>
                                 <Image Source="/Assets/Logo.png" />
                             </Button.Content>
@@ -218,21 +276,28 @@
                     </StackPanel>
                 </StackPanel>
                 </TabViewItem>
-                <TabViewItem Header="What's new" IsClosable="False">
+                <TabViewItem Header="What's new" IsClosable="False"
+                             AutomationProperties.AutomationId="PreferencesWhatsNewTab">
                 <ScrollViewer VerticalScrollBarVisibility="Visible" Height="450">
                     <TextBlock Name="Changelog" TextWrapping="Wrap" />
                 </ScrollViewer>
                 </TabViewItem>
-                <TabViewItem Header="Dev" Name="Dev" IsClosable="False">
+                <TabViewItem Header="Dev" Name="Dev" IsClosable="False"
+                             AutomationProperties.AutomationId="PreferencesDevTab">
                 <StackPanel Orientation="Horizontal">
                     <StackPanel>
-                        <Button Content="Set Init to false" Click="SetInitToFalse" Width="150" Margin="0,5" />
-                        <Button Content="Throw exception" Click="ThrowException" Width="150" Margin="0,5" />
-                        <Button Content="Attach Elmah" Click="{x:Bind Logger.AddElmahTarget}" Width="150" Margin="0,5" />
-                        <Button Content="Refresh Dev Stats" Click="RefreshDevStats" Width="150" Margin="0,5" />
+                        <Button Content="Set Init to false" Click="SetInitToFalse" Width="150" Margin="0,5"
+                                AutomationProperties.AutomationId="PreferencesSetInitFalseButton" />
+                        <Button Content="Throw exception" Click="ThrowException" Width="150" Margin="0,5"
+                                AutomationProperties.AutomationId="PreferencesThrowExceptionButton" />
+                        <Button Content="Attach Elmah" Click="{x:Bind Logger.AddElmahTarget}" Width="150" Margin="0,5"
+                                AutomationProperties.AutomationId="PreferencesAttachElmahButton" />
+                        <Button Content="Refresh Dev Stats" Click="RefreshDevStats" Width="150" Margin="0,5"
+                                AutomationProperties.AutomationId="PreferencesRefreshDevStatsButton" />
                         <CheckBox Content="Hide key file warning"
                                   IsChecked="{x:Bind PreferencesVm.HideKeyFileWarning, Mode=TwoWay}"
-                                  Width="150" Margin="0,5" />
+                                  Width="150" Margin="0,5"
+                                  AutomationProperties.AutomationId="PreferencesHideKeyWarningCheck" />
                     </StackPanel>
                     <ScrollViewer MaxHeight="400">
                         <StackPanel>

--- a/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml
@@ -21,75 +21,106 @@
             <TextBlock Text="Create reports for the following:" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
                        Margin="0,0,0,10" />
             <CheckBox Content="Story Overview" Grid.Column="0" Grid.Row="1"
-                      IsChecked="{x:Bind PrintVM.CreateOverview, Mode=TwoWay}" />
+                      IsChecked="{x:Bind PrintVM.CreateOverview, Mode=TwoWay}"
+                      AutomationProperties.AutomationId="PrintReportsOverviewCheck" />
             <CheckBox Content="Story Problem Structure" Grid.Row="1" Grid.Column="1" Margin="20,0,0,0"
-                      IsChecked="{x:Bind PrintVM.CreateStructure, Mode=TwoWay}" />
+                      IsChecked="{x:Bind PrintVM.CreateStructure, Mode=TwoWay}"
+                      AutomationProperties.AutomationId="PrintReportsStructureCheck" />
             <CheckBox Content="Story Synopsis" Grid.Column="0" Grid.Row="2" Margin="0,5,0,0"
-                      IsChecked="{x:Bind PrintVM.CreateSummary, Mode=TwoWay}" Checked="EmptySynopsisWarningCheck" />
+                      IsChecked="{x:Bind PrintVM.CreateSummary, Mode=TwoWay}" Checked="EmptySynopsisWarningCheck"
+                      AutomationProperties.AutomationId="PrintReportsSynopsisCheck" />
             <CheckBox Content="Story World" Grid.Row="2" Grid.Column="1" Margin="20,5,0,0"
-                      IsChecked="{x:Bind PrintVM.CreateStoryWorld, Mode=TwoWay}" />
+                      IsChecked="{x:Bind PrintVM.CreateStoryWorld, Mode=TwoWay}"
+                      AutomationProperties.AutomationId="PrintReportsStoryWorldCheck" />
             <CheckBox Content="Character Relationships" Grid.Column="0" Grid.Row="3" Margin="0,5,0,0"
-                      IsChecked="{x:Bind PrintVM.CreateRelationships, Mode=TwoWay}" />
+                      IsChecked="{x:Bind PrintVM.CreateRelationships, Mode=TwoWay}"
+                      AutomationProperties.AutomationId="PrintReportsRelationshipsCheck" />
             <CheckBox Content="Include Images Appendix" Grid.Row="3" Grid.Column="1" Margin="20,5,0,0"
-                      IsChecked="{x:Bind PrintVM.IncludeImagesAppendix, Mode=TwoWay}" />
+                      IsChecked="{x:Bind PrintVM.IncludeImagesAppendix, Mode=TwoWay}"
+                      AutomationProperties.AutomationId="PrintReportsImagesAppendixCheck" />
         </Grid>
 
 
-        <TabView TabWidthMode="Equal" CanDragTabs="False" CanReorderTabs="False" IsAddTabButtonVisible="False">
+        <TabView TabWidthMode="Equal" CanDragTabs="False" CanReorderTabs="False" IsAddTabButtonVisible="False"
+                 AutomationProperties.AutomationId="PrintReportsTabs">
             <TabView.TabItems>
-                <TabViewItem Header="Problems" IsClosable="False" TabIndex="0">
+                <TabViewItem Header="Problems" IsClosable="False" TabIndex="0"
+                             AutomationProperties.AutomationId="PrintReportsProblemsTab">
                 <StackPanel>
                     <CheckBox Content="Print a list of all Problems"
-                              IsChecked="{x:Bind PrintVM.ProblemList, Mode=TwoWay}" />
+                              IsChecked="{x:Bind PrintVM.ProblemList, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="PrintReportsProblemListCheck" />
                     <CheckBox Content="Print all problems" IsChecked="{x:Bind PrintVM.SelectAllProblems,Mode=TwoWay}"
-                              Click="CheckboxClicked" />
+                              Click="CheckboxClicked"
+                              AutomationProperties.AutomationId="PrintReportsSelectAllProblemsCheck" />
                     <ListView SelectionMode="Multiple" Height="260" Name="ProblemsList"
                               ItemsSource="{x:Bind PrintVM.ProblemNodes, Mode=TwoWay}"
-                              SelectionChanged="UpdateSelection" />
+                              SelectionChanged="UpdateSelection"
+                              AutomationProperties.AutomationId="PrintReportsProblemsList" />
                 </StackPanel>
                 </TabViewItem>
-                <TabViewItem Header="Characters" IsClosable="False">
+                <TabViewItem Header="Characters" IsClosable="False"
+                             AutomationProperties.AutomationId="PrintReportsCharactersTab">
                 <StackPanel>
                     <CheckBox Content="Print a list of all Characters"
-                              IsChecked="{x:Bind PrintVM.CharacterList, Mode=TwoWay}" />
+                              IsChecked="{x:Bind PrintVM.CharacterList, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="PrintReportsCharacterListCheck" />
                     <CheckBox Content="Print all characters"
-                              IsChecked="{x:Bind PrintVM.SelectAllCharacters,Mode=TwoWay}" Click="CheckboxClicked" />
+                              IsChecked="{x:Bind PrintVM.SelectAllCharacters,Mode=TwoWay}" Click="CheckboxClicked"
+                              AutomationProperties.AutomationId="PrintReportsSelectAllCharactersCheck" />
                     <ListView SelectionMode="Multiple" Height="260" Name="CharactersList"
                               ItemsSource="{x:Bind PrintVM.CharacterNodes, Mode=TwoWay}"
-                              SelectionChanged="UpdateSelection" />
+                              SelectionChanged="UpdateSelection"
+                              AutomationProperties.AutomationId="PrintReportsCharactersList" />
                 </StackPanel>
                 </TabViewItem>
-                <TabViewItem Header="Scenes" IsClosable="False">
+                <TabViewItem Header="Scenes" IsClosable="False"
+                             AutomationProperties.AutomationId="PrintReportsScenesTab">
                 <StackPanel>
-                    <CheckBox Content="Print a list of all Scenes" IsChecked="{x:Bind PrintVM.SceneList, Mode=TwoWay}" />
+                    <CheckBox Content="Print a list of all Scenes" IsChecked="{x:Bind PrintVM.SceneList, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="PrintReportsSceneListCheck" />
                     <CheckBox Content="Print all scenes" IsChecked="{x:Bind PrintVM.SelectAllScenes, Mode=TwoWay}"
-                              Click="CheckboxClicked" />
+                              Click="CheckboxClicked"
+                              AutomationProperties.AutomationId="PrintReportsSelectAllScenesCheck" />
                     <ListView SelectionMode="Multiple" Height="260" Name="ScenesList"
-                              ItemsSource="{x:Bind PrintVM.SceneNodes, Mode=TwoWay}" SelectionChanged="UpdateSelection" />
+                              ItemsSource="{x:Bind PrintVM.SceneNodes, Mode=TwoWay}" SelectionChanged="UpdateSelection"
+                              AutomationProperties.AutomationId="PrintReportsScenesList" />
                 </StackPanel>
                 </TabViewItem>
-                <TabViewItem Header="Settings" IsClosable="False">
+                <TabViewItem Header="Settings" IsClosable="False"
+                             AutomationProperties.AutomationId="PrintReportsSettingsTab">
                 <StackPanel>
                     <CheckBox Content="Print a list of all Settings"
-                              IsChecked="{x:Bind PrintVM.SettingList, Mode=TwoWay}" />
+                              IsChecked="{x:Bind PrintVM.SettingList, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="PrintReportsSettingListCheck" />
                     <CheckBox Content="Print all settings" IsChecked="{x:Bind PrintVM.SelectAllSettings,Mode=TwoWay}"
-                              Click="CheckboxClicked" />
+                              Click="CheckboxClicked"
+                              AutomationProperties.AutomationId="PrintReportsSelectAllSettingsCheck" />
                     <ListView SelectionMode="Multiple" Height="260" Name="SettingsList"
                               ItemsSource="{x:Bind PrintVM.SettingNodes, Mode=TwoWay}"
-                              SelectionChanged="UpdateSelection" />
+                              SelectionChanged="UpdateSelection"
+                              AutomationProperties.AutomationId="PrintReportsSettingsList" />
                 </StackPanel>
                 </TabViewItem>
-                <TabViewItem Header="Websites" IsClosable="False">
+                <TabViewItem Header="Websites" IsClosable="False"
+                             AutomationProperties.AutomationId="PrintReportsWebsitesTab">
                 <StackPanel>
-                    <CheckBox Content="Print a list of all Websites" IsChecked="{x:Bind PrintVM.WebList, Mode=TwoWay}" />
+                    <CheckBox Content="Print a list of all Websites" IsChecked="{x:Bind PrintVM.WebList, Mode=TwoWay}"
+                              AutomationProperties.AutomationId="PrintReportsWebListCheck" />
                     <CheckBox Content="Print all websites" IsChecked="{x:Bind PrintVM.SelectAllWeb,Mode=TwoWay}"
-                              Click="CheckboxClicked" />
+                              Click="CheckboxClicked"
+                              AutomationProperties.AutomationId="PrintReportsSelectAllWebCheck" />
                     <ListView SelectionMode="Multiple" Height="260" Name="WebList"
-                              ItemsSource="{x:Bind PrintVM.WebNodes, Mode=TwoWay}" SelectionChanged="UpdateSelection" />
+                              ItemsSource="{x:Bind PrintVM.WebNodes, Mode=TwoWay}" SelectionChanged="UpdateSelection"
+                              AutomationProperties.AutomationId="PrintReportsWebList" />
                 </StackPanel>
                 </TabViewItem>
             </TabView.TabItems>
         </TabView>
+        <!-- InfoBar: convention silence (neither the suffix table nor the coverage test's
+             interactive element list covers InfoBar). Not annotated here, matching three already-
+             merged Unit 6 dialogs with unannotated InfoBars (FeedbackDialog.xaml:23,
+             FileOpenMenu.xaml:84, HelpPage.xaml:19); see PR description for the proposed resolution. -->
         <InfoBar IsOpen="False" Name="SynopsisWarning" Severity="Warning"
                  Message="Add some scenes to your synopsis, otherwise it will be empty." Height="auto" />
     </StackPanel>

--- a/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml
@@ -117,11 +117,10 @@
                 </TabViewItem>
             </TabView.TabItems>
         </TabView>
-        <!-- InfoBar: convention silence (neither the suffix table nor the coverage test's
-             interactive element list covers InfoBar). Not annotated here, matching three already-
-             merged Unit 6 dialogs with unannotated InfoBars (FeedbackDialog.xaml:23,
-             FileOpenMenu.xaml:84, HelpPage.xaml:19); see PR description for the proposed resolution. -->
+        <!-- Id only, no explicit Name: the InfoBar peer announces Severity + Title + Message
+             natively (founder ruling on PR #1456, InfoBar suffix row added Unit 7). -->
         <InfoBar IsOpen="False" Name="SynopsisWarning" Severity="Warning"
-                 Message="Add some scenes to your synopsis, otherwise it will be empty." Height="auto" />
+                 Message="Add some scenes to your synopsis, otherwise it will be empty." Height="auto"
+                 AutomationProperties.AutomationId="PrintReportsSynopsisWarningInfoBar" />
     </StackPanel>
 </Page>

--- a/StoryCADTests/Xaml/AutomationConventionTests.cs
+++ b/StoryCADTests/Xaml/AutomationConventionTests.cs
@@ -70,7 +70,7 @@ public class AutomationConventionTests
         "ComboBox", "TextBox", "CheckBox", "RadioButton", "RadioButtons", "ToggleSwitch", "NumberBox",
         "AutoSuggestBox", "TabView", "TabViewItem", "TreeView", "ListView", "GridView",
         "Flyout", "RichEditBoxExtended", "BrowseTextBox", "Expander",
-        "NavigationView", "NavigationViewItem",
+        "NavigationView", "NavigationViewItem", "InfoBar",
     };
 
     /// <summary>
@@ -110,6 +110,7 @@ public class AutomationConventionTests
         ["Expander"] = "Expander",     // added Unit 4: founder-accepted Expander suffix ruling on PR #1451
         ["NavigationView"] = "Nav",         // added Unit 6: founder ruling on PR #1455 (FileOpenMenu nav strip)
         ["NavigationViewItem"] = "NavItem", // added Unit 6: founder ruling on PR #1455 (FileOpenMenu nav strip)
+        ["InfoBar"] = "InfoBar",            // added Unit 7: founder ruling on PR #1456 (id only; the peer announces Severity+Title+Message natively, so no explicit Name)
     };
 
     private const string AutomationIdAttribute = "AutomationProperties.AutomationId";

--- a/StoryCADTests/Xaml/AutomationConventionTests.cs
+++ b/StoryCADTests/Xaml/AutomationConventionTests.cs
@@ -46,6 +46,8 @@ public class AutomationConventionTests
         "StoryCADLib/Services/Dialogs/HelpPage.xaml",
         "StoryCADLib/Services/Dialogs/NewRelationshipPage.xaml",
         "StoryCADLib/Services/Dialogs/SaveAsDialog.xaml",
+        "StoryCADLib/Services/Dialogs/Tools/PreferencesDialog.xaml",
+        "StoryCADLib/Services/Dialogs/Tools/PrintReportsDialog.xaml",
     };
 
     /// <summary>

--- a/devdocs/automation_naming_convention.md
+++ b/devdocs/automation_naming_convention.md
@@ -36,6 +36,7 @@ Every interactive control gets `AutomationProperties.AutomationId`.
 | Expander | `Expander` | `GeographyExpander` *(added Unit 4)* |
 | NavigationView | `Nav` | `FileOpenNav` *(added Unit 6)* |
 | NavigationViewItem | `NavItem` | `RecentlyOpenedNavItem` *(added Unit 6)* |
+| InfoBar | `InfoBar` | `PrintReportsSynopsisWarningInfoBar` *(added Unit 7)* |
 
 - A control type not in this table gets a proposed suffix in the PR description; the table row is added when the PR merges.
 - Values are literal strings: ASCII letters and digits, no spaces, no bindings, never a story element name, file path, date, or any other runtime value.

--- a/devdocs/issue_1420_status_log.md
+++ b/devdocs/issue_1420_status_log.md
@@ -2,6 +2,18 @@
 
 Session-recovery state for the AutomationProperties annotation pass. Newest entry first.
 
+## 2026-07-04 (Unit 7 session) — Unit 7 PR #1456 filed; two founder decision items on the PR
+
+**Unit 7 is in review as PR #1456** after the standard cycle: Sonnet implementer (red exactly 76 → green, commit cee2042c), Sonnet reviewer (APPROVE, zero blockers, three nits), one nit applied by the same implementer (efa1c147: the AppStoreReview comment now cites the in-file literal-Content HyperlinkButton precedent instead of the FeedbackDialog bound-Header one). Actuals 76 ids / 9 Names against the plan's 74 est. (PreferencesDialog 49/9, PrintReportsDialog 27/0); prefixes `Preferences.../PrintReports...` match the merged Shell ids. Suite 1,138 / 0 failed run by implementer and reviewer; both heads verified at cee2042c and re-verified at branch head post-nit. x:Load pre-check clean across Services/Dialogs/Tools (implementer-checked, reviewer re-grepped).
+
+**The owed BrowseTextBox fix shipped as the unit's sole non-attribute diff (founder sign-off requested on the PR):** a Loaded handler in BrowseTextBox.xaml.cs derives per-instance internal ids (`{outerId}PathTextBox`/`{outerId}BrowseButton`) from each instance's outer AutomationId; XAML keeps the literal fallback ids the Coverage/Literalness tests require; reviewer hand-traced all six call sites (six distinct outer ids, six unique suffix-conformant derived pairs); the stale BrowseTextBox.xaml:6-12 comment now describes the fixed state. Static tests cannot see the derived ids — live Inspect on the six screens is the confirmation path, noted on the PR.
+
+**Second founder decision item: InfoBar.** PrintReportsDialog's SynopsisWarning InfoBar is in neither the suffix table nor the coverage element list (same class as Unit 4 Expander / Unit 6 NavigationView); three merged Unit 6 dialogs already carry unannotated InfoBars (FeedbackDialog:23, FileOpenMenu:84, HelpPage:19). Options on the PR: suffix row + element list + annotate all four in a follow-up commit, or a documented exemption (the peer announces Severity + Title + Message; the close button is templated). Left unannotated pending the ruling.
+
+**Reviewer premise correction for the record:** the five PrintReportsDialog ListViews have no ItemTemplate at all (TemplateSafety compliance is trivial there); realized-item announcements are a founder-review check, noted on the PR.
+
+**Next: founder reviews/merges PR #1456 with the two rulings. Then Unit 8 (StoryCADLib/Services/Dialogs/Tools: CopyElementsDialog 9, DramaticSituationsDialog 1, KeyQuestionsDialog 3, MasterPlotsDialog 1, NarrativeTool 10, StockScenesDialog 2, TopicsDialog 5, ~31 est.), branch `issue-1420-batch8-tools` off `dev`, fresh session, same cycle, x:Load check first (note: the Unit 7 pre-check already covered the whole Tools directory and found zero matches, but dev may move).**
+
 ## 2026-07-04 (end of session) — Unit 6 merged; three batches remain
 
 **PR #1455 merged to `dev` (175181b3) on founder instruction.** Merge cleanup done: #1420 body updated (Unit 6 checked off with the Nav/NavItem ruling, spin-off #1454, and the Unit 9 ElementPicker prefix note); wiki `log.md` entry appended (page updates postponed to closeout, wiki tree left uncommitted for StoryCADWiki#1, same posture as Units 3-5). Running total on `dev`: 457 AutomationIds across 24 XAML files (verified by grep post-merge), suite baseline 1,138 / 0 failed. No new audit trigger — #1441 was notified at Unit 5.

--- a/devdocs/issue_1420_status_log.md
+++ b/devdocs/issue_1420_status_log.md
@@ -2,6 +2,10 @@
 
 Session-recovery state for the AutomationProperties annotation pass. Newest entry first.
 
+## 2026-07-04 (Unit 7, ruling) — InfoBar joins the convention; one decision item left on PR #1456
+
+**Founder ruled option 1 on the InfoBar gap: suffix row, annotate all four instances in a follow-up commit.** Commit cea06c8e (same implementer, resumed): convention doc row `InfoBar` *(added Unit 7)* — full type name kept as the suffix, matching NumberBox/GridView/Flyout/Expander (the table abbreviates only where the trimmed form stays distinctive; neither `Info` nor `Bar` is) — InfoBar in the coverage test's element list and suffix map, red on exactly 4, then green: `FeedbackTipInfoBar`, `FileOpenWarningInfoBar`, `HelpVideoNoteInfoBar`, `PrintReportsSynopsisWarningInfoBar`. Id-only, no Names (the peer announces Severity + Title + Message natively). Convention tests 7/7; suite 1,138 / 0 failed; both heads build clean. Unit 7 totals now 80 ids / 9 Names (76 + 4, three of the four in Unit 6 files). Ruling execution recorded on PR #1456; the sole open decision item is the BrowseTextBox code-behind sign-off, which rides with founder review/merge.
+
 ## 2026-07-04 (Unit 7 session) — Unit 7 PR #1456 filed; two founder decision items on the PR
 
 **Unit 7 is in review as PR #1456** after the standard cycle: Sonnet implementer (red exactly 76 → green, commit cee2042c), Sonnet reviewer (APPROVE, zero blockers, three nits), one nit applied by the same implementer (efa1c147: the AppStoreReview comment now cites the in-file literal-Content HyperlinkButton precedent instead of the FeedbackDialog bound-Header one). Actuals 76 ids / 9 Names against the plan's 74 est. (PreferencesDialog 49/9, PrintReportsDialog 27/0); prefixes `Preferences.../PrintReports...` match the merged Shell ids. Suite 1,138 / 0 failed run by implementer and reviewer; both heads verified at cee2042c and re-verified at branch head post-nit. x:Load pre-check clean across Services/Dialogs/Tools (implementer-checked, reviewer re-grepped).


### PR DESCRIPTION
## Unit 7: PreferencesDialog + PrintReportsDialog (issue #1420)

Adds the two `StoryCADLib/Services/Dialogs/Tools` dialogs to the coverage ratchet and annotates all 76 interactive controls found, plus the BrowseTextBox per-instance AutomationId fix pre-announced on PR #1453. Two substantive commits: the annotation pass + fix (cee2042c) and a review-nit comment correction (efa1c147).

### Actuals

| File | AutomationIds | Explicit Names | Notes |
|---|---|---|---|
| PreferencesDialog.xaml | 49 | 9 | ids prefixed `Preferences...` (matches Shell's merged `PreferencesButton`); Names on the 7 icon-only social buttons (Content is an `<Image>`, zero extractable text), the header-less autosave-interval NumberBox, and the "?" HyperlinkButton ("Learn what's collected") |
| PrintReportsDialog.xaml | 27 | 0 | ids prefixed `PrintReports...` (matches Shell's `PrintReportsMenuItem`); every control is framework-named via Content/Header |

The plan estimated 48 + 26 = 74; the recount at annotation time is 76. The two `BrowseTextBox` rows in PreferencesDialog get outer ids (`PreferencesProjectDirTextBox`/`PreferencesBackupDirTextBox`) and no outer Name per the header-exposure ruling (both have `Header` set).

The five PrintReportsDialog ListViews (`ProblemsList` etc.) were re-prefixed rather than reused bare: `Problems`/`Characters`/`Scenes`/`Settings`/`Web` are exactly the cross-page-repeatable function names the convention's prefix bullet targets, and the naming procedure runs the collision check before the reuse step. The reviewer independently upheld this ordering.

### The BrowseTextBox per-instance id fix (the unit's sole non-attribute diff — founder sign-off requested)

PR #1453 documented that `BrowseTextBox`'s internal `PathTextBox`/`BrowseButton` ids duplicate across all six app-wide instances (BackupNow, SaveAsDialog, PreferencesDialog ×2, PreferencesInitialization ×2) and deferred the fix here because it exceeds an attribute-only diff.

Mechanism: the `BrowseTextBox` constructor subscribes to `Loaded`; the handler reads the instance's own outer id via `AutomationProperties.GetAutomationId(this)` and, when non-empty, overrides the internals with `{outerId}PathTextBox` / `{outerId}BrowseButton`. `Loaded` rather than the constructor because the host page's generated code applies the outer attribute after the child is constructed. The handler recomputes from scratch on every firing, so repeated `Loaded` events reassign the same string harmlessly.

Why the static tests stay honest: the XAML keeps the literal fallback ids (Coverage requires the attribute; Literalness forbids `{` in the value), the derived values keep the role suffix at the end, and uniqueness follows from the six outer ids, all of which sit in ratcheted files. The reviewer traced all six call sites by hand: six distinct outer ids, six unique derived pairs. The stale "known gap" comment at BrowseTextBox.xaml:6-12 now describes the fixed state.

This is a deviation from the plan's "XAML attributes plus test code only" ground rule, pre-announced on PR #1453 and flagged here per the plan's definition of done.

### Red/green and verification

- Red: coverage test reported exactly 76 violations after the two-file ratchet addition (49 + 27), matching a manual tag-by-tag enumeration.
- Green: all 7 `AutomationConventionTests` pass; re-run green again after the nit commit (the XDocument parse also proves the edited comment is well-formed XML).
- Full suite: 1,138 total, 1,124 passed, 14 skipped, 0 failed — run independently by the implementer agent and the reviewer agent.
- Both heads build clean (`net10.0-windows10.0.22621` and `net10.0-desktop`), verified at cee2042c by the implementer and re-verified at the branch head after the comment-only nit commit (the full solution build emits both heads).
- x:Load pre-check: zero matches anywhere in `Services/Dialogs/Tools` (checked before implementation and re-confirmed by the reviewer's own grep), so the #1452 literal-Name ban does not constrain this unit.
- Independent reviewer verdict: APPROVE, zero blockers, three nits (one applied in efa1c147; the other two are recorded in this description: actuals vs. estimate, and the ListView-template premise correction below). The reviewer also ran a full-corpus duplicate-id scan beyond the Uniqueness test: zero duplicates.

### Proposed convention addition (founder ruling requested): InfoBar

`PrintReportsDialog.xaml:93` carries an InfoBar (`SynopsisWarning`) and InfoBar is in neither the convention suffix table nor the coverage test's element list — the same structural-blindness class as Unit 4's Expander and Unit 6's NavigationView. Three already-merged Unit 6 dialogs carry unannotated InfoBars (FeedbackDialog.xaml:23, FileOpenMenu.xaml:84, HelpPage.xaml:19). Left unannotated this unit. Options:

1. Add an `InfoBar` suffix row plus element-list entry and annotate the four instances in a follow-up commit (the Expander/NavigationView pattern), or
2. Document an exemption: the InfoBar peer natively announces Severity + Title + Message, and its close button is templated, not author XAML.

Doc growth stays postponed to #1420 closeout per the standing posture; recording the proposal here.

### What the static tests cannot see (verification notes for founder review)

- The six runtime-derived BrowseTextBox id pairs are invisible to every convention test (they only parse XAML source). Static reasoning says all six are unique and suffix-conformant; an Accessibility Insights pass on the six screens is the only live confirmation.
- `PreferencesAppStoreReviewButton` has no explicit Name on the reasoning that its OneTime-bound Content resolves to a plain string before the AutomationPeer reads it (same as the literal-Content `PreferencesContributorsButton` above it). A live Inspect on this button settles it.
- The five PrintReportsDialog ListViews have no ItemTemplate at all (the reviewer corrected the "5 ListViews with templates" premise — items render via default framework conversion). Worth confirming realized list items announce their display text.

### How to test

Build `StoryCAD.sln` (Debug, x64), then run `vstest.console.exe` on `StoryCADTests/bin/x64/Debug/net10.0-windows10.0.22621/StoryCADTests.dll`; expect 1,138 total / 0 failed. For the desktop head: `msbuild StoryCAD/StoryCAD.csproj -t:Build -p:TargetFramework=net10.0-desktop -p:Configuration=Debug -p:Platform=x64`. To see the per-instance ids live: open Preferences and Inspect either Browse row; the inner controls should expose `PreferencesProjectDirTextBoxPathTextBox`-style ids, not the bare `PathTextBox`.

References #1420 (Unit 7 of 9; does not close the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
