### PR TITLE
#1448 Guard Package.Current in AppState.DeveloperBuild for unpackaged launches

### DIFF
--- a/StoryCADLib/Models/AppState.cs
+++ b/StoryCADLib/Models/AppState.cs
@@ -73,9 +73,31 @@ public class AppState
     ///     - The Build revision is NOT 0.
     ///     - A debugger i.e. VS2022 is attached.
     ///     - .ENV is missing.
+    ///     - The process has no package identity (exe launched unpackaged).
     ///     Usually it's all or none of the above.
     /// </summary>
-    public bool DeveloperBuild => Debugger.IsAttached || !EnvPresent || Package.Current.Id.Version.Revision != 0;
+    public bool DeveloperBuild
+    {
+        get
+        {
+            if (Debugger.IsAttached || !EnvPresent)
+            {
+                return true;
+            }
+
+            try
+            {
+                return Package.Current.Id.Version.Revision != 0;
+            }
+            catch
+            {
+                // Package.Current throws when the process has no package identity
+                // (e.g. StoryCAD.exe launched straight from bin\); an unpackaged
+                // run is never a Store release, so treat it as a developer build. (#1448)
+                return true;
+            }
+        }
+    }
 
     /// <summary>
     ///     Compile-time flag indicating this is a beta distribution.

--- a/StoryCADTests/Models/AppStateTests.cs
+++ b/StoryCADTests/Models/AppStateTests.cs
@@ -194,6 +194,24 @@ public class AppStateTests
 
     #endregion
 
+    #region DeveloperBuild Tests (Issue #1448)
+
+    [TestMethod]
+    public void DeveloperBuild_EnvPresentAndUnpackaged_ReturnsTrueWithoutThrowing()
+    {
+        // EnvPresent = true with no debugger forces evaluation of the package-revision
+        // term. The test host runs unpackaged (EnableMsixTooling=false), so
+        // Package.Current has no identity there; before the #1448 fix this getter
+        // threw InvalidOperationException under exactly these conditions.
+        var appState = new AppState { EnvPresent = true };
+
+        bool result = appState.DeveloperBuild;
+
+        Assert.IsTrue(result);
+    }
+
+    #endregion
+
     #region IsClosing Tests (Issue #1293)
 
     [TestMethod]


### PR DESCRIPTION
Fixes #1448.

## Change

`AppState.DeveloperBuild` (AppState.cs:78) evaluated `Package.Current.Id.Version.Revision` unconditionally once a debugger was absent and `.env` was present. `Package.Current` throws `InvalidOperationException` when the process has no package identity, so any launch of `StoryCAD.exe` straight from `bin\` with `.env` present died at `Shell_Loaded` (stack in #1448). The getter now wraps the revision check in try/catch and returns `true` when no package identity exists: an unpackaged run is never a Store release, so it's a developer build by the flag's own definition. This is the same packaged/unpackaged probe `App.xaml.cs:80-92` already uses to locate `.env`.

## Test

`DeveloperBuild_EnvPresentAndUnpackaged_ReturnsTrueWithoutThrowing` in `AppStateTests.cs`. The vstest host runs unpackaged (`EnableMsixTooling=false` in StoryCADTests.csproj), so the test exercises the exact crash conditions: `EnvPresent = true`, no debugger, no package identity. Verified it fails against the old getter (InvalidOperationException at AppState.cs:78) and passes with the fix.

## Verification

- Full suite: 1,139 tests, 1,125 passed, 14 skipped, 0 failed
- StoryCADLib builds clean on both `net10.0-windows10.0.22621` and `net10.0-desktop`
- Behavior change is limited to the previously-crashing case; packaged and debugger/no-env paths evaluate exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)