### PR TITLE
#1446 Fix "Adventureousness" misspelling in trait name

### DIFF
--- a/StoryCAD/Views/CharacterPage.xaml
+++ b/StoryCAD/Views/CharacterPage.xaml
@@ -357,12 +357,12 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
-                    <ComboBox IsEditable="True" Header="Adventureousness" Grid.Column="0" Grid.Row="0" MinWidth="0"
+                    <ComboBox IsEditable="True" Header="Adventurousness" Grid.Column="0" Grid.Row="0" MinWidth="0"
                               ItemsSource="{x:Bind CharVm.AdventurousnessList}"
                               Text="{x:Bind CharVm.Adventurousness, Mode=TwoWay}"
                               PlaceholderText="{x:Bind CharVm.Adventurousness, Mode=TwoWay}"
                               HorizontalAlignment="Stretch"
-                              AutomationProperties.AutomationId="AdventureousnessCombo" />
+                              AutomationProperties.AutomationId="AdventurousnessCombo" />
                     <ComboBox IsEditable="True" Header="Confidence" Grid.Column="0" Grid.Row="1" MinWidth="0"
                               ItemsSource="{x:Bind CharVm.ConfidenceList}"
                               Text="{x:Bind CharVm.Confidence, Mode=TwoWay}"

--- a/StoryCADLib/Assets/Install/Lists.json
+++ b/StoryCADLib/Assets/Install/Lists.json
@@ -2524,7 +2524,7 @@
                       "Suspense scene",
                       "Twister scene"
                   ],
-    "Adventureousness":  [
+    "Adventurousness":  [
                         "Active",
                         "Adventurous",
                         "Embittered",

--- a/StoryCADLib/Models/Elements/CharacterModel.cs
+++ b/StoryCADLib/Models/Elements/CharacterModel.cs
@@ -305,8 +305,8 @@ public class CharacterModel : StoryElement
     [JsonIgnore] private string _adventurousness;
 
     [JsonInclude]
-    [JsonPropertyName("Adventureousness")]
-    public string Adventureousness
+    [JsonPropertyName("Adventureousness")] // wire name kept misspelled: matches the key already persisted in existing .stbx files
+    public string Adventurousness
     {
         get => _adventurousness;
         set => _adventurousness = value;
@@ -506,7 +506,7 @@ public class CharacterModel : StoryElement
         Abnormality = string.Empty;
         Focus = string.Empty;
         PsychNotes = string.Empty;
-        Adventureousness = string.Empty;
+        Adventurousness = string.Empty;
         Aggression = string.Empty;
         Confidence = string.Empty;
         Conscientiousness = string.Empty;
@@ -556,7 +556,7 @@ public class CharacterModel : StoryElement
         Abnormality = string.Empty;
         Focus = string.Empty;
         PsychNotes = string.Empty;
-        Adventureousness = string.Empty;
+        Adventurousness = string.Empty;
         Aggression = string.Empty;
         Confidence = string.Empty;
         Conscientiousness = string.Empty;

--- a/StoryCADLib/Services/Reports/ReportFormatter.cs
+++ b/StoryCADLib/Services/Reports/ReportFormatter.cs
@@ -1062,7 +1062,7 @@ public class ReportFormatter
             sb.Replace("@Abnormality", character.Abnormality);
             sb.Replace("@PsychNotes", GetText(character.PsychNotes));
             //Inner Traits section
-            sb.Replace("@Adventure", character.Adventureousness);
+            sb.Replace("@Adventure", character.Adventurousness);
             sb.Replace("@Aggression", character.Aggression);
             sb.Replace("@Confidence", character.Confidence);
             sb.Replace("@Conscientious", character.Conscientiousness);

--- a/StoryCADLib/ViewModels/CharacterViewModel.cs
+++ b/StoryCADLib/ViewModels/CharacterViewModel.cs
@@ -607,7 +607,7 @@ public class CharacterViewModel : ElementViewModelBase, INavigable, ISaveable, I
         Abnormality = Model.Abnormality;
         Focus = Model.Focus;
         PsychNotes = Model.PsychNotes;
-        Adventurousness = Model.Adventureousness;
+        Adventurousness = Model.Adventurousness;
         Aggression = Model.Aggression;
         Confidence = Model.Confidence;
         Conscientiousness = Model.Conscientiousness;
@@ -672,7 +672,7 @@ public class CharacterViewModel : ElementViewModelBase, INavigable, ISaveable, I
         Model.Values = Values;
         Model.Abnormality = Abnormality;
         Model.Focus = Focus;
-        Model.Adventureousness = Adventurousness;
+        Model.Adventurousness = Adventurousness;
         Model.Aggression = Aggression;
         Model.Confidence = Confidence;
         Model.Conscientiousness = Conscientiousness;
@@ -1072,7 +1072,7 @@ public class CharacterViewModel : ElementViewModelBase, INavigable, ISaveable, I
             ValuesList = _lists["Values"];
             AbnormalityList = _lists["Abnormality"];
             FocusList = _lists["Focus"];
-            AdventurousnessList = _lists["Adventureousness"];
+            AdventurousnessList = _lists["Adventurousness"];
             AggressionList = _lists["Aggression"];
             ConfidenceList = _lists["Confidence"];
             ConscientiousnessList = _lists["Conscientiousness"];

--- a/StoryCADTests/DAL/ListLoaderTests.cs
+++ b/StoryCADTests/DAL/ListLoaderTests.cs
@@ -50,7 +50,7 @@ public class ListLoaderTests
         Assert.IsTrue(lists.ContainsKey("Values"));
         Assert.IsTrue(lists.ContainsKey("Abnormality"));
         Assert.IsTrue(lists.ContainsKey("Focus"));
-        Assert.IsTrue(lists.ContainsKey("Adventureousness"));
+        Assert.IsTrue(lists.ContainsKey("Adventurousness"));
         Assert.IsTrue(lists.ContainsKey("Aggression"));
         Assert.IsTrue(lists.ContainsKey("Confidence"));
         Assert.IsTrue(lists.ContainsKey("Conscientiousness"));


### PR DESCRIPTION
## What changed
Renames the misspelled "Adventureousness" trait to "Adventurousness" in the visible tab Header and AutomationId (`CharacterPage.xaml`), the `CharacterModel` property, the `Lists.json` lookup key, and `ReportFormatter`.

## Why
Found during the #1420 annotation pass. The tab a user sees was misspelled. `[JsonPropertyName("Adventureousness")]` is left unchanged, since that's the key already persisted in every existing `.stbx` file (including the shipped sample outlines and several with real data set, e.g. Hamlet, Danger Calls) — renaming it would silently drop the trait value on load for anyone who's already set it.

## How to test
Build and run; open Character > Personality tab, confirm the field now reads "Adventurousness". Open one of the shipped samples with a value already set (Hamlet or Danger Calls) and confirm the trait still loads correctly.

Full solution build: 0 errors. Full `StoryCADTests` run: 1125 passed, 14 pre-existing skips, 0 failed.

Closes #1446