### PR TITLE
fix: treat all-zero package version as unpackaged in DeveloperBuild

### DIFF
--- a/StoryCADLib/Models/AppState.cs
+++ b/StoryCADLib/Models/AppState.cs
@@ -87,7 +87,19 @@ public class AppState
 
             try
             {
-                return Package.Current.Id.Version.Revision != 0;
+                PackageVersion version = Package.Current.Id.Version;
+
+                // On the Uno desktop head Package.Current is a stub that doesn't
+                // throw; its version stays at the default (all-zero) in any process
+                // that never constructs an Uno Application, e.g. the test host.
+                // No real package identity ever has version 0.0.0.0, so treat it
+                // as unpackaged, same as the throw path below. (#1471)
+                if (version is { Major: 0, Minor: 0, Build: 0, Revision: 0 })
+                {
+                    return true;
+                }
+
+                return version.Revision != 0;
             }
             catch
             {


### PR DESCRIPTION
## What changed

`AppState.DeveloperBuild` now treats an all-zero `Package.Current.Id.Version` as a process with no package identity and returns true, ahead of the existing `Revision != 0` check. The #1448 catch for the WinAppSDK throw path is unchanged. One file, +13/-1.

## Why

Fixes #1471.

The test `DeveloperBuild_EnvPresentAndUnpackaged_ReturnsTrueWithoutThrowing` (added by #1459) fails both CI jobs on every PR targeting `dev`, because the #1448 guard expects `Package.Current` to throw for an unpackaged process. On the Uno `net10.0-desktop` head, the only head CI tests, it returns a stub instead.

Verified against Uno source: on the desktop head `PackageId.Version` defaults to all zeros (`PackageId.crossruntime.cs`) and is populated only by `Package.SetEntryAssembly`, called from the Uno `Application` constructor (`Application.cs:122`, skia/wasm only). The test host never constructs an `Application` (`TestSetup.cs` calls `BootStrapper.Initialise()` only), so it sees the all-zero version: no throw, `Revision == 0`, `DeveloperBuild` false, assert fails. A real desktop app run does construct `App` and gets the entry-assembly version with a non-zero Major, so released desktop builds keep `DeveloperBuild == false`; the new guard can only fire in identity-less processes.

## How to test

- Desktop head (the CI configuration): `dotnet test --project StoryCADTests/StoryCADTests.csproj --configuration Release -p:Platform=x64 -f net10.0-desktop`. Before this change the DeveloperBuild test fails; with it, local run is 1134 tests, 0 failed, 10 skipped.
- WinAppSDK head: build Debug x64, then `vstest.console.exe` on `StoryCADTests/bin/x64/Debug/net10.0-windows10.0.22621/StoryCADTests.dll`. Local run is 1139 tests, 0 failed, 14 skipped.

## After merge

`dev` has no push-triggered build workflow, so the fix shows its effect in later PR runs. Open PRs targeting `dev` (e.g. #1470) need one new push (e.g. merge `origin/dev` into the branch) to get a fresh merge-ref CI run; re-running old failed jobs reuses the stale merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
