### PR TITLE
#1462 Remove empty spacer chat rows in WorkflowPage

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -498,7 +498,6 @@ public class Collaborator : ICollaborator
                     var explanation = ExtractExplanationFromResponse(result.RawResponse);
                     if (!string.IsNullOrEmpty(explanation))
                     {
-                        viewModel.ConversationList.Add(ChatMessage.FromCollaborator(""));
                         viewModel.ConversationList.Add(ChatMessage.FromCollaborator(explanation));
                     }
                 }
@@ -668,17 +667,14 @@ public class Collaborator : ICollaborator
                         }
                     };
 
-                    viewModel.ConversationList.Add(ChatMessage.FromCollaborator(""));
                     viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
                         $"Found {result.UpdatedProperties.Count} property updates. Review them above and choose Accept All, Review Each, or Try Again."));
                 }
                 else
                 {
-                    viewModel.ConversationList.Add(ChatMessage.FromCollaborator(""));
                     viewModel.ConversationList.Add(ChatMessage.FromCollaborator("No property updates were extracted from the response."));
                 }
 
-                viewModel.ConversationList.Add(ChatMessage.FromCollaborator(""));
                 viewModel.ConversationList.Add(ChatMessage.FromCollaborator("You can ask questions or request changes using the chat below."));
             }
             else


### PR DESCRIPTION
## What changed

Deletes the four `viewModel.ConversationList.Add(ChatMessage.FromCollaborator(""));` calls in `CollaboratorLib/Collaborator.cs` (original lines 501, 671, 677, 681). No other lines touched.

## Why

Every completed Collaborator workflow run added these as blank-line visual spacers before summary messages. `WorkflowPage.xaml`'s chat row template binds the row's accessible name to `{Binding Text, Mode=OneWay}`; with `Text = ""` that resolves to an empty Name, and the ListViewItem automation peer falls back to `ChatMessage.ToString()`, which isn't overridden. Narrator announced "StoryCADLib.Collaborator.Models.ChatMessage" for each spacer row. The spacers also drew a stray "Collaborator"-captioned empty bubble. No replacement spacing is needed: the template root already carries `Margin="0,4,0,4"`.

Found during #1441 (post-annotation accessibility audit), live-check 2.

## How to test

1. Debug build with `COLLAB_DEV_ENABLED=1`, open an outline, run the Ideation workflow to completion.
2. Enumerate the `WorkflowConversationList` ListItems via UIA (Accessibility Insights, Inspect, or scripted): every ListItem Name is non-empty, and zero rows announce "StoryCADLib.Collaborator.Models.ChatMessage".
3. Visual check: no empty bubbles; explanation, updates summary, and chat-prompt bubbles remain distinct.

Full solution build: 0 errors. Full `StoryCADTests` run: 1125 passed, 14 pre-existing skips, 0 failed. Live UIA verification against this branch's commit: founder-run 2026-07-06, checked out clean.

Closes #1462
