### PR TITLE
#1449 Remove dead nested ListView from ScenePage Cast tab

### DIFF
--- a/StoryCAD/Views/ScenePage.xaml
+++ b/StoryCAD/Views/ScenePage.xaml
@@ -131,13 +131,6 @@
                                             Margin="0"
                                             IsChecked="{x:Bind IsSelected, Mode=TwoWay}"
                                             Checked="CastMember_Checked" Unchecked="CastMember_Unchecked" />
-                                        <ListView ItemsSource="{Binding CastSource}">
-                                            <ListView.ItemTemplate>
-                                                <DataTemplate>
-                                                    <TextBlock Text="{Binding Name}" />
-                                                </DataTemplate>
-                                            </ListView.ItemTemplate>
-                                        </ListView>
                                         <TextBlock Text="{x:Bind Name, Mode=OneWay}" MinWidth="250" />
                                     </StackPanel>
                                 </DataTemplate>


### PR DESCRIPTION
## Summary

- Deletes the dead nested `ListView` in `ScenePage.xaml`'s Cast tab (lines 134-140). It bound `{Binding CastSource}` against the row's `DataContext` (a `StoryElement`), which has no `CastSource` property, so the binding never resolved and the inner list always rendered empty.

## Root cause

Introduced in commit `91f3bfea` ("Add strong typing for Relationships", 2025-01-20), merged via PR #874 on issue #869 ("Strongly type Guids"). #869 scoped Guid-strong-typing work, not a new Cast-tab feature; the nested list was never wired to anything and no test in that PR or since exercised it. A working relationship-display surface already exists elsewhere: `CharacterPage.xaml`'s Relationships tab, backed by `RelationshipView.xaml` over `CharacterModel.RelationshipList`. Wiring the dead list up instead of deleting it would have duplicated that editor.

Full requirements-gathering trail, including confirmation the block is inert (no `x:Name`/`ElementName`/`StaticResource` references it, no `AutomationId`, not checked by `AutomationConventionTests`), is on issue #1449.

## Test plan

Targeted the tests that actually cover the two adjacent features, not just a full-suite pass:
- [x] `SceneViewModelTests` (56 tests, 13 Cast-related: add/remove cast member, switch cast view, `CastSource` change notification) — all pass
- [x] `AddRelationshipTests` (7 tests, `CharacterViewModel` relationship-creation logic behind `RelationshipView.xaml`) — all pass
- [x] `ReportFormatterRelationshipsTests` (5 tests, relationship-map report formatting) — all pass
- [x] `AutomationConventionTests` (7 tests) — all pass
- [x] `StoryCAD.sln` builds clean (Debug, x64)

## Agent effectiveness

One `general-purpose` agent handled requirements gathering: tracing the block to its origin commit/PR/issue, confirming it was never wired up or tested, and finding the existing `RelationshipView` UI it would have duplicated. The fix itself (single-file, 7-line XAML deletion) and test verification were mechanical and handled directly — below the threshold (>15 min / >2 files / architectural) for agent use.

Closes #1449.
