### PR TITLE
feat: capture proxy cost event into WorkflowResult (Collaborator #91)

### DIFF
--- a/CollaboratorLib/Models/ProxyCostInfo.cs
+++ b/CollaboratorLib/Models/ProxyCostInfo.cs
@@ -1,0 +1,20 @@
+namespace StoryCollaborator.Models
+{
+    /// <summary>
+    /// Per-call cost reported by the proxy on the SSE stream's <c>collab_cost</c> event.
+    /// Null on <see cref="WorkflowResult"/> when the proxy sent no cost event
+    /// (old Worker, unpriced model, or the direct-OpenAI fallback path).
+    /// </summary>
+    public sealed record ProxyCostInfo(
+        string Workflow,
+        string Model,
+        int InputTokens,
+        int OutputTokens,
+        long CostMicrodollars)
+    {
+        /// <summary>
+        /// <see cref="CostMicrodollars"/> converted to dollars for display.
+        /// </summary>
+        public decimal CostUsd => CostMicrodollars / 1_000_000m;
+    }
+}

--- a/CollaboratorLib/Models/WorkflowResult.cs
+++ b/CollaboratorLib/Models/WorkflowResult.cs
@@ -50,6 +50,12 @@ public class WorkflowResult
     public string? RemoteTemplateHash { get; set; }
 
     /// <summary>
+    /// Cost reported by the proxy's <c>collab_cost</c> SSE event.
+    /// Null when the proxy sent no cost event (old Worker, unpriced model, direct-OpenAI fallback path).
+    /// </summary>
+    public ProxyCostInfo? Cost { get; set; }
+
+    /// <summary>
     /// Creates a successful result.
     /// </summary>
     public static WorkflowResult Succeeded()

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -101,9 +101,10 @@ namespace StoryCollaborator
                 result.AssembledPrompt = null;
                 try
                 {
-                    var (proxyContent, proxyHash) = await PostToProxyAsync(kernelArgs);
+                    var (proxyContent, proxyHash, proxyCost) = await PostToProxyAsync(kernelArgs);
                     planResult = proxyContent;
                     result.RemoteTemplateHash = proxyHash;
+                    result.Cost = proxyCost;
                 }
                 catch (HttpRequestException ex)
                 {
@@ -866,9 +867,10 @@ namespace StoryCollaborator
 
         /// <summary>
         /// Posts the workflow request to the proxy's /v1/workflow endpoint.
-        /// Returns the SSE response text and the X-Template-Hash header value (null on fallback path).
+        /// Returns the SSE response text, the X-Template-Hash header value (null on fallback path),
+        /// and the cost reported by the proxy's collab_cost event (null when absent).
         /// </summary>
-        private async Task<(string Content, string? TemplateHash)> PostToProxyAsync(KernelArguments kernelArgs)
+        private async Task<(string Content, string? TemplateHash, ProxyCostInfo? Cost)> PostToProxyAsync(KernelArguments kernelArgs)
         {
             var proxyBaseUrl = Environment.GetEnvironmentVariable("COLLAB_PROXY_URL")
                 ?? KernelFactory.DefaultProxyBaseUrl;
@@ -893,13 +895,14 @@ namespace StoryCollaborator
             if (response.Headers.TryGetValues("X-Template-Hash", out var hashValues))
                 templateHash = hashValues.FirstOrDefault();
 
-            var content = await ReadSseStreamAsync(response);
-            return (content, templateHash);
+            var (content, cost) = await ReadSseStreamAsync(response);
+            return (content, templateHash, cost);
         }
 
-        private static async Task<string> ReadSseStreamAsync(HttpResponseMessage response)
+        internal static async Task<(string Content, ProxyCostInfo? Cost)> ReadSseStreamAsync(HttpResponseMessage response)
         {
             var sb = new System.Text.StringBuilder();
+            ProxyCostInfo? cost = null;
             using var stream = await response.Content.ReadAsStreamAsync();
             using var reader = new StreamReader(stream);
             string? line;
@@ -919,10 +922,23 @@ namespace StoryCollaborator
                     {
                         sb.Append(content.GetString());
                     }
+                    else if (doc.RootElement.TryGetProperty("collab_cost", out var collabCost))
+                    {
+                        try
+                        {
+                            cost = new ProxyCostInfo(
+                                collabCost.GetProperty("workflow").GetString()!,
+                                collabCost.GetProperty("model").GetString()!,
+                                collabCost.GetProperty("input_tokens").GetInt32(),
+                                collabCost.GetProperty("output_tokens").GetInt32(),
+                                collabCost.GetProperty("cost_microdollars").GetInt64());
+                        }
+                        catch (Exception) { /* malformed collab_cost — skip, Cost stays null */ }
+                    }
                 }
                 catch (JsonException) { /* malformed chunk — skip */ }
             }
-            return sb.ToString();
+            return (sb.ToString(), cost);
         }
 
 

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -926,12 +926,17 @@ namespace StoryCollaborator
                     {
                         try
                         {
-                            cost = new ProxyCostInfo(
-                                collabCost.GetProperty("workflow").GetString()!,
-                                collabCost.GetProperty("model").GetString()!,
-                                collabCost.GetProperty("input_tokens").GetInt32(),
-                                collabCost.GetProperty("output_tokens").GetInt32(),
-                                collabCost.GetProperty("cost_microdollars").GetInt64());
+                            var workflow = collabCost.GetProperty("workflow").GetString();
+                            var model = collabCost.GetProperty("model").GetString();
+                            if (workflow is not null && model is not null)
+                            {
+                                cost = new ProxyCostInfo(
+                                    workflow,
+                                    model,
+                                    collabCost.GetProperty("input_tokens").GetInt32(),
+                                    collabCost.GetProperty("output_tokens").GetInt32(),
+                                    collabCost.GetProperty("cost_microdollars").GetInt64());
+                            }
                         }
                         catch (Exception) { /* malformed collab_cost — skip, Cost stays null */ }
                     }


### PR DESCRIPTION
## What changed

CollaboratorLib learns to read the cost event the Collaborator proxy now appends to each workflow SSE stream. One commit (`c34be84d`):

- `Models/ProxyCostInfo.cs` — new record: workflow, model, input/output tokens, cost in microdollars, with a `CostUsd` convenience property.
- `Models/WorkflowResult.cs` — gains `ProxyCostInfo? Cost`; null when the proxy sends no cost event (old Worker, unpriced model, direct-OpenAI fallback), so old-Worker behavior is unchanged.
- `WorkflowRunner.ReadSseStreamAsync` — returns `(Content, Cost)`; captures a `collab_cost` data line, skips malformed cost JSON without throwing; made `internal` for CollaboratorTests. Threaded through `PostToProxyAsync`.

## Why

Collaborator issue #91 (storybuilder-org/Collaborator#91): every workflow run must report what it cost, so workflow testing can weigh cost against quality. Design of record: `Collaborator/devdocs/issue_91_design.md`, section 6. The parser lives here because CollaboratorLib moved into this repo under issue #82; Collaborator and PromptTestRunner share this code path.

## How to test

- From the Collaborator repo (checked out beside this one, branch `issue-91-workflow-cost`): CollaboratorTests suite via vstest — 182 pass / 22 skip, including the four `ReadSseStream_*` parser-contract tests on canned SSE transcripts (no mocks, no live model).
- CollaboratorLib builds clean on both target frameworks.

## Release order

The production Worker must deploy its #91 cost code before or with any client release that ships this change; until then clients simply see `Cost == null` (by design, silent).

Companion Collaborator PR: storybuilder-org/Collaborator#93 (Worker, journal, display, docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
