### PR TITLE
feat: Collaborator client billing (#90) and SSE truncation retry (#94)

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
@@ -5,6 +6,7 @@ using Microsoft.SemanticKernel.ChatCompletion;
 using NLog.Extensions.Logging;
 using StoryCADLib.Models;
 using StoryCADLib.Services.Collaborator.Contracts;
+using StoryCADLib.Services.Store;
 using StoryCollaborator.Services;
 using StoryCollaborator.Models;
 using StoryCollaborator.Workflows;
@@ -381,13 +383,31 @@ public class Collaborator : ICollaborator
             catch (Exception ex)
             {
                 _logger?.LogError(ex, "Error processing chat message");
-                throw;
+                throw TranslateChatException(ex);
             }
         };
 
         _logger?.LogInformation("Chat callback wired for workflow: {Workflow} with {Count} elements in context",
             workflow.Title, gatheredElements.Count);
     }
+
+    /// <summary>
+    /// Issue #90 design section 10 "The cutoff" (ruling of 2026-07-15, step 10): the shipped chat
+    /// sidebar sends through Semantic Kernel to the Worker's /v1/chat/completions, which refuses
+    /// with 429 (before any upstream dispatch) when the caller's balance is at or below zero.
+    /// Semantic Kernel wraps a non-success HTTP response in <see cref="HttpOperationException"/>
+    /// (its <see cref="HttpOperationException.StatusCode"/> carries the code); this recognizes the
+    /// 429 shape and translates it to <see cref="OutOfCreditsException"/> so
+    /// WorkflowViewModel.SendButtonClicked's <c>ChatMessage.Error(ex.Message)</c> shows a message
+    /// naming the credits screen instead of the raw HTTP exception text. Every other exception
+    /// passes through unchanged. internal static and side-effect-free, so it is testable without a
+    /// live kernel call: construct an HttpOperationException directly (its public 4-arg
+    /// constructor takes the status code) and assert on the returned exception's type/message.
+    /// </summary>
+    internal static Exception TranslateChatException(Exception ex) =>
+        ex is HttpOperationException { StatusCode: HttpStatusCode.TooManyRequests }
+            ? new OutOfCreditsException()
+            : ex;
 
     /// <summary>
     /// Builds a readable text context from gathered story elements for the chat system message.

--- a/CollaboratorLib/Models/KernelFactory.cs
+++ b/CollaboratorLib/Models/KernelFactory.cs
@@ -59,7 +59,7 @@ namespace StoryCollaborator.Models
 
             throw new InvalidOperationException(
                 "AI features are unavailable: subscribe to Collaborator, or (for dev builds) enroll " +
-                "on the allowlist and set COLLAB_DEV_ENABLED=1.");
+                "on the allowlist and set COLLAB_DEV_ACTIVATION=1.");
         }
 
         /// <summary>

--- a/CollaboratorLib/Models/KernelFactory.cs
+++ b/CollaboratorLib/Models/KernelFactory.cs
@@ -8,8 +8,9 @@ using StoryCADLib.Services.Store;
 namespace StoryCollaborator.Models
 {
     /// <summary>
-    /// Single construction point for Semantic Kernel. Resolves the active path
-    /// (direct OpenAI or proxy) and logs it on every build, per D6.
+    /// Single construction point for Semantic Kernel. Resolves the proxy path from the
+    /// activation JWT alone (issue #90 step 8 items 5 and 6 retire the direct-OpenAI path and the
+    /// COLLAB_PROXY_TOKEN shared-secret fallback) and logs it on every build, per D6.
     /// </summary>
     public static class KernelFactory
     {
@@ -19,18 +20,15 @@ namespace StoryCollaborator.Models
 
         private const string ModelId = "gpt-5.4-nano";
 
-        public enum KernelPath { Direct, Proxy }
+        public enum KernelPath { Proxy }
 
         public record KernelConfig(KernelPath Path, string ModelId, string Endpoint, string Credential);
 
         /// <summary>
         /// Pure config resolution — no I/O, no side effects, injectable env/JWT sources for tests.
-        /// Resolution order:
-        ///   1. Activation JWT held (subscriber) → Proxy path; the JWT is the credential
-        ///      (issue #90 retires the shared secret on /workflow in favor of this token).
-        ///   2. COLLAB_PROXY_TOKEN set → Proxy path (developer shared secret).
-        ///   3. OPENAI_API_KEY set → Direct path (developer fallback only; reached when proxy unreachable).
-        ///   4. None → InvalidOperationException with a message naming the missing config.
+        /// Resolution: activation JWT held (subscriber, or dev/tester on the allowlist) → Proxy
+        /// path; the JWT is the sole credential (issue #90 retires the shared secret on /workflow
+        /// and the direct-OpenAI path in favor of this token). No JWT → InvalidOperationException.
         /// </summary>
         public static KernelConfig ResolveConfig(Func<string, string?>? getEnv = null,
             Func<string?>? getActivationJwt = null)
@@ -38,35 +36,26 @@ namespace StoryCollaborator.Models
             getEnv ??= Environment.GetEnvironmentVariable;
 
             var proxyUrl = getEnv("COLLAB_PROXY_URL") ?? DefaultProxyBaseUrl;
-            var credential = ResolveWorkflowCredential(getEnv, getActivationJwt);
+            var credential = ResolveWorkflowCredential(getActivationJwt);
 
             if (!string.IsNullOrWhiteSpace(credential))
                 return new KernelConfig(KernelPath.Proxy, ModelId, proxyUrl, credential);
 
-            var openAiKey = getEnv("OPENAI_API_KEY");
-            if (!string.IsNullOrWhiteSpace(openAiKey))
-                return new KernelConfig(KernelPath.Direct, ModelId, "https://api.openai.com/v1", openAiKey);
-
             throw new InvalidOperationException(
-                "AI features are unavailable: subscribe to Collaborator, or set COLLAB_PROXY_TOKEN " +
-                "for proxy access or OPENAI_API_KEY for direct OpenAI access.");
+                "AI features are unavailable: subscribe to Collaborator, or (for dev builds) enroll " +
+                "on the allowlist and set COLLAB_DEV_ENABLED=1.");
         }
 
         /// <summary>
         /// The Bearer credential for Collaborator proxy calls: the Worker-issued activation JWT
-        /// when the user is activated, else the COLLAB_PROXY_TOKEN shared secret, else null
-        /// (callers must refuse to call the proxy rather than send an unauthenticated request).
-        /// The activation contract requires the JWT on every Collaborator call
-        /// (StoryCADWiki: wiki/repos/Collaborator/sources/iap-billing-docs.md).
+        /// when the user is activated, else null (callers must refuse to call the proxy rather
+        /// than send an unauthenticated request). The activation contract requires the JWT on
+        /// every Collaborator call (StoryCADWiki: wiki/repos/Collaborator/sources/iap-billing-docs.md).
         /// </summary>
-        internal static string? ResolveWorkflowCredential(Func<string, string?>? getEnv = null,
-            Func<string?>? getActivationJwt = null)
+        internal static string? ResolveWorkflowCredential(Func<string?>? getActivationJwt = null)
         {
-            getEnv ??= Environment.GetEnvironmentVariable;
             getActivationJwt ??= GetActivationJwt;
-
-            var jwt = getActivationJwt();
-            return !string.IsNullOrWhiteSpace(jwt) ? jwt : getEnv("COLLAB_PROXY_TOKEN");
+            return getActivationJwt();
         }
 
         /// <summary>
@@ -104,10 +93,7 @@ namespace StoryCollaborator.Models
             if (loggerFactory is not null)
                 builder.Services.AddSingleton(loggerFactory);
 
-            if (config.Path == KernelPath.Direct)
-                builder.AddOpenAIChatCompletion(config.ModelId, config.Credential);
-            else
-                builder.AddOpenAIChatCompletion(config.ModelId, new Uri(config.Endpoint), config.Credential);
+            builder.AddOpenAIChatCompletion(config.ModelId, new Uri(config.Endpoint), config.Credential);
 
             return builder.Build();
         }

--- a/CollaboratorLib/Models/KernelFactory.cs
+++ b/CollaboratorLib/Models/KernelFactory.cs
@@ -25,6 +25,22 @@ namespace StoryCollaborator.Models
         public record KernelConfig(KernelPath Path, string ModelId, string Endpoint, string Credential);
 
         /// <summary>
+        /// Override for <see cref="GetActivationJwt"/>'s default Ioc-based lookup (issue #90 step
+        /// 11). PromptTestRunner and CollaboratorTests have no <c>IStoreActivationService</c>
+        /// wired up with a held JWT; when <c>COLLAB_DEV_GUID</c> is set, each host activates on
+        /// the dev/tester allowlist itself (via the same <c>IActivationClient</c> /
+        /// <c>ProxyActivationClient</c> path StoryCAD's client uses) and sets this once at
+        /// startup, so every zero-argument credential resolution -- both
+        /// <see cref="ResolveWorkflowCredential(Func{string?}?)"/>'s workflow calls and
+        /// <see cref="Build"/>'s Semantic Kernel chat path -- picks up the same token. Null (the
+        /// default) leaves the existing Ioc-based resolution unchanged; shipped CollaboratorLib
+        /// and StoryCAD code never sets this (design section 2, D6: "shipped client code never
+        /// reads it" is about the env var, not this seam, but the intent -- no shipped path
+        /// depends on dev/tester tooling -- is the same).
+        /// </summary>
+        public static Func<string?>? DevActivationJwtProvider { get; set; }
+
+        /// <summary>
         /// Pure config resolution — no I/O, no side effects, injectable env/JWT sources for tests.
         /// Resolution: activation JWT held (subscriber, or dev/tester on the allowlist) → Proxy
         /// path; the JWT is the sole credential (issue #90 retires the shared secret on /workflow
@@ -59,12 +75,16 @@ namespace StoryCollaborator.Models
         }
 
         /// <summary>
-        /// The activation JWT held by StoryCAD's store-activation service, or null when the user
-        /// is not activated or IoC is not configured (PromptTestRunner, CollaboratorTests).
-        /// Read per call, never cached here: the service refreshes the JWT as it expires.
+        /// <see cref="DevActivationJwtProvider"/> first (issue #90 step 11 hosts); otherwise the
+        /// activation JWT held by StoryCAD's store-activation service, or null when the user is
+        /// not activated or IoC is not configured. Read per call, never cached here: the service
+        /// refreshes the JWT as it expires.
         /// </summary>
         internal static string? GetActivationJwt()
         {
+            if (DevActivationJwtProvider is not null)
+                return DevActivationJwtProvider();
+
             try
             {
                 return Ioc.Default.GetService<IStoreActivationService>()?.CurrentJwt;

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading.Tasks;
 using CollaboratorLib.Context;
+using CommunityToolkit.Mvvm.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using StoryCADLib.Models;
@@ -24,7 +24,6 @@ namespace StoryCollaborator
     {
         private static readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromMinutes(3) };
 
-        private Kernel _kernel;
         private IStoryCADAPI _storyApi;
         private StoryModel storyModel;
         private Workflow workflowModel;
@@ -32,11 +31,13 @@ namespace StoryCollaborator
         private CollaboratorSettings _settings;
         private readonly StoryCADLib.Services.Logging.ILogService? _auditLogger;
 
+        // No Kernel field: issue #90 step 8 item 5 retired the direct-OpenAI Semantic Kernel
+        // invocation path (InvokeDirectAsync), which was the only reason this class held one.
+        // PostToProxyAsync talks to the Worker over plain HttpClient, never through SK.
         internal WorkflowRunner(StoryModel model, Workflow workflow, IStoryCADAPI api, ILogger<WorkflowRunner>? logger = null, CollaboratorSettings? settings = null, StoryCADLib.Services.Logging.ILogService? auditLogger = null)
         {
             storyModel = model;
             workflowModel = workflow;
-            _kernel = KernelInitializer.Kernel;
             _logger = logger;
             _settings = settings ?? CollaboratorSettings.Default;
             _storyApi = api;
@@ -76,10 +77,10 @@ namespace StoryCollaborator
                     return WorkflowResult.Failed($"Missing required element: '{requirement.ElementLabel}'");
             }
 
-            // A subscriber's activation JWT counts as a proxy credential; without any
-            // credential the workflow degrades to the stub rather than calling out bare.
-            if (string.IsNullOrWhiteSpace(KernelFactory.ResolveWorkflowCredential()) &&
-                string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OPENAI_API_KEY")))
+            // Without a subscriber's (or allowlisted dev/tester's) activation JWT, the workflow
+            // degrades to the stub rather than calling out bare (issue #90 step 8 item 5: the
+            // OPENAI_API_KEY direct-to-OpenAI path retired, so a held JWT is the only credential).
+            if (string.IsNullOrWhiteSpace(KernelFactory.ResolveWorkflowCredential()))
             {
                 return BuildStubResponse();
             }
@@ -99,37 +100,14 @@ namespace StoryCollaborator
                 if (workflowIO.ExampleLists.Count > 0)
                     EnrichWithExamples(kernelArgs);
 
-                string planResult;
+                // Issue #90 step 8 item 5: the direct-to-OpenAI fallback retired along with
+                // OPENAI_API_KEY on the client. A proxy failure now propagates to the outer
+                // catch clauses below rather than retrying against OpenAI directly.
                 result.AssembledPrompt = null;
-                try
-                {
-                    var (proxyContent, proxyHash, proxyCost) = await PostToProxyAsync(kernelArgs);
-                    planResult = proxyContent;
-                    result.RemoteTemplateHash = proxyHash;
-                    result.Cost = proxyCost;
-                }
-                catch (HttpRequestException ex)
-                {
-                    var fallbackKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
-                    if (!string.IsNullOrWhiteSpace(fallbackKey))
-                    {
-                        _logger?.LogWarning($"fallback: direct, reason: {ex.GetType().Name}");
-                        result.AssembledPrompt = RenderTemplate(kernelArgs);
-                        planResult = await InvokeDirectAsync(kernelArgs);
-                    }
-                    else throw;
-                }
-                catch (TaskCanceledException ex)
-                {
-                    var fallbackKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
-                    if (!string.IsNullOrWhiteSpace(fallbackKey))
-                    {
-                        _logger?.LogWarning($"fallback: direct, reason: {ex.GetType().Name}");
-                        result.AssembledPrompt = RenderTemplate(kernelArgs);
-                        planResult = await InvokeDirectAsync(kernelArgs);
-                    }
-                    else throw;
-                }
+                var (proxyContent, proxyHash, proxyCost) = await PostToProxyAsync(kernelArgs);
+                string planResult = proxyContent;
+                result.RemoteTemplateHash = proxyHash;
+                result.Cost = proxyCost;
 
                 result.RawResponse = planResult;
 
@@ -253,125 +231,6 @@ namespace StoryCollaborator
             }
 
             return kernelArgs;
-        }
-
-        /// <summary>
-        /// Loads the raw prompt template for the current workflow.
-        /// Reads from COLLAB_TEMPLATE_DIR (points directly at the WorkflowPlans source folder).
-        /// </summary>
-        internal string? LoadTemplate()
-        {
-            try
-            {
-                var templateDir = Environment.GetEnvironmentVariable("COLLAB_TEMPLATE_DIR");
-                if (string.IsNullOrEmpty(templateDir)) return null;
-
-                var templatePath = Path.Combine(templateDir, workflowModel.Label, "skprompt.txt");
-                if (!File.Exists(templatePath)) return null;
-
-                return File.ReadAllText(templatePath);
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning($"Failed to load template: {ex.Message}");
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Renders the prompt template with kernel arguments substituted.
-        /// </summary>
-        internal string? RenderTemplate(KernelArguments kernelArgs)
-        {
-            var template = LoadTemplate();
-            if (string.IsNullOrEmpty(template)) return null;
-
-            try
-            {
-                foreach (var kvp in kernelArgs)
-                {
-                    var skPlaceholder = $"{{{{${kvp.Key}}}}}";
-                    var value = kvp.Value?.ToString() ?? string.Empty;
-                    template = template.Replace(skPlaceholder, value);
-
-                    var simplePlaceholder = $"{{{{{kvp.Key}}}}}";
-                    template = template.Replace(simplePlaceholder, value);
-                }
-
-                return template;
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning($"Failed to render template: {ex.Message}");
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Invokes the workflow plan via Semantic Kernel (direct path; used as fallback when proxy is unavailable).
-        /// COLLAB_TEMPLATE_DIR must point at the WorkflowPlans source folder; the parent is used as the plugin base.
-        /// </summary>
-        private async Task<string> InvokeDirectAsync(KernelArguments kernelArgs)
-        {
-            var templateDir = Environment.GetEnvironmentVariable("COLLAB_TEMPLATE_DIR");
-            if (string.IsNullOrEmpty(templateDir))
-            {
-                throw new InvalidOperationException("COLLAB_TEMPLATE_DIR environment variable not set");
-            }
-            var pluginBasePath = Path.GetDirectoryName(templateDir)
-                ?? throw new InvalidOperationException("COLLAB_TEMPLATE_DIR has no parent directory");
-
-            var functionsPath = Path.Combine(pluginBasePath, "WorkflowFunctions", workflowModel.Label);
-            if (Directory.Exists(functionsPath))
-            {
-                foreach (var pluginDir in Directory.GetDirectories(functionsPath))
-                {
-                    var pluginName = System.IO.Path.GetFileName(pluginDir);
-                    if (!_kernel.Plugins.TryGetPlugin(pluginName, out _))
-                    {
-                        _kernel.ImportPluginFromPromptDirectory(pluginDir);
-                    }
-                }
-            }
-
-            var plansPath = Path.Combine(pluginBasePath, "WorkflowPlans");
-            if (!_kernel.Plugins.TryGetPlugin("WorkflowPlans", out _))
-            {
-                if (!Directory.Exists(plansPath))
-                {
-                    throw new InvalidOperationException($"Workflow plans directory not found: {plansPath}");
-                }
-                _kernel.ImportPluginFromPromptDirectory(plansPath);
-            }
-
-            if (!_kernel.Plugins.TryGetPlugin("WorkflowPlans", out var planPlugin))
-            {
-                throw new InvalidOperationException("WorkflowPlans plugin not loaded");
-            }
-
-            if (!planPlugin.TryGetFunction(workflowModel.Label, out var plan))
-            {
-                throw new InvalidOperationException($"Workflow plan not found: {workflowModel.Label}");
-            }
-
-            FunctionResult functionResult;
-            try
-            {
-                functionResult = await _kernel.InvokeAsync(plan, kernelArgs);
-            }
-            catch (Exception ex)
-            {
-                _auditLogger?.LogException(StoryCADLib.Services.Logging.LogLevel.Error, ex,
-                    $"Semantic Kernel invocation failed for workflow: {workflowModel.Label}");
-                throw;
-            }
-            var responseText = functionResult.ToString();
-
-            _logger?.LogInformation("=== RAW AI RESPONSE ===");
-            _logger?.LogInformation(responseText);
-            _logger?.LogInformation("=== END RAW AI RESPONSE ===");
-
-            return responseText;
         }
 
         /// <summary>
@@ -884,13 +743,6 @@ namespace StoryCollaborator
         {
             var proxyBaseUrl = Environment.GetEnvironmentVariable("COLLAB_PROXY_URL")
                 ?? KernelFactory.DefaultProxyBaseUrl;
-            // Resolved per call: a subscriber's activation JWT replaces the shared secret
-            // (the Worker retires the shared secret on /workflow under issue #90), and the
-            // JWT rotates ~12-hourly so it must never be cached across calls.
-            var credential = KernelFactory.ResolveWorkflowCredential();
-            if (string.IsNullOrWhiteSpace(credential))
-                throw new InvalidOperationException(
-                    "No activation token held and COLLAB_PROXY_TOKEN not set; refusing to call the proxy workflow endpoint without a credential.");
 
             var args = new Dictionary<string, string>();
             foreach (var kvp in kernelArgs)
@@ -898,9 +750,20 @@ namespace StoryCollaborator
 
             var payload = JsonSerializer.Serialize(new { workflowId = workflowModel.Label, args });
 
-            using var request = CreateWorkflowRequest(proxyBaseUrl, credential, payload);
+            var response = await SendWithReactivationRetryAsync(
+                () => SendWorkflowRequestAsync(proxyBaseUrl, payload), ReactivateAsync);
 
-            var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            {
+                response.Dispose();
+                // No activation token held (never activated, or one reactivation attempt above
+                // still didn't produce one): refuse client-side rather than let
+                // EnsureSuccessStatusCode()'s generic "does not indicate success: 401" surface.
+                throw new InvalidOperationException(
+                    "No activation token held; refusing to call the proxy workflow endpoint without " +
+                    "a credential. Subscribe to Collaborator, or (for dev builds) enroll on the allowlist.");
+            }
+
             EnsureNotOutOfCredits(response);
             response.EnsureSuccessStatusCode();
 
@@ -913,16 +776,73 @@ namespace StoryCollaborator
         }
 
         /// <summary>
+        /// Sends one attempt of the workflow POST. Resolved per call: a subscriber's (or
+        /// allowlisted dev/tester's) activation JWT is the sole credential (issue #90 step 8 item
+        /// 6 retires the COLLAB_PROXY_TOKEN shared-secret fallback), and the JWT rotates
+        /// ~12-hourly so it must never be cached across calls. No credential available returns a
+        /// synthetic 401 rather than throwing, so <see cref="SendWithReactivationRetryAsync" />
+        /// handles a missing credential the same way it handles the Worker's own 401 (design
+        /// section 11's failure-mode row groups "JWT missing, invalid, or expired" together).
+        /// </summary>
+        private async Task<HttpResponseMessage> SendWorkflowRequestAsync(string proxyBaseUrl, string payload)
+        {
+            var credential = KernelFactory.ResolveWorkflowCredential();
+            if (string.IsNullOrWhiteSpace(credential))
+                return new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized);
+
+            using var request = CreateWorkflowRequest(proxyBaseUrl, credential, payload);
+            return await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+        }
+
+        // Re-activation trigger for the 401-refresh-once-and-retry policy (issue #90 step 8 item
+        // 7). No-op if IoC has no activation service configured (PromptTestRunner, tests) --
+        // matches KernelFactory.GetActivationJwt's InvalidOperationException guard for the same host.
+        private static Task ReactivateAsync()
+        {
+            try
+            {
+                var service = Ioc.Default.GetService<StoryCADLib.Services.Store.IStoreActivationService>();
+                return service?.ReactivateAsync() ?? Task.CompletedTask;
+            }
+            catch (InvalidOperationException)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>
+        /// 401-refresh-once-and-retry (issue #90 step 8 item 7 / design section 11's expired-token
+        /// row): a workflow call that comes back 401 refreshes the activation once through
+        /// re-activation and retries with the refreshed credential before failing. Exactly one
+        /// retry -- a second 401 is returned as-is so the caller's handling surfaces it rather than
+        /// looping. internal static and testable without a live HTTP transport or activation flow:
+        /// sendRequest and reactivate are injected, matching CreateWorkflowRequest/
+        /// EnsureNotOutOfCredits's existing testable-without-network pattern in this class.
+        /// </summary>
+        internal static async Task<HttpResponseMessage> SendWithReactivationRetryAsync(
+            Func<Task<HttpResponseMessage>> sendRequest, Func<Task> reactivate)
+        {
+            var response = await sendRequest();
+            if (response.StatusCode != System.Net.HttpStatusCode.Unauthorized)
+                return response;
+
+            response.Dispose();
+            await reactivate();
+            return await sendRequest();
+        }
+
+        /// <summary>
         /// Issue #90 design section 10 "The cutoff" (ruling of 2026-07-15, step 10): the Worker
         /// refuses a workflow call with 429 before any upstream dispatch when the caller's balance
         /// is at or below zero. Checked before EnsureSuccessStatusCode() so the thrown exception is
         /// StoryCADLib.Services.Store.OutOfCreditsException, not the generic HttpRequestException
         /// EnsureSuccessStatusCode() would otherwise produce (message: "Response status code does
-        /// not indicate success: 429"). Deliberately not an HttpRequestException itself: the
-        /// existing `catch (HttpRequestException ex)` clause in RunAsync retries direct against
-        /// OpenAI when OPENAI_API_KEY is set (the enforcement-bypass fallback issue #90 step 8
-        /// retires) -- an out-of-credits refusal must never be caught there, or a capped user with a
-        /// personal API key would route straight around the balance cutoff. internal static and
+        /// not indicate success: 429"). Deliberately not an HttpRequestException itself, so it can
+        /// never be mistaken for a transport failure and swallowed by ordinary HTTP error handling:
+        /// an out-of-credits refusal must always reach the caller as its own recognizable state
+        /// (step 8 item 5 retired the direct-to-OpenAI fallback that used to make this distinction
+        /// load-bearing for a different reason -- routing a capped user's personal API key around
+        /// the balance cutoff -- but the exception stays distinct regardless). internal static and
         /// side-effect-free on success, matching CreateWorkflowRequest/ReadSseStreamAsync's existing
         /// testable-without-HTTP-transport pattern in this class.
         /// </summary>

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -157,6 +157,14 @@ namespace StoryCollaborator
 
                 return result;
             }
+            catch (StoryCADLib.Services.Store.OutOfCreditsException ex)
+            {
+                // Issue #90 design section 10 (step 10): shown as-is, not wrapped in
+                // "Workflow execution failed: ..." -- this is a recognized, actionable state
+                // (buy more credits or wait for renewal), not an unexpected failure.
+                _logger?.LogWarning("Workflow call refused: out of credits ({Workflow})", workflowModel.Title);
+                return WorkflowResult.Failed(ex.Message);
+            }
             catch (Exception ex)
             {
                 _logger?.LogError(ex, "WorkflowRunner.RunAsync error");
@@ -893,6 +901,7 @@ namespace StoryCollaborator
             using var request = CreateWorkflowRequest(proxyBaseUrl, credential, payload);
 
             var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            EnsureNotOutOfCredits(response);
             response.EnsureSuccessStatusCode();
 
             string? templateHash = null;
@@ -901,6 +910,26 @@ namespace StoryCollaborator
 
             var (content, cost) = await ReadSseStreamAsync(response);
             return (content, templateHash, cost);
+        }
+
+        /// <summary>
+        /// Issue #90 design section 10 "The cutoff" (ruling of 2026-07-15, step 10): the Worker
+        /// refuses a workflow call with 429 before any upstream dispatch when the caller's balance
+        /// is at or below zero. Checked before EnsureSuccessStatusCode() so the thrown exception is
+        /// StoryCADLib.Services.Store.OutOfCreditsException, not the generic HttpRequestException
+        /// EnsureSuccessStatusCode() would otherwise produce (message: "Response status code does
+        /// not indicate success: 429"). Deliberately not an HttpRequestException itself: the
+        /// existing `catch (HttpRequestException ex)` clause in RunAsync retries direct against
+        /// OpenAI when OPENAI_API_KEY is set (the enforcement-bypass fallback issue #90 step 8
+        /// retires) -- an out-of-credits refusal must never be caught there, or a capped user with a
+        /// personal API key would route straight around the balance cutoff. internal static and
+        /// side-effect-free on success, matching CreateWorkflowRequest/ReadSseStreamAsync's existing
+        /// testable-without-HTTP-transport pattern in this class.
+        /// </summary>
+        internal static void EnsureNotOutOfCredits(HttpResponseMessage response)
+        {
+            if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+                throw new StoryCADLib.Services.Store.OutOfCreditsException();
         }
 
         /// <summary>

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using CollaboratorLib.Context;
 using CommunityToolkit.Mvvm.DependencyInjection;
@@ -22,7 +23,26 @@ namespace StoryCollaborator
 
     internal class WorkflowRunner
     {
-        private static readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromMinutes(3) };
+        private static HttpClient _httpClient = new() { Timeout = TimeSpan.FromMinutes(3) };
+
+        // Test-only accessor (issue #94 design section 5 item 2): lets
+        // WorkflowRunnerTruncationTests.cs observe ResetHttpClient's swap without any network activity.
+        internal static HttpClient CurrentHttpClient => _httpClient;
+
+        /// <summary>
+        /// Swaps in a fresh HttpClient, disposing the old one (issue #94 design section 5 item 2):
+        /// the truncation retry calls this to abandon the pooled connection, which server evidence
+        /// pins to a flagged Cloudflare isolate after a mid-stream kill (design doc section 2, phase
+        /// C). Safe because workflow calls are sequential -- the UI runs one workflow at a time,
+        /// PromptTestRunner and the tests included -- and the chat sidebar uses Semantic Kernel's own
+        /// HttpClient, untouched here.
+        /// </summary>
+        internal static void ResetHttpClient()
+        {
+            var fresh = new HttpClient { Timeout = TimeSpan.FromMinutes(3) };
+            var old = Interlocked.Exchange(ref _httpClient, fresh);
+            old.Dispose();
+        }
 
         private IStoryCADAPI _storyApi;
         private StoryModel storyModel;
@@ -104,11 +124,20 @@ namespace StoryCollaborator
                 // OPENAI_API_KEY on the client. A proxy failure now propagates to the outer
                 // catch clauses below rather than retrying against OpenAI directly.
                 result.AssembledPrompt = null;
-                var (proxyContent, proxyHash, proxyCost) = await PostToProxyAsync(kernelArgs);
-                string planResult = proxyContent;
+                var (proxyContent, proxyHash, proxyCost, proxyComplete) = await PostToProxyAsync(kernelArgs);
                 result.RemoteTemplateHash = proxyHash;
                 result.Cost = proxyCost;
 
+                if (!proxyComplete)
+                {
+                    // Issue #94 design section 5 item 3 ("surface, never mask"): the one truncation
+                    // retry (PostToProxyAsync -> ExecuteWithTruncationRetryAsync) still came back
+                    // incomplete. The partial text is preserved for diagnostics but must never reach
+                    // ExtractOutputs or a Success result.
+                    return BuildTruncationFailureResult(proxyContent);
+                }
+
+                string planResult = proxyContent;
                 result.RawResponse = planResult;
 
                 if (string.IsNullOrEmpty(planResult))
@@ -735,11 +764,13 @@ namespace StoryCollaborator
         }
 
         /// <summary>
-        /// Posts the workflow request to the proxy's /v1/workflow endpoint.
+        /// Posts the workflow request to the proxy's /v1/workflow endpoint, retrying once on a
+        /// fresh connection if the stream comes back truncated (issue #94 design section 5 item 2).
         /// Returns the SSE response text, the X-Template-Hash header value (null on fallback path),
-        /// and the cost reported by the proxy's collab_cost event (null when absent).
+        /// the cost reported by the proxy's collab_cost event (null when absent), and whether the
+        /// returned stream (after the retry, if one occurred) is complete.
         /// </summary>
-        private async Task<(string Content, string? TemplateHash, ProxyCostInfo? Cost)> PostToProxyAsync(KernelArguments kernelArgs)
+        private async Task<(string Content, string? TemplateHash, ProxyCostInfo? Cost, bool Complete)> PostToProxyAsync(KernelArguments kernelArgs)
         {
             var proxyBaseUrl = Environment.GetEnvironmentVariable("COLLAB_PROXY_URL")
                 ?? KernelFactory.DefaultProxyBaseUrl;
@@ -750,6 +781,18 @@ namespace StoryCollaborator
 
             var payload = JsonSerializer.Serialize(new { workflowId = workflowModel.Label, args });
 
+            return await ExecuteWithTruncationRetryAsync(
+                () => PostToProxyOnceAsync(proxyBaseUrl, payload), ResetHttpClient);
+        }
+
+        /// <summary>
+        /// One attempt of the full send-plus-read sequence PostToProxyAsync's truncation retry
+        /// wraps: credential resolution via SendWithReactivationRetryAsync, the 401 guard,
+        /// EnsureNotOutOfCredits, EnsureSuccessStatusCode, the X-Template-Hash header read, then
+        /// ReadSseStreamAsync (issue #94 design section 5 item 2).
+        /// </summary>
+        private async Task<(string Content, string? TemplateHash, ProxyCostInfo? Cost, bool Complete)> PostToProxyOnceAsync(string proxyBaseUrl, string payload)
+        {
             var response = await SendWithReactivationRetryAsync(
                 () => SendWorkflowRequestAsync(proxyBaseUrl, payload), ReactivateAsync);
 
@@ -771,8 +814,8 @@ namespace StoryCollaborator
             if (response.Headers.TryGetValues("X-Template-Hash", out var hashValues))
                 templateHash = hashValues.FirstOrDefault();
 
-            var (content, cost) = await ReadSseStreamAsync(response);
-            return (content, templateHash, cost);
+            var (content, cost, complete) = await ReadSseStreamAsync(response);
+            return (content, templateHash, cost, complete);
         }
 
         /// <summary>
@@ -864,10 +907,18 @@ namespace StoryCollaborator
             return request;
         }
 
-        internal static async Task<(string Content, ProxyCostInfo? Cost)> ReadSseStreamAsync(HttpResponseMessage response)
+        /// <summary>
+        /// Reads the /workflow endpoint's SSE stream to completion. Complete is true iff a
+        /// <c>data: [DONE]</c> line was actually read -- the Worker appends it on every complete
+        /// stream, including the cost-missing and unpriced-model paths, so its absence is a
+        /// truncation with no false-positive source (issue #94 design section 5 item 1). collab_cost
+        /// stays optional (ADR-002 fail-open): [DONE] without a cost event is still Complete=true.
+        /// </summary>
+        internal static async Task<(string Content, ProxyCostInfo? Cost, bool Complete)> ReadSseStreamAsync(HttpResponseMessage response)
         {
             var sb = new System.Text.StringBuilder();
             ProxyCostInfo? cost = null;
+            bool complete = false;
             using var stream = await response.Content.ReadAsStreamAsync();
             using var reader = new StreamReader(stream);
             string? line;
@@ -875,7 +926,7 @@ namespace StoryCollaborator
             {
                 if (!line.StartsWith("data: ")) continue;
                 var data = line.Substring(6).Trim();
-                if (data == "[DONE]") break;
+                if (data == "[DONE]") { complete = true; break; }
                 try
                 {
                     using var doc = JsonDocument.Parse(data);
@@ -908,7 +959,48 @@ namespace StoryCollaborator
                 }
                 catch (JsonException) { /* malformed chunk — skip */ }
             }
-            return (sb.ToString(), cost);
+            return (sb.ToString(), cost, complete);
+        }
+
+        /// <summary>
+        /// Truncation-retry-once policy (issue #94 design section 5 items 2-3): a stream that comes
+        /// back incomplete (no <c>data: [DONE]</c> read -- <see cref="ReadSseStreamAsync"/>) resets
+        /// the shared HttpClient (abandoning the pooled connection -- server evidence pins it to a
+        /// flagged Cloudflare isolate after a kill, so a same-connection retry would die again) and
+        /// re-sends once end-to-end through the same credential path before returning the (possibly
+        /// still incomplete) result to the caller. Exactly one retry, mirroring
+        /// <see cref="SendWithReactivationRetryAsync"/>'s refresh-once-and-retry shape. internal
+        /// static and testable without a live HTTP transport: attempt and reset are injected,
+        /// matching this class's existing testable-without-network pattern.
+        /// </summary>
+        internal static async Task<(string Content, string? TemplateHash, ProxyCostInfo? Cost, bool Complete)> ExecuteWithTruncationRetryAsync(
+            Func<Task<(string Content, string? TemplateHash, ProxyCostInfo? Cost, bool Complete)>> attempt,
+            Action reset)
+        {
+            var result = await attempt();
+            if (result.Complete)
+                return result;
+
+            reset();
+            return await attempt();
+        }
+
+        /// <summary>
+        /// Issue #94 design section 5 item 3 ("surface, never mask"): builds the failed result for a
+        /// stream that came back incomplete even after PostToProxyAsync's one truncation retry. The
+        /// partial text is preserved in RawResponse for diagnostics; it never reaches ExtractOutputs
+        /// or a Success result. internal static and pinned directly by its own test (driving RunAsync
+        /// end-to-end here would require faking HTTP), per the NO MOCKS rule in
+        /// Collaborator/CLAUDE.md.
+        /// </summary>
+        internal static WorkflowResult BuildTruncationFailureResult(string partialContent)
+        {
+            return new WorkflowResult
+            {
+                Success = false,
+                ErrorMessage = "The AI response stream ended before completion; the answer may be incomplete. Please try again.",
+                RawResponse = partialContent
+            };
         }
 
 

--- a/StoryCAD/App.xaml.cs
+++ b/StoryCAD/App.xaml.cs
@@ -222,6 +222,11 @@ public partial class App : Application
         //Load user preferences or initialise them.
         await new PreferencesIo().ReadPreferences();
 
+        // Explicit startup step (issue #90 D8 as amended): generate and persist the client-side
+        // user GUID on first launch, before store activation ever runs. Must run after
+        // ReadPreferences and before the activation kickoff below.
+        await Preferences.EnsureUserGuidProvisionedAsync();
+
         // Restore macOS security-scoped bookmarks so previously selected folders remain accessible
         if (OperatingSystem.IsMacOS())
         {

--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -428,6 +428,15 @@
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE71B;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
+                <AppBarButton Width="50" IsCompact="True" Label="Buy Credits"
+                              ToolTipService.ToolTip="Buy Collaborator Credits"
+                              AutomationProperties.AutomationId="BuyCreditsButton"
+                              Visibility="{x:Bind ShellVm.CollaboratorVisibility, Mode=OneWay}"
+                              Command="{x:Bind ShellVm.BuyCreditsCommand, Mode=OneWay}">
+                    <AppBarButton.Icon>
+                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE719;" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
                 <AppBarButton Width="50" IsCompact="True" Label="Tools" ToolTipService.ToolTip="Tools Menu"
                               AutomationProperties.AutomationId="ToolsMenuButton">
                     <AppBarButton.Icon>

--- a/StoryCADLib/DAL/PreferencesIo.cs
+++ b/StoryCADLib/DAL/PreferencesIo.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Microsoft.UI;
 using StoryCADLib.Models.Tools;
 using StoryCADLib.Services;
@@ -12,6 +13,15 @@ namespace StoryCADLib.DAL;
 /// </summary>
 public class PreferencesIo
 {
+    // Masks StoreUserGuid's value in the two debug lines below that log the whole preferences
+    // JSON (issue #90 D8): the GUID must never appear in a log at any level, and these lines are
+    // the only place the full-JSON dump exposes it.
+    private static readonly Regex UserGuidLogPattern = new(
+        "(\"StoreUserGuid\"\\s*:\\s*\")[^\"]*(\")", RegexOptions.Compiled);
+
+    private static string MaskUserGuidForLog(string preferencesJson) =>
+        UserGuidLogPattern.Replace(preferencesJson, "$1***$2");
+
     private readonly AppState _appState;
     private readonly ILogService _log;
     private readonly PreferenceService _preferenceService;
@@ -49,7 +59,7 @@ public class PreferencesIo
                     _log.Log(LogLevel.Info, "Preferences.json found, reading it.");
                     StorageFile _preferencesFile = await StorageFile.GetFileFromPathAsync(PreferencesFilePath);
                     var _preferencesJson = await FileIO.ReadTextAsync(_preferencesFile);
-                    _log.Log(LogLevel.Debug, $"Preferences Contents: {_preferencesJson}");
+                    _log.Log(LogLevel.Debug, $"Preferences Contents: {MaskUserGuidForLog(_preferencesJson)}");
 
                     //Update _model, with new values.
                     _model = JsonSerializer.Deserialize<PreferencesModel>(_preferencesJson);
@@ -138,7 +148,7 @@ public class PreferencesIo
                     CreationCollisionOption.OpenIfExists);
 
                 //Log and write.
-                _log.Log(LogLevel.Debug, $"Serialised preferences as {_newPreferences}");
+                _log.Log(LogLevel.Debug, $"Serialised preferences as {MaskUserGuidForLog(_newPreferences)}");
                 await FileIO.WriteTextAsync(_preferencesFile, _newPreferences); //Writes file to disk
                 _log.Log(LogLevel.Info, "Preferences write complete.");
             }, CancellationToken.None, _log);

--- a/StoryCADLib/Models/Tools/PreferencesModel.cs
+++ b/StoryCADLib/Models/Tools/PreferencesModel.cs
@@ -284,7 +284,9 @@ public class PreferencesModel : ObservableObject
 
     /// <summary>
     ///     Stable per-user GUID embedded in the store's signed purchase proof (Apple
-    ///     appAccountToken / Microsoft publisherUserId). Must match the server users.guid.
+    ///     appAccountToken / Microsoft publisherUserId). Generated on this machine at first
+    ///     launch if empty (issue #90 D8); no server mints or stores it, and it never appears in
+    ///     the UI or in a log.
     /// </summary>
     [JsonInclude]
     [JsonPropertyName("StoreUserGuid")]

--- a/StoryCADLib/Services/Collaborator/CollaboratorService.cs
+++ b/StoryCADLib/Services/Collaborator/CollaboratorService.cs
@@ -73,10 +73,11 @@ public class CollaboratorService
             return;
         }
 
-        // Issue #90 ruling of 2026-07-15: the COLLAB_DEV_ENABLED purchase-check bypass retired.
+        // Issue #90 ruling of 2026-07-15: the old COLLAB_DEV_ENABLED purchase-check bypass retired.
         // Entitlement is holding a valid activation, however obtained -- including via the
-        // dev/tester allowlist, which COLLAB_DEV_ENABLED now only routes StoreActivationService
-        // toward (item 3), rather than skipping this check.
+        // dev/tester allowlist, which COLLAB_DEV_ACTIVATION (renamed from COLLAB_DEV_ENABLED,
+        // 2026-07-17) only routes StoreActivationService toward (item 3), rather than skipping
+        // this check.
         if (!IsPurchaseVerified())
         {
             _logService.Log(LogLevel.Warn, "Collaborator blocked: no active store activation.");

--- a/StoryCADLib/Services/Collaborator/CollaboratorService.cs
+++ b/StoryCADLib/Services/Collaborator/CollaboratorService.cs
@@ -73,10 +73,13 @@ public class CollaboratorService
             return;
         }
 
-        bool devEnabled = Environment.GetEnvironmentVariable("COLLAB_DEV_ENABLED") == "1";
-        if (!devEnabled && !IsPurchaseVerified())
+        // Issue #90 ruling of 2026-07-15: the COLLAB_DEV_ENABLED purchase-check bypass retired.
+        // Entitlement is holding a valid activation, however obtained -- including via the
+        // dev/tester allowlist, which COLLAB_DEV_ENABLED now only routes StoreActivationService
+        // toward (item 3), rather than skipping this check.
+        if (!IsPurchaseVerified())
         {
-            _logService.Log(LogLevel.Warn, "Collaborator blocked: purchase not verified and COLLAB_DEV_ENABLED != 1");
+            _logService.Log(LogLevel.Warn, "Collaborator blocked: no active store activation.");
             // Offer the subscription. If the user completes it (now Active), fall through and open
             // Collaborator; otherwise stop here.
             if (!await ShowSubscribeDialogAsync())

--- a/StoryCADLib/Services/Collaborator/CollaboratorService.cs
+++ b/StoryCADLib/Services/Collaborator/CollaboratorService.cs
@@ -65,11 +65,15 @@ public class CollaboratorService
             return;
         }
 
-        // Get the current StoryModel from AppState
+        // Get the current StoryModel from AppState. Close/Reset leaves a non-null document
+        // with an empty model (FilePath null, CurrentView empty) — same gate as Print Reports.
         var storyModel = _appState.CurrentDocument?.Model;
-        if (storyModel == null)
+        if (storyModel == null || storyModel.CurrentView.Count == 0)
         {
-            _logService.Log(LogLevel.Error, "No StoryModel available - no document is open");
+            _logService.Log(LogLevel.Warn, "No story is open; Collaborator not started.");
+            WeakReferenceMessenger.Default.Send(new StatusChangedMessage(
+                new StatusMessage("No story is open. Open an outline before using Collaborator.",
+                    LogLevel.Warn)));
             return;
         }
 

--- a/StoryCADLib/Services/Collaborator/CollaboratorService.cs
+++ b/StoryCADLib/Services/Collaborator/CollaboratorService.cs
@@ -171,6 +171,38 @@ public class CollaboratorService
         return await vm.ShowAsync(windowing);
     }
 
+    /// <summary>
+    ///     Offers a credit-pack purchase via <see cref="BuyCreditsDialogViewModel.ShowAsync" />
+    ///     (issue #90 design section 10 "Credit packs", step 10). Returns true when a pack was
+    ///     purchased and credited. Public (unlike <see cref="ShowSubscribeDialogAsync" />, which
+    ///     has no caller outside <see cref="OpenCollaborator" />'s own gate): the out-of-credits
+    ///     message the workflow and chat callers show (StoryCADLib.Services.Store.
+    ///     OutOfCreditsException) names this screen, so a menu item or in-panel button can call it
+    ///     directly once one is wired up -- no further plumbing needed on this side.
+    /// </summary>
+    public async Task<bool> ShowBuyCreditsDialogAsync()
+    {
+        var store = Ioc.Default.GetService<IStoreService>();
+        if (store is null || !store.IsSupported)
+        {
+            _logService.Log(LogLevel.Warn, "Buy Credits dialog suppressed; no platform store is available in this build.");
+            WeakReferenceMessenger.Default.Send(new StatusChangedMessage(new StatusMessage(
+                "Buying credits requires the Microsoft Store or Mac App Store edition of StoryCAD.",
+                LogLevel.Warn, true)));
+            return false;
+        }
+
+        var windowing = Ioc.Default.GetService<Windowing>();
+        var vm = Ioc.Default.GetService<BuyCreditsDialogViewModel>();
+        if (windowing is null || vm is null)
+        {
+            _logService.Log(LogLevel.Warn, "Buy Credits dialog unavailable; no Windowing or view model registered.");
+            return false;
+        }
+
+        return await vm.ShowAsync(windowing);
+    }
+
     #endregion
 
     #region Show/Hide window

--- a/StoryCADLib/Services/Dialogs/BuyCreditsDialog.xaml
+++ b/StoryCADLib/Services/Dialogs/BuyCreditsDialog.xaml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Content body for the "Buy Credits" ContentDialog (issue #90 design section 10 "Credit packs",
+     step 10). The dialog title and the Buy / Not now buttons live on the ContentDialog wrapper
+     (created in code, shown via Windowing.ShowContentDialog). This Page is the same on macOS
+     (Skia) and Windows (WinAppSDK); the platform's own payment sheet appears after Buy.
+     Data-driven from IStoreService via BuyCreditsDialogViewModel (bound as Vm). Mirrors
+     SubscribeDialog.xaml's structure, without the auto-renewal disclosure or restore button:
+     a credit pack is a one-time consumable, not a subscription. -->
+<Page
+    x:Class="StoryCADLib.Services.Dialogs.BuyCreditsDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:store="using:StoryCADLib.Services.Store"
+    mc:Ignorable="d">
+
+    <StackPanel Width="440" Spacing="16">
+
+        <!-- What a credit pack is -->
+        <TextBlock TextWrapping="Wrap"
+                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                   Text="Add credit for Collaborator's AI features on top of your monthly allowance. Credits never expire." />
+
+        <!-- Pack selection, data-driven from the store. Collapses to a single row when only one
+             pack size is configured; the whole block is hidden until products load. -->
+        <RadioButtons x:Name="PackChoice"
+                      Header="Choose a pack"
+                      Visibility="{x:Bind Vm.HasPacks, Mode=OneWay}"
+                      ItemsSource="{x:Bind Vm.Packs, Mode=OneWay}"
+                      SelectedItem="{x:Bind Vm.SelectedPack, Mode=TwoWay}"
+                      AutomationProperties.AutomationId="BuyCreditsPackChoiceRadios">
+            <RadioButtons.ItemTemplate>
+                <DataTemplate x:DataType="store:StoreProduct">
+                    <Grid ColumnSpacing="12" MinWidth="360">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Text="{x:Bind DisplayName}" FontWeight="SemiBold" />
+                            <TextBlock Text="{x:Bind Description}" TextWrapping="Wrap"
+                                       FontSize="12"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        </StackPanel>
+                        <TextBlock Grid.Column="1" VerticalAlignment="Center"
+                                   FontWeight="SemiBold"
+                                   Text="{x:Bind DisplayPrice}" />
+                    </Grid>
+                </DataTemplate>
+            </RadioButtons.ItemTemplate>
+        </RadioButtons>
+
+        <!-- Progress while the store round-trips (purchase / activation). -->
+        <StackPanel Orientation="Horizontal" Spacing="8"
+                    Visibility="{x:Bind Vm.IsBusy, Mode=OneWay}">
+            <ProgressRing IsActive="{x:Bind Vm.IsBusy, Mode=OneWay}" Width="16" Height="16" />
+            <TextBlock Text="Contacting the store…" VerticalAlignment="Center"
+                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+        </StackPanel>
+
+        <!-- Status feedback: errors ("no charge was made, here's what to do") and informational
+             outcomes (Ask-to-Buy pending). Severity is view-model-driven. -->
+        <InfoBar IsOpen="{x:Bind Vm.HasStatus, Mode=OneWay}"
+                 Severity="{x:Bind Vm.StatusSeverity, Mode=OneWay}" IsClosable="False"
+                 Message="{x:Bind Vm.StatusMessage, Mode=OneWay}"
+                 AutomationProperties.AutomationId="BuyCreditsStatusInfoBar" />
+    </StackPanel>
+</Page>

--- a/StoryCADLib/Services/Dialogs/BuyCreditsDialog.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/BuyCreditsDialog.xaml.cs
@@ -1,0 +1,19 @@
+using StoryCADLib.ViewModels.Store;
+
+namespace StoryCADLib.Services.Dialogs;
+
+/// <summary>
+///     Content body for the "Buy Credits" ContentDialog. The wrapper dialog (title, Buy / Not now
+///     buttons) is assembled by <see cref="BuyCreditsDialogViewModel.ShowAsync" />, which passes
+///     itself in here so the page binds the same instance that drives the buttons.
+/// </summary>
+public sealed partial class BuyCreditsDialog : Page
+{
+    public BuyCreditsDialogViewModel Vm { get; }
+
+    public BuyCreditsDialog(BuyCreditsDialogViewModel vm)
+    {
+        Vm = vm;
+        InitializeComponent();
+    }
+}

--- a/StoryCADLib/Services/IoC/BootStrapper.cs
+++ b/StoryCADLib/Services/IoC/BootStrapper.cs
@@ -136,6 +136,8 @@ public static class BootStrapper
         Services.AddSingleton<IActivationClient, ProxyActivationClient>();
         Services.AddSingleton<IStoreActivationService, StoreActivationService>();
         Services.AddSingleton<StoryCADLib.ViewModels.Store.SubscribeDialogViewModel>();
+        // Credit packs (issue #90 design section 10, step 10).
+        Services.AddSingleton<StoryCADLib.ViewModels.Store.BuyCreditsDialogViewModel>();
         Services.AddSingleton<OutlineViewModel>();
         Services.AddSingleton<ShellViewModel>();
         Services.AddSingleton<PreferenceService>();

--- a/StoryCADLib/Services/PreferenceService.cs
+++ b/StoryCADLib/Services/PreferenceService.cs
@@ -1,4 +1,5 @@
-﻿using StoryCADLib.Models.Tools;
+﻿using StoryCADLib.DAL;
+using StoryCADLib.Models.Tools;
 
 namespace StoryCADLib.Services;
 
@@ -11,4 +12,27 @@ public class PreferenceService
     ///     User preferences model that's currently loaded.
     /// </summary>
     public PreferencesModel Model = new();
+
+    /// <summary>
+    ///     Explicit startup step (issue #90 D8 as amended): if <see cref="PreferencesModel.StoreUserGuid" />
+    ///     is empty, generates a GUID and persists it via <see cref="PreferencesIo.WritePreferences" /> as
+    ///     its own serialized operation, so the GUID exists before any purchase or activation attempt.
+    ///     Called once, right after <see cref="PreferencesIo.ReadPreferences" /> in the startup path;
+    ///     <c>ReadPreferences()</c> itself stays a pure read and never triggers this.
+    /// </summary>
+    /// <param name="writePreferences">
+    ///     Injectable write delegate (defaults to <c>new PreferencesIo().WritePreferences</c>), so tests
+    ///     can verify persistence without a second disk-writing path.
+    /// </param>
+    public async Task EnsureUserGuidProvisionedAsync(Func<PreferencesModel, Task> writePreferences = null)
+    {
+        if (!string.IsNullOrEmpty(Model.StoreUserGuid))
+        {
+            return;
+        }
+
+        Model.StoreUserGuid = Guid.NewGuid().ToString();
+        writePreferences ??= new PreferencesIo().WritePreferences;
+        await writePreferences(Model);
+    }
 }

--- a/StoryCADLib/Services/Store/IActivationClient.cs
+++ b/StoryCADLib/Services/Store/IActivationClient.cs
@@ -20,12 +20,19 @@ public interface IActivationClient
     Task<ActivationResponse> ActivateAsync(PurchaseProof proof, CancellationToken ct = default);
 
     /// <summary>
-    ///     Windows only: fetches the short-lived Azure AD service ticket the client passes to
-    ///     <c>StoreContext.GetCustomerPurchaseIdAsync</c> when producing Microsoft purchase proof.
-    ///     The Worker holds the AAD client secret and mints the ticket (audience
-    ///     <c>https://onestore.microsoft.com</c>); the client never sees the secret. Returns null
-    ///     when the ticket cannot be obtained (unauthenticated build, endpoint down) — the caller
-    ///     then produces no proof rather than throwing. Never called on macOS.
+    ///     Windows only: fetches the short-lived Azure AD service ticket the client passes to a
+    ///     <c>StoreContext</c> key-minting call. The Worker holds the AAD client secret and mints
+    ///     the ticket; the client never sees the secret. Returns null when the ticket cannot be
+    ///     obtained (unauthenticated build, endpoint down) — the caller then produces no proof
+    ///     rather than throwing. Never called on macOS.
     /// </summary>
-    Task<string> GetStoreTicketAsync(CancellationToken ct = default);
+    /// <param name="purpose">
+    ///     "purchase" (default) mints the ticket for <c>StoreContext.GetCustomerPurchaseIdAsync</c>
+    ///     (subscriptions); "collections" mints the *different* ticket audience
+    ///     <c>StoreContext.GetCustomerCollectionsIdAsync</c> needs for a consumable purchase (issue
+    ///     #90 design section 10 "Credit packs", step 10 correction). Maps to the Worker's
+    ///     <c>/store/ticket?purpose=collections</c> query parameter.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<string> GetStoreTicketAsync(string purpose = "purchase", CancellationToken ct = default);
 }

--- a/StoryCADLib/Services/Store/IStoreActivationService.cs
+++ b/StoryCADLib/Services/Store/IStoreActivationService.cs
@@ -42,4 +42,11 @@ public interface IStoreActivationService
 
     /// <summary>The current Worker JWT, attached to Collaborator calls; null when not active.</summary>
     string CurrentJwt { get; }
+
+    /// <summary>
+    ///     Re-presents proof to the Worker on demand (issue #90 step 8 item 7). Used by a workflow
+    ///     caller that gets a 401 to refresh once before retrying, covering a session that outlives
+    ///     the ~12h JWT between the launch/purchase/restore/entitlement-change refresh points above.
+    /// </summary>
+    Task ReactivateAsync(CancellationToken ct = default);
 }

--- a/StoryCADLib/Services/Store/IStoreContextAdapter.cs
+++ b/StoryCADLib/Services/Store/IStoreContextAdapter.cs
@@ -89,4 +89,15 @@ public interface IStoreContextAdapter
     /// </summary>
     Task<string> GetCustomerPurchaseIdAsync(string serviceTicket, string publisherUserId,
         CancellationToken ct = default);
+
+    /// <summary>
+    ///     Mints the Microsoft *collections*-ID key via <c>GetCustomerCollectionsIdAsync</c> (issue
+    ///     #90 design section 10 "Credit packs", step 10 correction) — a different Microsoft Store ID
+    ///     key than <see cref="GetCustomerPurchaseIdAsync" />: consumables are queried by the
+    ///     collection API, not the purchase API, and that API needs its own key kind, minted against
+    ///     the Worker's <c>/store/ticket?purpose=collections</c> ticket. <paramref name="serviceTicket" />
+    ///     and <paramref name="publisherUserId" /> have the same meaning as the purchase-key sibling.
+    /// </summary>
+    Task<string> GetCustomerCollectionsIdAsync(string serviceTicket, string publisherUserId,
+        CancellationToken ct = default);
 }

--- a/StoryCADLib/Services/Store/IStoreService.cs
+++ b/StoryCADLib/Services/Store/IStoreService.cs
@@ -58,4 +58,32 @@ public interface IStoreService
     ///     when the store reports no entitlement.
     /// </summary>
     Task<PurchaseProof> GetPurchaseProofAsync(string userGuid, CancellationToken ct = default);
+
+    /// <summary>
+    ///     The credit-pack (consumable) product identifiers this store understands (issue #90
+    ///     design section 10 "Credit packs", step 10); empty for <see cref="NullStoreService" />.
+    ///     Parallel to <see cref="ProductIds" />, which is the subscription catalog only — packs are
+    ///     a separate product family with no ongoing entitlement, so they get their own list rather
+    ///     than joining it.
+    /// </summary>
+    IReadOnlyList<string> CreditPackProductIds { get; }
+
+    /// <summary>
+    ///     Purchases a consumable (credit pack) and returns its own proof directly from the purchase
+    ///     call — unlike a subscription, a consumable has no ongoing entitlement
+    ///     <see cref="GetPurchaseProofAsync" /> could re-derive one from afterward.
+    ///     <paramref name="userGuid" /> is embedded in the proof the same way <see cref="PurchaseAsync" />
+    ///     embeds it for a subscription.
+    /// </summary>
+    Task<ConsumablePurchaseResult> PurchaseConsumableAsync(string productId, string userGuid, CancellationToken ct = default);
+
+    /// <summary>
+    ///     Finishes a consumable transaction after the Worker has confirmed the credit (design
+    ///     section 10: "the client finishes the transaction only after the Worker's 200"). Apple:
+    ///     finishes the StoreKit transaction <see cref="PurchaseConsumableAsync" /> deliberately left
+    ///     open. Windows: a no-op — the Worker itself reports consumable fulfillment to the Microsoft
+    ///     collection API (design section 10's step 10 correction), so there is nothing for the
+    ///     client to finish.
+    /// </summary>
+    Task FinishConsumableAsync(string transactionId, CancellationToken ct = default);
 }

--- a/StoryCADLib/Services/Store/MacStoreService.cs
+++ b/StoryCADLib/Services/Store/MacStoreService.cs
@@ -74,6 +74,37 @@ public sealed class MacStoreService : IStoreService
         return new PurchaseProof("apple", current.Jws, current.ProductId, userGuid);
     }
 
+    public IReadOnlyList<string> CreditPackProductIds => StoreConfig.AppleCreditPackProductIds;
+
+    public async Task<ConsumablePurchaseResult> PurchaseConsumableAsync(string productId, string userGuid,
+        CancellationToken ct = default)
+    {
+        // Same purchase export subscriptions use; the shim (StoreKitShim.swift) already returns
+        // jws/transactionId in the response and, for a consumable product, defers finishing the
+        // transaction until FinishConsumableAsync below confirms the Worker credited it (design
+        // section 10 "Credit packs", step 10).
+        var appAccountToken = string.IsNullOrWhiteSpace(userGuid) ? null : userGuid;
+        var payload = await StoreKitInterop.PurchaseAsync(productId, appAccountToken, ct);
+        return StoreKitPayloads.ParseConsumablePurchase(payload, productId, userGuid);
+    }
+
+    public async Task FinishConsumableAsync(string transactionId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(transactionId))
+        {
+            return;
+        }
+
+        var payload = await StoreKitInterop.FinishTransactionAsync(transactionId, ct);
+        if (!StoreKitPayloads.ParseFinishTransactionOk(payload))
+        {
+            // Best-effort, matching RestoreAsync's pattern below: the credit is already correctly
+            // recorded server-side at this point (the caller only reaches here after the Worker's
+            // 200), so a failed finish blocks a future repurchase, not this one.
+            _logService.Log(LogLevel.Warn, $"Failed to finish consumable transaction {transactionId}.");
+        }
+    }
+
     // Delivered on a Swift task thread; marshal to the UI thread before raising.
     private void OnNativeEntitlementChanged(string payload)
     {

--- a/StoryCADLib/Services/Store/NullStoreService.cs
+++ b/StoryCADLib/Services/Store/NullStoreService.cs
@@ -35,4 +35,12 @@ public sealed class NullStoreService : IStoreService
 
     public Task<PurchaseProof> GetPurchaseProofAsync(string userGuid, CancellationToken ct = default) =>
         Task.FromResult<PurchaseProof>(null);
+
+    public IReadOnlyList<string> CreditPackProductIds => Array.Empty<string>();
+
+    public Task<ConsumablePurchaseResult> PurchaseConsumableAsync(string productId, string userGuid,
+        CancellationToken ct = default) =>
+        Task.FromResult(new ConsumablePurchaseResult(PurchaseStatus.Failed, Error: "No store is available in this build."));
+
+    public Task FinishConsumableAsync(string transactionId, CancellationToken ct = default) => Task.CompletedTask;
 }

--- a/StoryCADLib/Services/Store/OutOfCreditsException.cs
+++ b/StoryCADLib/Services/Store/OutOfCreditsException.cs
@@ -1,0 +1,22 @@
+namespace StoryCADLib.Services.Store;
+
+/// <summary>
+///     Thrown when the Worker refuses an LLM call because the caller's balance is at or below
+///     zero (issue #90 design section 10 "The cutoff": a 429 before any upstream dispatch).
+///     Both Collaborator callers (<c>WorkflowRunner.PostToProxyAsync</c>,
+///     <c>Collaborator</c>'s chat callback) recognize the Worker's 429 and throw this instead of
+///     letting the generic <c>HttpRequestException</c> / <c>HttpOperationException</c> propagate,
+///     so the message the user sees names the credits screen instead of reading
+///     "Response status code does not indicate success: 429". Deliberately a distinct exception
+///     type, not <see cref="System.Net.Http.HttpRequestException" />: WorkflowRunner's existing
+///     <c>catch (HttpRequestException ex)</c> clause retries direct against OpenAI when
+///     <c>OPENAI_API_KEY</c> is set (the fallback issue #90 step 8 retires) — an out-of-credits
+///     refusal must never be caught there, or a capped user with a personal API key would route
+///     straight around the balance cutoff.
+/// </summary>
+public sealed class OutOfCreditsException : Exception
+{
+    public OutOfCreditsException() : base(StoreConfig.OutOfCreditsMessage)
+    {
+    }
+}

--- a/StoryCADLib/Services/Store/OutOfCreditsException.cs
+++ b/StoryCADLib/Services/Store/OutOfCreditsException.cs
@@ -8,11 +8,9 @@ namespace StoryCADLib.Services.Store;
 ///     letting the generic <c>HttpRequestException</c> / <c>HttpOperationException</c> propagate,
 ///     so the message the user sees names the credits screen instead of reading
 ///     "Response status code does not indicate success: 429". Deliberately a distinct exception
-///     type, not <see cref="System.Net.Http.HttpRequestException" />: WorkflowRunner's existing
-///     <c>catch (HttpRequestException ex)</c> clause retries direct against OpenAI when
-///     <c>OPENAI_API_KEY</c> is set (the fallback issue #90 step 8 retires) — an out-of-credits
-///     refusal must never be caught there, or a capped user with a personal API key would route
-///     straight around the balance cutoff.
+///     type, not <see cref="System.Net.Http.HttpRequestException" />, so an out-of-credits
+///     refusal is never mistaken for an ordinary transport failure and swallowed by generic HTTP
+///     error handling.
 /// </summary>
 public sealed class OutOfCreditsException : Exception
 {

--- a/StoryCADLib/Services/Store/ProxyActivationClient.cs
+++ b/StoryCADLib/Services/Store/ProxyActivationClient.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -36,10 +35,9 @@ public sealed class StoreActivationUnreachableException : Exception
 }
 
 /// <summary>
-///     Posts purchase proof to the Collaborator proxy Worker's <c>/activate</c> endpoint.
-///     Interim authentication reuses the shared <c>COLLAB_PROXY_TOKEN</c> Bearer channel that
-///     the Collaborator workflow client uses today; issue #30's per-install channel is a
-///     Worker-track prerequisite that will replace it.
+///     Posts purchase proof to the Collaborator proxy Worker's <c>/activate</c> endpoint. No
+///     request credential: the store's signed proof in the body is the credential (issue #90
+///     ruling of 2026-07-15); the Worker ignores any stray Authorization header.
 /// </summary>
 public sealed class ProxyActivationClient : IActivationClient
 {
@@ -56,7 +54,6 @@ public sealed class ProxyActivationClient : IActivationClient
 
     // Resolved once: the class is a DI singleton and the proxy channel cannot change mid-process.
     private readonly string _baseUrl;
-    private readonly string _token;
 
     public ProxyActivationClient(ILogService logService) : this(logService, SharedHttpClient)
     {
@@ -69,21 +66,13 @@ public sealed class ProxyActivationClient : IActivationClient
         _logService = logService;
         _httpClient = httpClient;
         _baseUrl = Environment.GetEnvironmentVariable("COLLAB_PROXY_URL") ?? DefaultProxyBaseUrl;
-        _token = Environment.GetEnvironmentVariable("COLLAB_PROXY_TOKEN");
     }
 
-    // Single home for the proxy-channel wiring (base URL + Bearer auth); issue #30's per-install
-    // credential swap lands here once, for every endpoint.
-    private HttpRequestMessage BuildRequest(HttpMethod method, string path)
-    {
-        var request = new HttpRequestMessage(method, $"{_baseUrl}{path}");
-        if (!string.IsNullOrWhiteSpace(_token))
-        {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
-        }
-
-        return request;
-    }
+    // Single home for the proxy-channel base URL; every endpoint builds its request through here.
+    // No request credential (issue #90 D6 as overruled): the store's signed proof is the
+    // credential on /activate, and /store/ticket needs none either.
+    private HttpRequestMessage BuildRequest(HttpMethod method, string path) =>
+        new(method, $"{_baseUrl}{path}");
 
     public async Task<ActivationResponse> ActivateAsync(PurchaseProof proof, CancellationToken ct = default)
     {

--- a/StoryCADLib/Services/Store/ProxyActivationClient.cs
+++ b/StoryCADLib/Services/Store/ProxyActivationClient.cs
@@ -129,10 +129,14 @@ public sealed class ProxyActivationClient : IActivationClient
             $"Store activation returned unexpected status {(int)response.StatusCode}.");
     }
 
-    public async Task<string> GetStoreTicketAsync(CancellationToken ct = default)
+    public async Task<string> GetStoreTicketAsync(string purpose = "purchase", CancellationToken ct = default)
     {
         // GET /store/ticket -> {"ticket":"<aad-access-token>"} (Worker contract, Windows only).
-        using var request = BuildRequest(HttpMethod.Get, "/store/ticket");
+        // ?purpose=collections mints the consumable-purchase ticket audience instead of the
+        // default subscription one (issue #90 design section 10 "Credit packs", step 10
+        // correction); any other value (including the default) keeps the original path unchanged.
+        var path = purpose == "collections" ? "/store/ticket?purpose=collections" : "/store/ticket";
+        using var request = BuildRequest(HttpMethod.Get, path);
 
         try
         {

--- a/StoryCADLib/Services/Store/StoreActivationService.cs
+++ b/StoryCADLib/Services/Store/StoreActivationService.cs
@@ -125,7 +125,7 @@ public sealed class StoreActivationService : IStoreActivationService
                     "StoreUserGuid is empty; purchase proof cannot be bound to a user.");
             }
 
-            // Dev/tester allowlist activation (issue #90 D7/D8): COLLAB_DEV_ENABLED routes around
+            // Dev/tester allowlist activation (issue #90 D7/D8): COLLAB_DEV_ACTIVATION routes around
             // the platform store entirely -- there is no store proof to present, only the GUID a
             // human approved on the Worker's allowlist. payload/productId are ignored by the
             // Worker for platform "dev" (design section 6).
@@ -190,11 +190,11 @@ public sealed class StoreActivationService : IStoreActivationService
         }
     }
 
-    // COLLAB_DEV_ENABLED is a routing hint only (design section 12): it says "activate through the
+    // COLLAB_DEV_ACTIVATION is a routing hint only (design section 12): it says "activate through the
     // dev/tester allowlist instead of the platform store"; it grants nothing by itself -- the
     // Worker's allowlist row decides dev entitlement.
     private static bool IsDevActivationEnabled() =>
-        Environment.GetEnvironmentVariable("COLLAB_DEV_ENABLED") == "1";
+        Environment.GetEnvironmentVariable("COLLAB_DEV_ACTIVATION") == "1";
 
     /// <summary>
     ///     Re-presents proof to the Worker on demand (issue #90 step 8 item 7): used by a workflow

--- a/StoryCADLib/Services/Store/StoreActivationService.cs
+++ b/StoryCADLib/Services/Store/StoreActivationService.cs
@@ -52,8 +52,10 @@ public sealed class StoreActivationService : IStoreActivationService
 
     public string CurrentJwt => string.IsNullOrEmpty(_jwt) ? null : _jwt;
 
-    // The stable user GUID embedded in the signed proof at purchase time. Populated from the
-    // server users.guid (issue #30 prerequisite); empty until then, which fails activation closed.
+    // The stable per-user GUID, generated on this machine at startup (issue #90 D8) and embedded
+    // in the signed proof at purchase time. Provisioned by
+    // PreferenceService.EnsureUserGuidProvisionedAsync before this service's InitializeAsync runs,
+    // so it is never empty in practice; defensively empty-coalesced below.
     private string UserGuid => _preferenceService.Model.StoreUserGuid ?? string.Empty;
 
     public async Task InitializeAsync(CancellationToken ct = default)
@@ -116,14 +118,20 @@ public sealed class StoreActivationService : IStoreActivationService
         {
             if (string.IsNullOrEmpty(UserGuid))
             {
-                // Issue #30 prerequisite: until the server populates users.guid, proofs carry an
-                // empty user GUID and the Worker cannot bind the purchase to a user. Log so the
-                // resulting refusals are diagnosable in the field.
+                // Defensive: the startup provisioning step (issue #90 D8) should have populated
+                // StoreUserGuid before this runs. Log so an unexpected empty value -- proofs
+                // carrying it cannot be bound to a user -- is diagnosable in the field.
                 _logService.Log(LogLevel.Warn,
-                    "StoreUserGuid is empty; purchase proof cannot be bound to a user (issue #30 prerequisite).");
+                    "StoreUserGuid is empty; purchase proof cannot be bound to a user.");
             }
 
-            var proof = await _store.GetPurchaseProofAsync(UserGuid, ct);
+            // Dev/tester allowlist activation (issue #90 D7/D8): COLLAB_DEV_ENABLED routes around
+            // the platform store entirely -- there is no store proof to present, only the GUID a
+            // human approved on the Worker's allowlist. payload/productId are ignored by the
+            // Worker for platform "dev" (design section 6).
+            var proof = IsDevActivationEnabled()
+                ? new PurchaseProof("dev", string.Empty, string.Empty, UserGuid)
+                : await _store.GetPurchaseProofAsync(UserGuid, ct);
             if (proof is null)
             {
                 // Authoritative "no purchase" from the store: drop any cached JWT.
@@ -181,6 +189,20 @@ public sealed class StoreActivationService : IStoreActivationService
             _gate.Release();
         }
     }
+
+    // COLLAB_DEV_ENABLED is a routing hint only (design section 12): it says "activate through the
+    // dev/tester allowlist instead of the platform store"; it grants nothing by itself -- the
+    // Worker's allowlist row decides dev entitlement.
+    private static bool IsDevActivationEnabled() =>
+        Environment.GetEnvironmentVariable("COLLAB_DEV_ENABLED") == "1";
+
+    /// <summary>
+    ///     Re-presents proof to the Worker on demand (issue #90 step 8 item 7): used by a workflow
+    ///     caller that gets a 401 to refresh once before retrying, covering a session that outlives
+    ///     the ~12h JWT between the launch/purchase/restore/entitlement-change refresh points above.
+    ///     Shares <see cref="RefreshActivationAsync" /> with those callers, including its gate.
+    /// </summary>
+    public Task ReactivateAsync(CancellationToken ct = default) => RefreshActivationAsync(ct);
 
     private async void OnStoreEntitlementChanged(object sender, StoreEntitlement e)
     {

--- a/StoryCADLib/Services/Store/StoreConfig.cs
+++ b/StoryCADLib/Services/Store/StoreConfig.cs
@@ -23,4 +23,21 @@ public static class StoreConfig
     // TODO #30: replace with the real hosted pages before store submission.
     public const string TermsOfUseUrl = "https://storybuilder.org/terms";
     public const string PrivacyPolicyUrl = "https://storybuilder.org/privacy";
+
+    // Credit-pack (consumable) product IDs (issue #90 design section 10 "Credit packs", step 10).
+    // Placeholders: pack sizes, prices, and the credit exchange rate are gate 3 decisions, not yet
+    // made (devdocs/store_submissions.md). Must match the Worker's PRODUCT_MAP entries verbatim
+    // (proxy/src/index.js, Collaborator repo) or a genuine purchase will refuse with "invalid" —
+    // the Worker only recognizes a signed proof for a product it has in its own table.
+    public static readonly IReadOnlyList<string> AppleCreditPackProductIds = new[] { "CollabCreditPack500" };
+    public static readonly IReadOnlyList<string> WindowsCreditPackStoreIds = new[] { "9PCREDITPAK1" };
+
+    // Shown by the workflow and chat callers when the Worker refuses an LLM call with 429 because
+    // the caller's balance is at or below zero (issue #90 design section 10 "The cutoff"; ruling of
+    // 2026-07-15, step 10). The Worker's 429 shape is identical for this case and the unrelated
+    // daily-rate-limit case (design section 10: "the existing 429 quota response"), so this message
+    // is shown for either — a deliberate simplification the wire contract does not distinguish.
+    public const string OutOfCreditsMessage =
+        "You've used all your credits for this period. Buy more from Collaborator's Buy Credits " +
+        "screen, or wait for your next monthly renewal.";
 }

--- a/StoryCADLib/Services/Store/StoreKitInterop.cs
+++ b/StoryCADLib/Services/Store/StoreKitInterop.cs
@@ -48,6 +48,13 @@ internal static partial class StoreKitInterop
     private static unsafe partial void storycad_iap_purchase(long requestId, string productId, string appAccountToken,
         delegate* unmanaged[Cdecl]<long, byte*, void> cb);
 
+    // Issue #90 design section 10 "Credit packs" (step 10): finishes a consumable transaction the
+    // shim deliberately left open (StoreKitShim.swift's storycad_iap_purchase), once the caller has
+    // confirmed the Worker credited it.
+    [LibraryImport(Library, StringMarshalling = StringMarshalling.Utf8)]
+    private static unsafe partial void storycad_iap_finish_transaction(long requestId, string transactionId,
+        delegate* unmanaged[Cdecl]<long, byte*, void> cb);
+
     [LibraryImport(Library)]
     private static unsafe partial void storycad_iap_current_entitlements(long requestId,
         delegate* unmanaged[Cdecl]<long, byte*, void> cb);
@@ -90,6 +97,15 @@ internal static partial class StoreKitInterop
         var (id, tcs) = NewRequest();
         storycad_iap_purchase(id, productId, appAccountToken, &OnCallback);
         return AwaitResponseAsync(id, tcs, InteractiveTimeout, ct);
+    }
+
+    internal static unsafe Task<string> FinishTransactionAsync(string transactionId, CancellationToken ct = default)
+    {
+        var (id, tcs) = NewRequest();
+        storycad_iap_finish_transaction(id, transactionId, &OnCallback);
+        // Not interactive (no system UI), but not a pure query either -- give it the same leash as
+        // PurchaseAsync since it can race a purchase's own in-flight interactive call on first use.
+        return AwaitResponseAsync(id, tcs, QueryTimeout, ct);
     }
 
     internal static unsafe Task<string> CurrentEntitlementsAsync(CancellationToken ct = default)

--- a/StoryCADLib/Services/Store/StoreKitPayloads.cs
+++ b/StoryCADLib/Services/Store/StoreKitPayloads.cs
@@ -106,6 +106,47 @@ internal static class StoreKitPayloads
         return new PurchaseResult(MapPurchaseStatus(resp.Status));
     }
 
+    // Issue #90 design section 10 "Credit packs" (step 10): unlike ParsePurchase above, a
+    // consumable purchase needs the jws/transactionId the shim's storycad_iap_purchase response
+    // already carries (StoreKitShim.swift; ParsePurchase discards them because a subscription
+    // re-derives its proof from GetCurrentEntitlementsAsync instead, which excludes consumables).
+    // requestedProductId/userGuid fill the proof's fields the purchase response's own productId
+    // never carries the caller's userGuid, and the response's productId can be trusted to match
+    // requestedProductId (the shim purchases exactly the id it was given).
+    public static ConsumablePurchaseResult ParseConsumablePurchase(string json, string requestedProductId, string userGuid)
+    {
+        var resp = Deserialize(json, StoreKitJsonContext.Default.ShimPurchaseResponse);
+        if (resp is null)
+        {
+            return new ConsumablePurchaseResult(PurchaseStatus.Failed, Error: "Unparseable purchase response.");
+        }
+
+        if (!resp.Ok)
+        {
+            return new ConsumablePurchaseResult(PurchaseStatus.Failed, Error: resp.Error ?? "Purchase failed.");
+        }
+
+        var status = MapPurchaseStatus(resp.Status);
+        if (status != PurchaseStatus.Success)
+        {
+            return new ConsumablePurchaseResult(status);
+        }
+
+        if (string.IsNullOrEmpty(resp.Jws) || string.IsNullOrEmpty(resp.TransactionId))
+        {
+            return new ConsumablePurchaseResult(PurchaseStatus.Failed, Error: "Purchase succeeded but the store returned no proof.");
+        }
+
+        var proof = new PurchaseProof("apple", resp.Jws, resp.ProductId ?? requestedProductId, userGuid);
+        return new ConsumablePurchaseResult(PurchaseStatus.Success, proof, resp.TransactionId);
+    }
+
+    // Issue #90 design section 10 "Credit packs" (step 10): the shim's storycad_iap_finish_transaction
+    // response is a bare {"ok":true}/{"ok":false,"error":...} acknowledgement, so this reuses
+    // ShimPurchaseResponse's Ok/Error fields rather than adding a single-purpose DTO.
+    public static bool ParseFinishTransactionOk(string json) =>
+        Deserialize(json, StoreKitJsonContext.Default.ShimPurchaseResponse)?.Ok ?? false;
+
     public static IReadOnlyList<StoreEntitlement> ParseEntitlements(string json)
     {
         var resp = Deserialize(json, StoreKitJsonContext.Default.ShimEntitlementsResponse);

--- a/StoryCADLib/Services/Store/StoreModels.cs
+++ b/StoryCADLib/Services/Store/StoreModels.cs
@@ -62,6 +62,18 @@ public record StoreEntitlement(
 public record PurchaseResult(PurchaseStatus Status, string Error = null);
 
 /// <summary>
+///     Result of <see cref="IStoreService.PurchaseConsumableAsync" /> (issue #90 design section 10
+///     "Credit packs", step 10). Unlike a subscription, a consumable's proof comes directly from the
+///     purchase call itself: StoreKit's <c>Transaction.currentEntitlements</c> excludes consumables,
+///     so there is no ongoing entitlement <see cref="IStoreService.GetPurchaseProofAsync" /> could
+///     re-query afterward. <see cref="Proof" /> and <see cref="TransactionId" /> are set only when
+///     <see cref="Status" /> is <see cref="PurchaseStatus.Success" />; <see cref="TransactionId" /> is
+///     the identifier <see cref="IStoreService.FinishConsumableAsync" /> needs (Apple only —
+///     Windows has nothing to finish client-side, per the design's step 10 correction).
+/// </summary>
+public record ConsumablePurchaseResult(PurchaseStatus Status, PurchaseProof Proof = null, string TransactionId = null, string Error = null);
+
+/// <summary>
 ///     Store-signed proof of purchase sent to the Worker <c>/activate</c> endpoint.
 ///     <see cref="Platform" /> is "apple" or "microsoft"; <see cref="Payload" /> is the
 ///     JWS on macOS or the Microsoft purchase-ID key on Windows. <see cref="UserGuid" />

--- a/StoryCADLib/Services/Store/WindowsStoreContextAdapter.cs
+++ b/StoryCADLib/Services/Store/WindowsStoreContextAdapter.cs
@@ -109,6 +109,15 @@ public sealed class WindowsStoreContextAdapter : IStoreContextAdapter
         return await _context.GetCustomerPurchaseIdAsync(serviceTicket, publisherUserId).AsTask(ct);
     }
 
+    public async Task<string> GetCustomerCollectionsIdAsync(string serviceTicket, string publisherUserId,
+        CancellationToken ct = default)
+    {
+        // Issue #90 design section 10 step 10 correction: a distinct WinRT call from
+        // GetCustomerPurchaseIdAsync above — mints a Microsoft Store ID key scoped to the
+        // *collection* API (consumables), never call with a cached/expired ticket.
+        return await _context.GetCustomerCollectionsIdAsync(serviceTicket, publisherUserId).AsTask(ct);
+    }
+
     private void EnsureWindowInitialised()
     {
         if (_windowInitialised)

--- a/StoryCADLib/Services/Store/WindowsStoreService.cs
+++ b/StoryCADLib/Services/Store/WindowsStoreService.cs
@@ -35,7 +35,8 @@ public sealed class WindowsStoreService : IStoreService
     }
 
     // A store context is always obtainable on the Windows head; a sideloaded debug build has no license
-    // context and purchases fail there, which is exactly what the COLLAB_DEV_ENABLED dev stub is for.
+    // context and purchases fail there. COLLAB_DEV_ENABLED routes StoreActivationService around this
+    // store entirely (dev/tester allowlist activation, issue #90 D7/D8) rather than patching it here.
     public bool IsSupported => true;
 
     public IReadOnlyList<string> ProductIds => StoreConfig.WindowsStoreIds;

--- a/StoryCADLib/Services/Store/WindowsStoreService.cs
+++ b/StoryCADLib/Services/Store/WindowsStoreService.cs
@@ -35,7 +35,7 @@ public sealed class WindowsStoreService : IStoreService
     }
 
     // A store context is always obtainable on the Windows head; a sideloaded debug build has no license
-    // context and purchases fail there. COLLAB_DEV_ENABLED routes StoreActivationService around this
+    // context and purchases fail there. COLLAB_DEV_ACTIVATION routes StoreActivationService around this
     // store entirely (dev/tester allowlist activation, issue #90 D7/D8) rather than patching it here.
     public bool IsSupported => true;
 

--- a/StoryCADLib/Services/Store/WindowsStoreService.cs
+++ b/StoryCADLib/Services/Store/WindowsStoreService.cs
@@ -91,7 +91,7 @@ public sealed class WindowsStoreService : IStoreService
 
         // The Worker mints the AAD ticket (it holds the secret); the client only forwards it to the
         // Store. No ticket -> no proof -> activation reports NotPurchased and offers retry.
-        var ticket = await _activationClient.GetStoreTicketAsync(ct);
+        var ticket = await _activationClient.GetStoreTicketAsync(ct: ct);
         if (string.IsNullOrEmpty(ticket))
         {
             _logService.Log(LogLevel.Warn, "No store ticket available; cannot produce Microsoft purchase proof.");
@@ -105,6 +105,50 @@ public sealed class WindowsStoreService : IStoreService
         }
 
         return new PurchaseProof("microsoft", key, current.ProductId, userGuid);
+    }
+
+    public IReadOnlyList<string> CreditPackProductIds => StoreConfig.WindowsCreditPackStoreIds;
+
+    public async Task<ConsumablePurchaseResult> PurchaseConsumableAsync(string productId, string userGuid,
+        CancellationToken ct = default)
+    {
+        var purchase = await _adapter.RequestPurchaseAsync(productId, ct);
+        if (purchase.Outcome is not (StorePurchaseOutcome.Succeeded or StorePurchaseOutcome.AlreadyPurchased))
+        {
+            return purchase.Outcome == StorePurchaseOutcome.NotPurchased
+                ? new ConsumablePurchaseResult(PurchaseStatus.UserCancelled)
+                : new ConsumablePurchaseResult(PurchaseStatus.Failed,
+                    Error: purchase.ExtendedError ?? "The Microsoft Store purchase could not be completed.");
+        }
+
+        // Design section 10 "Credit packs" (step 10 correction): a consumable proof is a
+        // *collections*-audience Microsoft Store ID key (GetCustomerCollectionsIdAsync), not the
+        // purchase-audience key GetPurchaseProofAsync above uses for subscriptions — a different
+        // key kind entirely, minted against the Worker's /store/ticket?purpose=collections ticket.
+        var ticket = await _activationClient.GetStoreTicketAsync("collections", ct);
+        if (string.IsNullOrEmpty(ticket))
+        {
+            _logService.Log(LogLevel.Warn, "No collections store ticket available; cannot produce Microsoft consumable proof.");
+            return new ConsumablePurchaseResult(PurchaseStatus.Failed,
+                Error: "Couldn't reach the store. Check your connection and try again.");
+        }
+
+        var key = await _adapter.GetCustomerCollectionsIdAsync(ticket, userGuid, ct);
+        if (string.IsNullOrEmpty(key))
+        {
+            return new ConsumablePurchaseResult(PurchaseStatus.Failed,
+                Error: "Couldn't reach the store. Check your connection and try again.");
+        }
+
+        return new ConsumablePurchaseResult(PurchaseStatus.Success, new PurchaseProof("microsoft", key, productId, userGuid));
+    }
+
+    public Task FinishConsumableAsync(string transactionId, CancellationToken ct = default)
+    {
+        // The Worker itself reports the consumable fulfilled to the Microsoft collection API
+        // (design section 10's step 10 correction: POST /collections/consume); there is nothing
+        // for the Windows client to finish, unlike Apple's local StoreKit transaction.
+        return Task.CompletedTask;
     }
 
     private static StoreProduct MapProduct(StoreProductInfo p) =>

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -144,6 +144,7 @@ public class ShellViewModel : ObservableRecipient
 
         // StoryCAD Collaborator
         CollaboratorCommand = new RelayCommand(LaunchCollaborator, SerializationLock.CanExecuteCommands);
+        BuyCreditsCommand = new RelayCommand(BuyCredits, SerializationLock.CanExecuteCommands);
 
         // Tools commands
         KeyQuestionsCommand = new RelayCommand(async () => await OutlineManager.KeyQuestionsTool(),
@@ -381,6 +382,10 @@ public class ShellViewModel : ObservableRecipient
 
     // Launch Collaborator
     public RelayCommand CollaboratorCommand { get; }
+
+    // Buy Collaborator credits (issue #90 design section 10 "Credit packs"; wiring landed step 8
+    // per Session F's review carry-over). Mirrors CollaboratorCommand's shape exactly.
+    public RelayCommand BuyCreditsCommand { get; }
     public RelayCommand HelpCommand { get; }
 
     // Tools MenuFlyOut Commands
@@ -1076,6 +1081,24 @@ public class ShellViewModel : ObservableRecipient
             var collaboratorService = Ioc.Default.GetService<CollaboratorService>();
             collaboratorService?.OpenCollaborator();
 
+        }
+    }
+
+    /// <summary>
+    ///     This method is invoked when the user clicks the Buy Credits AppBarButton
+    ///     on the Shell CommandBar. Opens CollaboratorService.ShowBuyCreditsDialogAsync
+    ///     (issue #90 design section 10 "Credit packs"; wiring landed step 8).
+    /// </summary>
+    private async void BuyCredits()
+    {
+        if (SerializationLock.CanExecuteCommands())
+        {
+            Logger.Log(LogLevel.Info, "Opening Buy Credits dialog");
+            var collaboratorService = Ioc.Default.GetService<CollaboratorService>();
+            if (collaboratorService != null)
+            {
+                await collaboratorService.ShowBuyCreditsDialogAsync();
+            }
         }
     }
 

--- a/StoryCADLib/ViewModels/ShellViewModel.cs
+++ b/StoryCADLib/ViewModels/ShellViewModel.cs
@@ -945,6 +945,9 @@ public class ShellViewModel : ObservableRecipient
         CloseCommand.NotifyCanExecuteChanged();
         ExitCommand.NotifyCanExecuteChanged();
         CollaboratorCommand.NotifyCanExecuteChanged();
+        // Wired with CollaboratorCommand (issue #90 step 8); must refresh on the same cadence
+        // or the toolbar button stays stuck disabled after a serialization-lock cycle.
+        BuyCreditsCommand.NotifyCanExecuteChanged();
         KeyQuestionsCommand.NotifyCanExecuteChanged();
         TopicsCommand.NotifyCanExecuteChanged();
         MasterPlotsCommand.NotifyCanExecuteChanged();

--- a/StoryCADLib/ViewModels/Store/BuyCreditsDialogViewModel.cs
+++ b/StoryCADLib/ViewModels/Store/BuyCreditsDialogViewModel.cs
@@ -60,6 +60,18 @@ public sealed class BuyCreditsDialogViewModel : ObservableObject
     // ongoing ActivationState to check afterward -- it either credited the account or it didn't).
     private bool _lastPurchaseSucceeded;
 
+    // 2026-07-16 review finding 3: a purchase that succeeded but whose activation failed for a
+    // retryable reason (the Worker unreachable, or refused) is held here so the next BuyAsync
+    // call re-activates this same proof instead of purchasing again. Without this, clicking Buy
+    // again after such a failure spent the user's money a second time: on Apple, a second
+    // Product.purchase() on a consumable either double-charges or errors on the transaction
+    // PurchaseConsumableAsync deliberately left unfinished; on Windows it happens to self-heal
+    // via AlreadyPurchased, but there's no reason to spend a second store round trip. Cleared on
+    // successful activation. This view model is a DI singleton (BootStrapper), so the field
+    // deliberately survives a dialog reopen within the session as well -- the held proof is still
+    // good and still worth retrying.
+    private ConsumablePurchaseResult _pendingUnactivatedPurchase;
+
     private string UserGuid => _preferenceService.Model.StoreUserGuid ?? string.Empty;
 
     /// <summary>Loads the configured packs from the store. Call when the dialog opens.</summary>
@@ -134,15 +146,27 @@ public sealed class BuyCreditsDialogViewModel : ObservableObject
     /// <summary>Purchases the selected pack and posts its proof to the Worker. Returns true on success.</summary>
     public async Task<bool> BuyAsync(CancellationToken ct = default)
     {
-        if (SelectedPack is null)
-        {
-            return false;
-        }
-
         IsBusy = true;
         ClearStatus();
         try
         {
+            // A prior call already spent the money and holds a proof that only failed to
+            // activate for a retryable reason (see _pendingUnactivatedPurchase above). Re-run
+            // activation on that same proof instead of starting a new purchase -- regardless of
+            // which pack is currently selected, since the money already spent is for whatever
+            // pack the held proof names, not SelectedPack.
+            if (_pendingUnactivatedPurchase is not null)
+            {
+                var pendingPurchase = _pendingUnactivatedPurchase;
+                _lastPurchaseSucceeded = await ActivatePurchaseAsync(pendingPurchase, ct);
+                return _lastPurchaseSucceeded;
+            }
+
+            if (SelectedPack is null)
+            {
+                return false;
+            }
+
             var purchase = await _store.PurchaseConsumableAsync(SelectedPack.Id, UserGuid, ct);
             switch (purchase.Status)
             {
@@ -195,8 +219,12 @@ public sealed class BuyCreditsDialogViewModel : ObservableObject
         catch (Exception ex)
         {
             _logService.Log(LogLevel.Warn, $"Credit-pack activation unreachable: {ex.Message}");
+            // Retryable: the money is already spent and this proof is still good. Held so the
+            // next BuyAsync call (the same "try again" this message asks for) re-activates it
+            // instead of purchasing a second time.
+            _pendingUnactivatedPurchase = purchase;
             SetStatus("Your purchase went through, but we couldn't add the credits yet. " +
-                      "Check your connection; try again from this screen.");
+                      "Check your connection, then use Buy again to retry.");
             return false;
         }
 
@@ -204,12 +232,16 @@ public sealed class BuyCreditsDialogViewModel : ObservableObject
         {
             // The wire contract's refusal reasons (invalid/revoked/expired) don't map to a
             // meaningful distinction for a just-completed consumable purchase; any refusal here
-            // means the Worker did not credit the account.
-            SetStatus("The store confirmed your purchase, but the credits couldn't be applied. " +
-                      "Contact support.");
+            // means the Worker did not credit the account. Retryable for the same reason as the
+            // unreachable case above (e.g. a transient 503 from the Worker) -- held so a second
+            // Buy click re-activates this proof instead of purchasing again.
+            _pendingUnactivatedPurchase = purchase;
+            SetStatus("The store confirmed your purchase, but the credits couldn't be applied yet. " +
+                      "Use Buy again to retry.");
             return false;
         }
 
+        _pendingUnactivatedPurchase = null;
         await _store.FinishConsumableAsync(purchase.TransactionId, ct);
         return true;
     }

--- a/StoryCADLib/ViewModels/Store/BuyCreditsDialogViewModel.cs
+++ b/StoryCADLib/ViewModels/Store/BuyCreditsDialogViewModel.cs
@@ -1,0 +1,226 @@
+using System.Collections.ObjectModel;
+using System.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using StoryCADLib.Services;
+using StoryCADLib.Services.Dialogs;
+using StoryCADLib.Services.Store;
+
+namespace StoryCADLib.ViewModels.Store;
+
+/// <summary>
+///     Backs <c>BuyCreditsDialog</c> (issue #90 design section 10 "Credit packs", step 10). Loads
+///     the configured credit packs from the platform store, lets the user pick one, purchases it,
+///     and posts the resulting proof straight to the Worker's <c>/v1/activate</c> via
+///     <see cref="IActivationClient" /> — unlike <see cref="SubscribeDialogViewModel" />, this does
+///     not go through <see cref="IStoreActivationService" />: a pack purchase tops up the balance
+///     behind the caller's *existing* JWT, so there is no cached-JWT state for this view model to
+///     update (the Worker's 200 for a pack activation is discarded once the credit is confirmed).
+/// </summary>
+public sealed class BuyCreditsDialogViewModel : ObservableObject
+{
+    private readonly IStoreService _store;
+    private readonly IActivationClient _client;
+    private readonly PreferenceService _preferenceService;
+    private readonly ILogService _logService;
+
+    public BuyCreditsDialogViewModel(IStoreService store, IActivationClient client,
+        PreferenceService preferenceService, ILogService logService)
+    {
+        _store = store;
+        _client = client;
+        _preferenceService = preferenceService;
+        _logService = logService;
+    }
+
+    public ObservableCollection<StoreProduct> Packs { get; } = new();
+
+    private StoreProduct _selectedPack;
+    public StoreProduct SelectedPack { get => _selectedPack; set => SetProperty(ref _selectedPack, value); }
+
+    private bool _isBusy;
+    public bool IsBusy { get => _isBusy; set => SetProperty(ref _isBusy, value); }
+
+    // The stored status state is just message + severity; everything else is derived (same shape
+    // as SubscribeDialogViewModel's status handling).
+    private InfoBarSeverity _statusSeverity = InfoBarSeverity.Error;
+    public InfoBarSeverity StatusSeverity { get => _statusSeverity; private set => SetProperty(ref _statusSeverity, value); }
+
+    private string _statusMessage = string.Empty;
+    public string StatusMessage { get => _statusMessage; private set => SetProperty(ref _statusMessage, value); }
+
+    /// <summary>True while any status message (error or informational) should be visible.</summary>
+    public bool HasStatus => !string.IsNullOrEmpty(StatusMessage);
+
+    public bool HasError => HasStatus && StatusSeverity == InfoBarSeverity.Error;
+
+    public bool HasPacks => Packs.Count > 0;
+
+    // Set by BuyAsync; ShowAsync reports this once the dialog closes rather than re-deriving it
+    // from a persistent state property (unlike SubscribeDialogViewModel, a pack purchase has no
+    // ongoing ActivationState to check afterward -- it either credited the account or it didn't).
+    private bool _lastPurchaseSucceeded;
+
+    private string UserGuid => _preferenceService.Model.StoreUserGuid ?? string.Empty;
+
+    /// <summary>Loads the configured packs from the store. Call when the dialog opens.</summary>
+    public async Task LoadAsync(CancellationToken ct = default)
+    {
+        ClearStatus();
+
+        // Packs are static for the session, same reasoning as SubscribeDialogViewModel.LoadAsync:
+        // don't re-query the store every time the dialog reopens. A failed load leaves Packs empty,
+        // so the retry path still fetches.
+        if (Packs.Count > 0)
+        {
+            SelectedPack ??= Packs.FirstOrDefault();
+            return;
+        }
+
+        try
+        {
+            var products = await _store.GetProductsAsync(_store.CreditPackProductIds, ct);
+            Packs.Clear();
+            foreach (var product in products)
+            {
+                Packs.Add(product);
+            }
+
+            SelectedPack = Packs.FirstOrDefault();
+            OnPropertyChanged(nameof(HasPacks));
+        }
+        catch (Exception ex)
+        {
+            _logService.Log(LogLevel.Warn, $"Failed to load credit packs: {ex.Message}");
+            SetStatus("Couldn't reach the store. Check your connection and try again.");
+        }
+    }
+
+    /// <summary>
+    ///     Shows the buy-credits dialog (same panel on macOS and Windows) and drives the purchase.
+    ///     Returns true when a pack was successfully purchased and credited.
+    /// </summary>
+    public async Task<bool> ShowAsync(Windowing windowing)
+    {
+        await LoadAsync();
+        _lastPurchaseSucceeded = false;
+
+        var dialog = new ContentDialog
+        {
+            Title = "Buy Credits",
+            Content = new BuyCreditsDialog(this),
+            PrimaryButtonText = "Buy",
+            CloseButtonText = "Not now",
+            DefaultButton = ContentDialogButton.Primary
+        };
+
+        dialog.PrimaryButtonClick += async (_, args) =>
+        {
+            var deferral = args.GetDeferral();
+            try
+            {
+                // Keep the dialog open unless the purchase actually credited the account.
+                args.Cancel = !await BuyAsync();
+            }
+            finally
+            {
+                deferral.Complete();
+            }
+        };
+
+        await windowing.ShowContentDialog(dialog);
+        return _lastPurchaseSucceeded;
+    }
+
+    /// <summary>Purchases the selected pack and posts its proof to the Worker. Returns true on success.</summary>
+    public async Task<bool> BuyAsync(CancellationToken ct = default)
+    {
+        if (SelectedPack is null)
+        {
+            return false;
+        }
+
+        IsBusy = true;
+        ClearStatus();
+        try
+        {
+            var purchase = await _store.PurchaseConsumableAsync(SelectedPack.Id, UserGuid, ct);
+            switch (purchase.Status)
+            {
+                case PurchaseStatus.Success:
+                    _lastPurchaseSucceeded = await ActivatePurchaseAsync(purchase, ct);
+                    return _lastPurchaseSucceeded;
+                case PurchaseStatus.Pending:
+                    // Ask to Buy: not a failure. Tell the user what happens next; the dialog
+                    // stays open so this message is visible until they dismiss it.
+                    SetStatus("Your purchase is waiting for approval. Your credits will be added " +
+                              "automatically once it's approved.", InfoBarSeverity.Informational);
+                    return false;
+                case PurchaseStatus.UserCancelled:
+                    return false; // the user backed out of the system sheet; no message needed
+                default:
+                    SetStatus(purchase.Error ?? "That didn't go through. You haven't been charged. Try again.");
+                    return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logService.Log(LogLevel.Warn, $"Buy credits failed: {ex.Message}");
+            SetStatus("Couldn't reach the store. Check your connection and try again.");
+            return false;
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    // Design section 10 "Credit packs": the Worker records the purchase (journals and credits the
+    // ledger) before the client tells the store it is consumed, so FinishConsumableAsync (Apple:
+    // Transaction.finish(); Windows: a no-op, the Worker reports fulfillment itself) runs only
+    // after ActivateAsync's 200, never before.
+    private async Task<bool> ActivatePurchaseAsync(ConsumablePurchaseResult purchase, CancellationToken ct)
+    {
+        if (purchase.Proof is null)
+        {
+            SetStatus("Your purchase went through, but the store returned no proof. " +
+                      "Check your connection and try again.");
+            return false;
+        }
+
+        ActivationResponse response;
+        try
+        {
+            response = await _client.ActivateAsync(purchase.Proof, ct);
+        }
+        catch (Exception ex)
+        {
+            _logService.Log(LogLevel.Warn, $"Credit-pack activation unreachable: {ex.Message}");
+            SetStatus("Your purchase went through, but we couldn't add the credits yet. " +
+                      "Check your connection; try again from this screen.");
+            return false;
+        }
+
+        if (!response.Ok)
+        {
+            // The wire contract's refusal reasons (invalid/revoked/expired) don't map to a
+            // meaningful distinction for a just-completed consumable purchase; any refusal here
+            // means the Worker did not credit the account.
+            SetStatus("The store confirmed your purchase, but the credits couldn't be applied. " +
+                      "Contact support.");
+            return false;
+        }
+
+        await _store.FinishConsumableAsync(purchase.TransactionId, ct);
+        return true;
+    }
+
+    private void SetStatus(string message, InfoBarSeverity severity = InfoBarSeverity.Error)
+    {
+        StatusSeverity = severity;
+        StatusMessage = message ?? string.Empty;
+        OnPropertyChanged(nameof(HasStatus));
+        OnPropertyChanged(nameof(HasError));
+    }
+
+    private void ClearStatus() => SetStatus(null);
+}

--- a/StoryCADTests/Collaborator/KernelFactoryTests.cs
+++ b/StoryCADTests/Collaborator/KernelFactoryTests.cs
@@ -7,10 +7,11 @@ using StoryCollaborator.Models;
 namespace StoryCADTests.Collaborator;
 
 /// <summary>
-///     Covers the Collaborator proxy credential resolution added for the PR #1470 review item
-///     (issue #89 omission): the store-activation JWT replaces the COLLAB_PROXY_TOKEN shared
-///     secret on Collaborator calls, and no credential at all refuses the call client-side.
-///     Env and JWT sources are injected, so nothing here reads real environment variables or IoC.
+///     Covers the Collaborator proxy credential resolution after issue #90 step 8 items 5 and 6:
+///     the direct-to-OpenAI path (OPENAI_API_KEY) and the COLLAB_PROXY_TOKEN shared-secret
+///     fallback both retired, so the store-activation JWT is the sole credential and the only
+///     resolution path is Proxy. No credential at all refuses the call client-side.
+///     The JWT source is injected, so nothing here reads real environment variables or IoC.
 /// </summary>
 [TestClass]
 public class KernelFactoryTests
@@ -23,35 +24,24 @@ public class KernelFactoryTests
     // ── ResolveWorkflowCredential ────────────────────────────────────────────
 
     [TestMethod]
-    public void ResolveWorkflowCredential_JwtHeld_ReturnsJwtNotSharedSecret()
+    public void ResolveWorkflowCredential_JwtHeld_ReturnsJwt()
     {
-        var credential = KernelFactory.ResolveWorkflowCredential(
-            Env("COLLAB_PROXY_TOKEN", "shared-secret"), () => "activation-jwt");
+        var credential = KernelFactory.ResolveWorkflowCredential(() => "activation-jwt");
 
-        Assert.AreEqual("activation-jwt", credential,
-            "an activated subscriber's JWT must replace the shared secret");
+        Assert.AreEqual("activation-jwt", credential);
     }
 
     [TestMethod]
-    public void ResolveWorkflowCredential_NoJwt_FallsBackToSharedSecret()
+    public void ResolveWorkflowCredential_NoJwt_ReturnsNull()
     {
-        var credential = KernelFactory.ResolveWorkflowCredential(
-            Env("COLLAB_PROXY_TOKEN", "shared-secret"), () => null);
-
-        Assert.AreEqual("shared-secret", credential);
-    }
-
-    [TestMethod]
-    public void ResolveWorkflowCredential_NoCredentials_ReturnsNull()
-    {
-        Assert.IsNull(KernelFactory.ResolveWorkflowCredential(NoEnv, () => null),
-            "no JWT and no shared secret must yield no credential, never an empty one");
+        Assert.IsNull(KernelFactory.ResolveWorkflowCredential(() => null),
+            "no JWT must yield no credential; the shared-secret fallback is retired");
     }
 
     // ── ResolveConfig ────────────────────────────────────────────────────────
 
     [TestMethod]
-    public void ResolveConfig_JwtOnly_ProxyPathWithJwtCredential()
+    public void ResolveConfig_JwtHeld_ProxyPathWithJwtCredential()
     {
         var config = KernelFactory.ResolveConfig(NoEnv, () => "activation-jwt");
 
@@ -61,8 +51,20 @@ public class KernelFactoryTests
     }
 
     [TestMethod]
-    public void ResolveConfig_JwtAndSharedToken_JwtWins()
+    public void ResolveConfig_CustomProxyUrl_UsesConfiguredEndpoint()
     {
+        var config = KernelFactory.ResolveConfig(
+            Env("COLLAB_PROXY_URL", "https://dev.example.com/v1"), () => "activation-jwt");
+
+        Assert.AreEqual("https://dev.example.com/v1", config.Endpoint);
+        Assert.AreEqual("activation-jwt", config.Credential);
+    }
+
+    [TestMethod]
+    public void ResolveConfig_SharedTokenEnvVarSet_IgnoredNotUsedAsCredential()
+    {
+        // COLLAB_PROXY_TOKEN retired as a credential (issue #90 D6 as overruled): even if the env
+        // var happens to be set (e.g. a developer's shell), it must not be read as a fallback.
         var config = KernelFactory.ResolveConfig(
             Env("COLLAB_PROXY_TOKEN", "shared-secret"), () => "activation-jwt");
 
@@ -70,29 +72,21 @@ public class KernelFactoryTests
     }
 
     [TestMethod]
-    public void ResolveConfig_SharedTokenOnly_ProxyPathUnchanged()
+    public void ResolveConfig_NoJwt_ThrowsNamingSubscribeAndAllowlist()
     {
-        var config = KernelFactory.ResolveConfig(
-            Env("COLLAB_PROXY_TOKEN", "shared-secret"), () => null);
-
-        Assert.AreEqual(KernelFactory.KernelPath.Proxy, config.Path);
-        Assert.AreEqual("shared-secret", config.Credential);
-    }
-
-    [TestMethod]
-    public void ResolveConfig_OpenAiKeyOnly_DirectPathUnchanged()
-    {
-        var config = KernelFactory.ResolveConfig(
-            Env("OPENAI_API_KEY", "sk-key"), () => null);
-
-        Assert.AreEqual(KernelFactory.KernelPath.Direct, config.Path);
-        Assert.AreEqual("sk-key", config.Credential);
-    }
-
-    [TestMethod]
-    public void ResolveConfig_NoCredentialsAnywhere_Throws()
-    {
-        Assert.ThrowsExactly<InvalidOperationException>(
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(
             () => KernelFactory.ResolveConfig(NoEnv, () => null));
+
+        StringAssert.Contains(ex.Message, "subscribe");
+        StringAssert.Contains(ex.Message, "allowlist");
+    }
+
+    [TestMethod]
+    public void ResolveConfig_OpenAiKeyEnvVarSet_StillThrows()
+    {
+        // OPENAI_API_KEY retired as a fallback (issue #90 step 8 item 5): no Direct path remains,
+        // so its presence in the environment must not resolve a config.
+        Assert.ThrowsExactly<InvalidOperationException>(
+            () => KernelFactory.ResolveConfig(Env("OPENAI_API_KEY", "sk-key"), () => null));
     }
 }

--- a/StoryCADTests/DAL/PreferencesIOTests.cs
+++ b/StoryCADTests/DAL/PreferencesIOTests.cs
@@ -117,4 +117,33 @@ public class PreferencesIOTests
         Assert.AreEqual(expected.ThemePreference, model.ThemePreference);
         Assert.AreSame(model, Ioc.Default.GetRequiredService<PreferenceService>().Model);
     }
+
+    /// <summary>
+    ///     Pins the pure-read invariant issue #90 D8 (as amended) restates: ReadPreferences()
+    ///     must never write, even when StoreUserGuid is empty. GUID provisioning is a separate,
+    ///     explicit startup step (PreferenceService.EnsureUserGuidProvisionedAsync), not a side
+    ///     effect of the read. Runs against the same headless test fixture path
+    ///     (AppState.RootDirectory resolves to the test binary's directory, never a real user's
+    ///     roaming preferences folder) the other tests in this class use, so a headless test run
+    ///     never touches a real preferences file.
+    /// </summary>
+    [TestMethod]
+    public async Task ReadPreferences_EmptyGuid_DoesNotWriteFile()
+    {
+        var filePath = Path.Combine(Ioc.Default.GetRequiredService<AppState>().RootDirectory, "Preferences.json");
+        var model = new PreferencesModel { StoreUserGuid = string.Empty };
+        await File.WriteAllTextAsync(filePath, JsonSerializer.Serialize(model));
+        var beforeContent = await File.ReadAllTextAsync(filePath);
+        var beforeWriteUtc = File.GetLastWriteTimeUtc(filePath);
+
+        var _sut = new PreferencesIo();
+        var actual = await _sut.ReadPreferences();
+
+        Assert.AreEqual(string.Empty, actual.StoreUserGuid ?? string.Empty,
+            "sanity check: the fixture's empty GUID round-tripped");
+        var afterContent = await File.ReadAllTextAsync(filePath);
+        var afterWriteUtc = File.GetLastWriteTimeUtc(filePath);
+        Assert.AreEqual(beforeContent, afterContent, "ReadPreferences must not rewrite the file");
+        Assert.AreEqual(beforeWriteUtc, afterWriteUtc, "ReadPreferences must not touch the file's mtime");
+    }
 }

--- a/StoryCADTests/ManualTests/Collaborator_Test_Plan.md
+++ b/StoryCADTests/ManualTests/Collaborator_Test_Plan.md
@@ -1,301 +1,326 @@
 # Collaborator Manual Test Plan
 
-Tests for the AI Collaborator feature (CollaboratorLib). Requires a document open in StoryCAD
-and a GUID enrolled on the dev Worker's allowlist. Set `COLLAB_DEV_ACTIVATION=1` to activate
-through that allowlist instead of the platform store (issue #90 D7/D8); it does not bypass the
-purchase gate, which now requires holding a valid activation however obtained.
+Tests for the AI Collaborator feature (CollaboratorLib).
+
+**Scope:** StoryCAD ↔ Collaborator ↔ proxy interactions — open/close, gates, autosave/backup pause, run a workflow without hang/timeout, accept/reject, basic proxy error, credits dialog entry. Requires a document open in StoryCAD and a GUID enrolled on the dev Worker's allowlist.
+
+**Out of scope:** Prompt quality, workflow content debugging, Try Again behavior, element-picker memory across runs.
+
+Set `COLLAB_DEV_ACTIVATION=1` to activate through the allowlist instead of the platform store (issue #90 D7/D8). It is a routing hint only; the Worker's allowlist row grants access.
+
+## Environment variables (one method)
+
+Use **Windows user environment variables** and launch StoryCAD from the **Start menu** or **File Explorer** so a new process loads them. Do not rely on PowerShell, Visual Studio F5, or an already-open StoryCAD process (those often keep an old environment block).
+
+### Set or change a variable
+
+1. Fully quit StoryCAD (and Visual Studio if it was used only as a launcher).
+2. Open Start, search for **Edit environment variables for your account**, open it.
+3. Under **User variables**, New or Edit:
+   - Name: `COLLAB_DEV_ACTIVATION` — Value: `1` (required for these tests)
+   - Name: `COLLAB_PROXY_URL` — Value: dev Worker base, e.g. `https://storycad-collaborator-proxy.storybuilder-foundation.workers.dev/v1` (optional; omit to use the build default)
+4. OK out of all dialogs.
+5. Start StoryCAD from **Start** or **File Explorer** (sideloaded/MSIX install, or a deployed build path). Do not use a terminal or VS instance that was open before step 3.
+
+### Temporary change (e.g. TC-118)
+
+1. Quit StoryCAD completely.
+2. Edit the user variable in the same dialog as above.
+3. Start StoryCAD again from Start or Explorer.
+4. After the case, quit StoryCAD, restore the previous value (or delete the variable), start StoryCAD again the same way.
+
+### Verify before testing
+
+- `COLLAB_DEV_ACTIVATION` is `1` (user variable).
+- Your `StoreUserGuid` is **approved** on the dev Worker allowlist (first Collaborator open with the flag set may self-enroll as `pending`; approve with category `developer` or `beta_tester` per the workflow guide). If Subscribe appears instead of Collaborator, the process did not see the flag or the GUID is not approved.
 
 ## Session Setup (Run Once Before Testing)
-1. Launch StoryCAD
-2. Go to Tools > Preferences > General tab; set Auto-save interval to 30 seconds and enable it
-3. Go to Backup tab; enable Automatic backups with a 1-minute interval
-4. Click OK
-5. Open the sample outline "Danger Calls" (File > Open Sample Outline)
-6. Verify `COLLAB_DEV_ACTIVATION=1` is set in your environment and your GUID is approved on the allowlist
+
+1. Set environment variables per **Environment variables** above; start StoryCAD from Start or Explorer.
+2. Tools > Preferences > Backup tab: enable autosave every **30** seconds; enable timed backups every **1** minute. Note the **Backup directory** path shown under Save Locations (that is where TC-113 looks — not a fixed LocalAppData path).
+3. Save preferences.
+4. Open the sample outline **Danger Calls** (File > Open Sample Outline).
+5. Confirm Collaborator opens without the Subscribe dialog (allowlist activation worked).
 
 ## Session Cleanup (After All Tests)
-1. Restore original autosave and backup preferences
-2. Close StoryCAD
+
+1. Close Collaborator if open (window X or Exit).
+2. Restore original autosave/backup preferences if you changed them.
+3. Restore `COLLAB_PROXY_URL` if TC-118 changed it; start StoryCAD once from Start/Explorer to confirm.
+4. Close StoryCAD.
+
+## Collaborator session cleanup (between cases)
+
+When a case says reset Collaborator or discard AI work:
+
+1. Do **not** Accept / Accept All unless the case requires it.
+2. **Close the Collaborator window** (ends the session; next open is a new instance).
+3. If the outline must be clean: close the outline and reopen **Danger Calls** (or revert edits).
+4. Open Collaborator again and re-select the workflow if the next case needs a run.
+
+Closing only the outline without closing Collaborator does not fully reset Collaborator UI state.
 
 ---
 
 ## Launch and Window
 
 ### TC-110: Open Collaborator Window
-**Priority:** Critical
+**Priority:** Critical  
 **Time:** ~2 minutes
 
 **Setup:**
-- "Danger Calls" outline open
-- `COLLAB_DEV_ACTIVATION=1`
+- Session Setup done; "Danger Calls" open
 
 **Steps:**
-1. Click the Collaborator button in the toolbar (or Tools > Story Collaborator)
+1. Click the Collaborator button in the toolbar (or Tools > Story Collaborator)  
    **Expected:** Story Collaborator window opens alongside the main window
-
-2. Verify the workflow navigation shell loads
-   **Expected:** Left panel shows list of available workflows (Premise, GMC, etc.)
-
-3. Verify the main StoryCAD window remains responsive
+2. Verify the workflow navigation shell loads  
+   **Expected:** Left panel lists workflows (Ideation/Premise, GMC, etc.)
+3. Verify the main StoryCAD window remains responsive  
    **Expected:** Can click elements in the navigation pane without the app hanging
 
 **Cleanup:**
-- Close Collaborator window
+1. Close the Collaborator window (X).
+2. Leave "Danger Calls" open for the next case.
 
 ---
 
 ### TC-111: No Document Open
-**Priority:** High
+**Priority:** High  
 **Time:** ~1 minute
 
 **Setup:**
-- No outline open (close any open document first)
+- Close any open outline (File > Close or equivalent) so no story is loaded
 
 **Steps:**
-1. Click the Collaborator button
-   **Expected:** Error message appears — "No StoryModel available" or similar; no crash
-
-2. Dismiss the message
-   **Expected:** Returns to main window normally
+1. Click the Collaborator button  
+   **Expected:** Collaborator does **not** open. Status bar shows a warning such as "No story is open. Open an outline before using Collaborator." No crash. (Close leaves an empty document in AppState; the gate uses empty `CurrentView`, not a null model.)
+2. Confirm the main window still works  
+   **Expected:** Can open a file or sample
 
 **Cleanup:**
-- Reopen "Danger Calls" for subsequent tests
+1. Open sample **Danger Calls** again.
+2. Collaborator stays closed until the next case opens it.
 
 ---
 
 ## Autosave and Backup Suspension
 
 ### TC-112: Autosave Paused While Collaborator Is Open
-**Priority:** High
+**Priority:** High  
 **Time:** ~4 minutes
 
 **Setup:**
-- "Danger Calls" open
-- Autosave set to 30 seconds (Session Setup)
-- Note the file's last-modified timestamp before starting
+- "Danger Calls" open; autosave 30 seconds (Session Setup)
+- Note the outline file's last-modified time (sample is often under `%TEMP%\Danger Calls.stbx`)
 
 **Steps:**
-1. Open Collaborator
-   **Expected:** Story Collaborator window opens
-
-2. Make a visible edit in StoryCAD's main window (e.g., change a character name)
-   **Expected:** Changed indicator appears in status bar
-
-3. Wait 90 seconds without closing Collaborator
-   **Expected:** File's last-modified timestamp does NOT change during this period
-
-4. Close Collaborator window
-   **Expected:** Collaborator closes
-
-5. Wait 60 seconds
-   **Expected:** Autosave fires — file's last-modified timestamp updates
+1. Open Collaborator  
+   **Expected:** Window opens
+2. Make a visible edit in StoryCAD's main window (e.g. change a character name)  
+   **Expected:** Changed indicator in the status bar
+3. Wait 90 seconds without closing Collaborator  
+   **Expected:** File last-modified time does **not** change
+4. Close Collaborator  
+   **Expected:** Window closes
+5. Wait 60 seconds  
+   **Expected:** Autosave updates the file last-modified time
 
 **Cleanup:**
-- Revert any edits made to "Danger Calls"
+1. Close Collaborator if still open.
+2. Undo or re-open **Danger Calls** so the sample is not left dirty for later cases.
 
 ---
 
 ### TC-113: Backup Timer Paused While Collaborator Is Open
-**Priority:** High
+**Priority:** High  
 **Time:** ~4 minutes
 
 **Setup:**
-- "Danger Calls" open
-- Timed backup enabled at 1-minute interval (Session Setup)
-- Note backup folder contents before starting (typically `%LOCALAPPDATA%\StoryCAD\Backups`)
+- "Danger Calls" open; timed backup every 1 minute (Session Setup)
+- Note contents of the **Backup directory** from Preferences > Save Locations (e.g. a Google Drive or Documents folder). Sort by date modified.
 
 **Steps:**
-1. Open Collaborator
-   **Expected:** Story Collaborator window opens
-
-2. Wait 90 seconds
-   **Expected:** No new backup file appears in the backup folder
-
-3. Close Collaborator
-   **Expected:** Collaborator closes
-
-4. Wait 90 seconds
-   **Expected:** New backup file appears in backup folder
+1. Open Collaborator  
+   **Expected:** Window opens
+2. Wait 90 seconds  
+   **Expected:** No **new** `Danger Calls as of ….zip` in that backup directory
+3. Close Collaborator  
+   **Expected:** Window closes
+4. Wait 90 seconds  
+   **Expected:** A new backup zip appears in that directory
 
 **Cleanup:**
-- Delete the test backup file created in step 4
+1. Close Collaborator if still open.
+2. Optionally delete the zip created in step 4 from the backup directory.
 
 ---
 
 ## Workflow Execution
 
-### TC-114: Run a Workflow — Premise
-**Priority:** Critical
+### TC-114: Run a Workflow
+**Priority:** Critical  
 **Time:** ~5 minutes
 
+**Scope note:** Assert run completes and UI stays usable. Do not score premise quality or prompt wording.
+
 **Setup:**
-- "Danger Calls" open; Story Overview node selected
-- Collaborator window open
+- "Danger Calls" open; Story Overview selected
+- Collaborator open
 
 **Steps:**
-1. Select "Premise" from the workflow list
-   **Expected:** Premise workflow page loads, showing input fields for the story
-
-2. Click Execute (or equivalent run button)
-   **Expected:** Progress indicator appears; conversation list shows "Running Premise..."
-
-3. Wait for response (up to 3 minutes)
-   **Expected:** AI response appears in conversation list; Accept buttons appear next to output fields
-
-4. Verify no crash or timeout error
-   **Expected:** Response text is coherent; progress indicator disappears
+1. Select a short workflow from the list (e.g. Ideation / Premise)  
+   **Expected:** Workflow page loads; element gathering can complete
+2. Run / Execute when required  
+   **Expected:** Progress or "Running…" in the conversation list
+3. Wait for completion (up to 3 minutes)  
+   **Expected:** Response appears; Accept controls available if the workflow produces property updates; no crash or hang treated as timeout before 3 minutes
+4. Leave Accept unused  
+   **Expected:** Pending updates not applied yet
 
 **Cleanup:**
-- Do not accept changes yet (used in TC-115 and TC-116)
+1. Do **not** Accept All (TC-115/116 may use output, or discard below).
+2. If continuing to TC-115 with this output, leave Collaborator open.
+3. If stopping here: close Collaborator without Accept; reopen sample if the outline must stay clean.
 
 ---
 
 ### TC-115: Accept All Workflow Changes
-**Priority:** Critical
+**Priority:** Critical  
 **Time:** ~2 minutes
 
 **Setup:**
-- TC-114 completed; workflow output visible with Accept buttons
+- TC-114 completed with Accept controls visible
 
 **Steps:**
-1. Click "Accept All" button
-   **Expected:** All output fields write to the StoryCAD outline
-
-2. Close Collaborator
-   **Expected:** Collaborator closes; StoryCAD reloads the current ViewModel
-
-3. Select Story Overview in the navigation pane
-   **Expected:** Fields updated with Collaborator's output (e.g., Premise text now populated)
+1. Click **Accept All**  
+   **Expected:** Output fields write to the outline
+2. Close Collaborator  
+   **Expected:** Window closes; StoryCAD reloads the current view from the model
+3. Select Story Overview (or the element that was updated)  
+   **Expected:** Fields show Collaborator's applied text
 
 **Cleanup:**
-- Revert any changes if "Danger Calls" should remain unmodified
+1. Collaborator already closed in step 2.
+2. Close outline and reopen **Danger Calls** (or revert) so later cases start from a clean sample.
 
 ---
 
 ### TC-116: Accept Individual Property
-**Priority:** High
+**Priority:** High  
 **Time:** ~3 minutes
 
 **Setup:**
-- Run a workflow (TC-114) to produce output with multiple fields
+- Run a workflow (as in TC-114) so multiple Accept controls appear
 
 **Steps:**
-1. Click the Accept button next to one specific output field only
-   **Expected:** That field writes to the outline; other fields unchanged
-
-2. Click the Accept button for a second field
-   **Expected:** Second field writes; first field still shows accepted value
-
-3. Close Collaborator without accepting remaining fields
-   **Expected:** Only the two accepted fields are updated in StoryCAD
+1. Accept **one** field only  
+   **Expected:** That field applies; others remain pending
+2. Accept a **second** field  
+   **Expected:** Second applies; first remains applied
+3. Close Collaborator without accepting the rest  
+   **Expected:** Only the accepted fields are updated in StoryCAD
 
 **Cleanup:**
-- Revert changes
+1. Collaborator closed in step 3.
+2. Close outline and reopen **Danger Calls** (or revert) for a clean sample.
 
 ---
 
-### TC-117: Reject All / Close Without Accepting
-**Priority:** High
+### TC-117: Close Without Accepting
+**Priority:** High  
 **Time:** ~2 minutes
 
 **Setup:**
-- Run a workflow to produce output
+- Run a workflow to produce output; note one or two StoryCAD field values first
 
 **Steps:**
-1. Note the current values of one or two output fields in StoryCAD before accepting anything
-
-2. Close Collaborator window without clicking any Accept button
-   **Expected:** Collaborator closes; ViewModel reloads
-
-3. Verify the fields in StoryCAD are unchanged
-   **Expected:** Original values intact — Collaborator made no edits
+1. Close Collaborator without any Accept  
+   **Expected:** Window closes
+2. Check those fields in StoryCAD  
+   **Expected:** Unchanged — no edits applied
 
 **Cleanup:**
-- None
+1. Collaborator already closed.
+2. No outline revert required if nothing was accepted.
 
 ---
 
 ## Error Handling
 
 ### TC-118: Proxy Unreachable
-**Priority:** Medium
+**Priority:** Medium  
 **Time:** ~3 minutes
 
 **Setup:**
-- Set environment variable `COLLAB_PROXY_URL=https://invalid.example.com` (temporarily)
-- Restart StoryCAD for the variable to take effect
+1. Quit StoryCAD completely.
+2. Set user env `COLLAB_PROXY_URL` = `https://invalid.example.com` (see **Environment variables**).
+3. Start StoryCAD from Start or Explorer; open **Danger Calls**.
+4. Keep `COLLAB_DEV_ACTIVATION=1`.
 
 **Steps:**
-1. Open Collaborator and select any workflow
-
-2. Click Execute
-   **Expected:** Progress indicator appears; after timeout, an error message appears in the conversation list (not a crash)
-
-3. Verify main StoryCAD window is still functional
-   **Expected:** Can navigate outline, close Collaborator normally
+1. Open Collaborator and start any workflow run  
+   **Expected:** After failure/timeout, conversation list shows an error (not a crash). Host name `invalid.example.com` may appear in the message.
+2. Use the main StoryCAD window  
+   **Expected:** Outline still navigable; Collaborator can be closed normally
 
 **Cleanup:**
-- Unset `COLLAB_PROXY_URL` and restart StoryCAD
+1. Close Collaborator.
+2. Quit StoryCAD.
+3. Restore `COLLAB_PROXY_URL` to the dev Worker URL (or remove the variable).
+4. Start StoryCAD from Start or Explorer and confirm a normal workflow can run again.
 
 ---
 
 ### TC-119: Close and Reopen Collaborator in Same Session
-**Priority:** Medium
+**Priority:** Medium  
 **Time:** ~3 minutes
 
 **Setup:**
-- "Danger Calls" open
+- "Danger Calls" open; `COLLAB_PROXY_URL` restored if TC-118 ran
 
 **Steps:**
-1. Open Collaborator
-   **Expected:** Collaborator window opens
-
-2. Close Collaborator
-   **Expected:** Window closes; autosave/backup resume
-
-3. Open Collaborator again
-   **Expected:** Fresh Collaborator window opens; workflow list available
-
-4. Run a workflow
-   **Expected:** Executes normally — no stale state from previous session
+1. Open Collaborator  
+   **Expected:** Window opens
+2. Close Collaborator  
+   **Expected:** Window closes; autosave/backup may resume
+3. Open Collaborator again  
+   **Expected:** Fresh window; workflow list available
+4. Run a short workflow  
+   **Expected:** Completes without hang (no need to Accept)
 
 **Cleanup:**
-- Close Collaborator
+1. Close Collaborator without Accept (unless you want applied edits).
+2. Reopen sample only if the outline was dirtied.
 
 ---
 
 ## Credits
 
 ### TC-120: Buy Credits Button Opens the Dialog
-**Priority:** High
+**Priority:** High  
 **Time:** ~2 minutes
-
-Wiring landed in issue #90 step 8 (the dialog itself was built in step 10); this case is the manual
-click-through that a headless session cannot verify.
 
 **Setup:**
 - "Danger Calls" open
+- Buy Credits toolbar button visible next to Collaborator (same visibility as Collaborator)
 
 **Steps:**
-1. Locate the Buy Credits button on the Shell toolbar, next to the Collaborator button
-   **Expected:** Visible exactly when the Collaborator button is; tooltip reads "Buy Collaborator Credits"
-
-2. Click the Buy Credits button
-   **Expected:** Buy Credits dialog opens (on a sideloaded dev build with no store license context,
-   the dialog's pack listing may show its failure state instead of products — the assertion is that
-   the button opens the dialog, not that the store answers)
-
-3. Close the dialog without purchasing
-   **Expected:** Dialog closes; no purchase initiated; main window responsive
+1. Confirm the button is enabled (not stuck gray after a save/open). Tooltip: "Buy Collaborator Credits"  
+   **Expected:** Clickable when the command bar is idle
+2. Click **Buy Credits**  
+   **Expected:** Buy Credits dialog opens. On a sideloaded/dev build, pack list may be empty or show a store error — assertion is **dialog opens**, not a successful purchase
+3. Click **Not now** (or equivalent)  
+   **Expected:** Dialog closes; no purchase; main window responsive
 
 **Cleanup:**
-- None
+- None (dialog already closed)
 
 ---
 
 ## Notes
 
-- **COLLAB_DEBUG=1**: Set this to trigger the debugger-attach dialog on Collaborator open (dev use only).
-- **COLLAB_PROXY_URL**: Overrides the default proxy endpoint. Leave unset for production Worker.
-- Proxy responses can take up to 3 minutes — do not treat a slow response as a hang before the timeout elapses.
-- TC-112 and TC-113 require watching timestamps or log output; NLog writes to `%LOCALAPPDATA%\StoryCAD\logs\` and will show `Collaborator logging initialized` at session start.
+- **COLLAB_DEBUG=1**: Debugger-attach dialog on Collaborator open (dev only); set via the same user-env method if needed.
+- Proxy responses can take up to 3 minutes — do not treat a slow response as a hang before that.
+- Logs: under the app's `RootDirectory` logs folder (package or unpackaged); useful if open/activation fails.
+- Manual pass for issue #90 Test (lane A) is this suite TC-110–TC-120, not prompt review.

--- a/StoryCADTests/ManualTests/Collaborator_Test_Plan.md
+++ b/StoryCADTests/ManualTests/Collaborator_Test_Plan.md
@@ -1,52 +1,36 @@
 # Collaborator Manual Test Plan
 
-Tests for the AI Collaborator feature (CollaboratorLib).
+Tests for the AI Collaborator feature (CollaboratorLib) as used inside StoryCAD.
 
-**Scope:** StoryCAD ↔ Collaborator ↔ proxy interactions — open/close, gates, autosave/backup pause, run a workflow without hang/timeout, accept/reject, basic proxy error, credits dialog entry. Requires a document open in StoryCAD and a GUID enrolled on the dev Worker's allowlist.
+**Scope:** Open/close, document gate, autosave/backup pause, run a workflow without hang/timeout, accept/reject, credits dialog entry. Requires a document open and Collaborator already able to open for this machine (see Prerequisites).
 
-**Out of scope:** Prompt quality, workflow content debugging, Try Again behavior, element-picker memory across runs.
+**Out of scope:** Prompt quality, workflow content debugging, Try Again behavior, element-picker memory across runs. Store purchase / paid activation paths. Administrative enrollment of a tester identity (private setup plan).
 
-Set `COLLAB_DEV_ACTIVATION=1` to activate through the allowlist instead of the platform store (issue #90 D7/D8). It is a routing hint only; the Worker's allowlist row grants access.
+**Related (private repo):** system setup, environment configuration, identity enrollment, and the proxy-unreachable case live in Collaborator `CollaboratorTests/ManualTests/Collaborator_System_Setup_Test_Plan.md`. Do not copy those steps into this public plan.
 
-## Environment variables (one method)
+---
 
-Use **Windows user environment variables** and launch StoryCAD from the **Start menu** or **File Explorer** so a new process loads them. Do not rely on PowerShell, Visual Studio F5, or an already-open StoryCAD process (those often keep an old environment block).
+## Prerequisites
 
-### Set or change a variable
+Complete **before** this suite. This plan does not document how.
 
-1. Fully quit StoryCAD (and Visual Studio if it was used only as a launcher).
-2. Open Start, search for **Edit environment variables for your account**, open it.
-3. Under **User variables**, New or Edit:
-   - Name: `COLLAB_DEV_ACTIVATION` — Value: `1` (required for these tests)
-   - Name: `COLLAB_PROXY_URL` — Value: dev Worker base, e.g. `https://storycad-collaborator-proxy.storybuilder-foundation.workers.dev/v1` (optional; omit to use the build default)
-4. OK out of all dialogs.
-5. Start StoryCAD from **Start** or **File Explorer** (sideloaded/MSIX install, or a deployed build path). Do not use a terminal or VS instance that was open before step 3.
+1. Developer or tester activation for this machine is configured so Collaborator opens without the Subscribe dialog.
+2. The AI proxy this build uses is reachable from your network.
+3. If Collaborator still offers Subscribe instead of the feature UI, stop here and finish the private system setup plan. Do not treat that as a TC-110 failure.
 
-### Temporary change (e.g. TC-118)
+## Session Setup (run once)
 
-1. Quit StoryCAD completely.
-2. Edit the user variable in the same dialog as above.
-3. Start StoryCAD again from Start or Explorer.
-4. After the case, quit StoryCAD, restore the previous value (or delete the variable), start StoryCAD again the same way.
-
-### Verify before testing
-
-- `COLLAB_DEV_ACTIVATION` is `1` (user variable).
-- Your `StoreUserGuid` is **approved** on the dev Worker allowlist (first Collaborator open with the flag set may self-enroll as `pending`; approve with category `developer` or `beta_tester` per the workflow guide). If Subscribe appears instead of Collaborator, the process did not see the flag or the GUID is not approved.
-
-## Session Setup (Run Once Before Testing)
-
-1. Set environment variables per **Environment variables** above; start StoryCAD from Start or Explorer.
-2. Tools > Preferences > Backup tab: enable autosave every **30** seconds; enable timed backups every **1** minute. Note the **Backup directory** path shown under Save Locations (that is where TC-113 looks — not a fixed LocalAppData path).
+1. Start StoryCAD the same way you will for the whole session (Start menu, File Explorer, or your usual installed build). A process that was already open may not see recent configuration changes.
+2. Tools > Preferences > Backup: enable autosave every **30** seconds; enable timed backups every **1** minute. Note the **Backup directory** under Save Locations (TC-113 uses that path).
 3. Save preferences.
 4. Open the sample outline **Danger Calls** (File > Open Sample Outline).
-5. Confirm Collaborator opens without the Subscribe dialog (allowlist activation worked).
+5. Open Collaborator once and confirm the workflow list appears (not Subscribe). Close Collaborator.
 
-## Session Cleanup (After All Tests)
+## Session Cleanup (after all tests)
 
-1. Close Collaborator if open (window X or Exit).
+1. Close Collaborator if open.
 2. Restore original autosave/backup preferences if you changed them.
-3. Restore `COLLAB_PROXY_URL` if TC-118 changed it; start StoryCAD once from Start/Explorer to confirm.
+3. If you ran the private proxy-unreachable case earlier in the day, confirm normal configuration was restored (see that plan's cleanup).
 4. Close StoryCAD.
 
 ## Collaborator session cleanup (between cases)
@@ -94,7 +78,7 @@ Closing only the outline without closing Collaborator does not fully reset Colla
 
 **Steps:**
 1. Click the Collaborator button  
-   **Expected:** Collaborator does **not** open. Status bar shows a warning such as "No story is open. Open an outline before using Collaborator." No crash. (Close leaves an empty document in AppState; the gate uses empty `CurrentView`, not a null model.)
+   **Expected:** Collaborator does **not** open. Status bar shows a warning such as "No story is open. Open an outline before using Collaborator." No crash.
 2. Confirm the main window still works  
    **Expected:** Can open a file or sample
 
@@ -112,7 +96,7 @@ Closing only the outline without closing Collaborator does not fully reset Colla
 
 **Setup:**
 - "Danger Calls" open; autosave 30 seconds (Session Setup)
-- Note the outline file's last-modified time (sample is often under `%TEMP%\Danger Calls.stbx`)
+- Note the outline file's last-modified time (sample is often under a temp folder for sample outlines)
 
 **Steps:**
 1. Open Collaborator  
@@ -138,7 +122,7 @@ Closing only the outline without closing Collaborator does not fully reset Colla
 
 **Setup:**
 - "Danger Calls" open; timed backup every 1 minute (Session Setup)
-- Note contents of the **Backup directory** from Preferences > Save Locations (e.g. a Google Drive or Documents folder). Sort by date modified.
+- Note contents of the **Backup directory** from Preferences > Save Locations. Sort by date modified.
 
 **Steps:**
 1. Open Collaborator  
@@ -246,38 +230,15 @@ Closing only the outline without closing Collaborator does not fully reset Colla
 
 ---
 
-## Error Handling
-
-### TC-118: Proxy Unreachable
-**Priority:** Medium  
-**Time:** ~3 minutes
-
-**Setup:**
-1. Quit StoryCAD completely.
-2. Set user env `COLLAB_PROXY_URL` = `https://invalid.example.com` (see **Environment variables**).
-3. Start StoryCAD from Start or Explorer; open **Danger Calls**.
-4. Keep `COLLAB_DEV_ACTIVATION=1`.
-
-**Steps:**
-1. Open Collaborator and start any workflow run  
-   **Expected:** After failure/timeout, conversation list shows an error (not a crash). Host name `invalid.example.com` may appear in the message.
-2. Use the main StoryCAD window  
-   **Expected:** Outline still navigable; Collaborator can be closed normally
-
-**Cleanup:**
-1. Close Collaborator.
-2. Quit StoryCAD.
-3. Restore `COLLAB_PROXY_URL` to the dev Worker URL (or remove the variable).
-4. Start StoryCAD from Start or Explorer and confirm a normal workflow can run again.
-
----
+## Session stability
 
 ### TC-119: Close and Reopen Collaborator in Same Session
 **Priority:** Medium  
 **Time:** ~3 minutes
 
 **Setup:**
-- "Danger Calls" open; `COLLAB_PROXY_URL` restored if TC-118 ran
+- "Danger Calls" open
+- Normal proxy configuration restored if you ran the private proxy-unreachable case earlier
 
 **Steps:**
 1. Open Collaborator  
@@ -309,7 +270,7 @@ Closing only the outline without closing Collaborator does not fully reset Colla
 1. Confirm the button is enabled (not stuck gray after a save/open). Tooltip: "Buy Collaborator Credits"  
    **Expected:** Clickable when the command bar is idle
 2. Click **Buy Credits**  
-   **Expected:** Buy Credits dialog opens. On a sideloaded/dev build, pack list may be empty or show a store error — assertion is **dialog opens**, not a successful purchase
+   **Expected:** Buy Credits dialog opens. On a sideloaded or non-store build, pack list may be empty or show a store error. Assertion is **dialog opens**, not a successful purchase.
 3. Click **Not now** (or equivalent)  
    **Expected:** Dialog closes; no purchase; main window responsive
 
@@ -320,7 +281,7 @@ Closing only the outline without closing Collaborator does not fully reset Colla
 
 ## Notes
 
-- **COLLAB_DEBUG=1**: Debugger-attach dialog on Collaborator open (dev only); set via the same user-env method if needed.
-- Proxy responses can take up to 3 minutes — do not treat a slow response as a hang before that.
-- Logs: under the app's `RootDirectory` logs folder (package or unpackaged); useful if open/activation fails.
-- Manual pass for issue #90 Test (lane A) is this suite TC-110–TC-120, not prompt review.
+- Proxy responses can take up to 3 minutes. Do not treat a slow response as a hang before that.
+- Logs: under the app's `RootDirectory` logs folder (package or unpackaged); useful if open fails after Prerequisites were believed complete.
+- Numbering: TC-118 (proxy unreachable) is intentional gap; that case is on the private system setup plan.
+- In-app product pass for Collaborator is this suite (TC-110–TC-117, TC-119–TC-120), not prompt review.

--- a/StoryCADTests/ManualTests/Collaborator_Test_Plan.md
+++ b/StoryCADTests/ManualTests/Collaborator_Test_Plan.md
@@ -1,7 +1,7 @@
 # Collaborator Manual Test Plan
 
 Tests for the AI Collaborator feature (CollaboratorLib). Requires a document open in StoryCAD
-and a GUID enrolled on the dev Worker's allowlist. Set `COLLAB_DEV_ENABLED=1` to activate
+and a GUID enrolled on the dev Worker's allowlist. Set `COLLAB_DEV_ACTIVATION=1` to activate
 through that allowlist instead of the platform store (issue #90 D7/D8); it does not bypass the
 purchase gate, which now requires holding a valid activation however obtained.
 
@@ -11,7 +11,7 @@ purchase gate, which now requires holding a valid activation however obtained.
 3. Go to Backup tab; enable Automatic backups with a 1-minute interval
 4. Click OK
 5. Open the sample outline "Danger Calls" (File > Open Sample Outline)
-6. Verify `COLLAB_DEV_ENABLED=1` is set in your environment and your GUID is approved on the allowlist
+6. Verify `COLLAB_DEV_ACTIVATION=1` is set in your environment and your GUID is approved on the allowlist
 
 ## Session Cleanup (After All Tests)
 1. Restore original autosave and backup preferences
@@ -27,7 +27,7 @@ purchase gate, which now requires holding a valid activation however obtained.
 
 **Setup:**
 - "Danger Calls" outline open
-- `COLLAB_DEV_ENABLED=1`
+- `COLLAB_DEV_ACTIVATION=1`
 
 **Steps:**
 1. Click the Collaborator button in the toolbar (or Tools > Story Collaborator)

--- a/StoryCADTests/ManualTests/Collaborator_Test_Plan.md
+++ b/StoryCADTests/ManualTests/Collaborator_Test_Plan.md
@@ -264,6 +264,35 @@ purchase gate, which now requires holding a valid activation however obtained.
 
 ---
 
+## Credits
+
+### TC-120: Buy Credits Button Opens the Dialog
+**Priority:** High
+**Time:** ~2 minutes
+
+Wiring landed in issue #90 step 8 (the dialog itself was built in step 10); this case is the manual
+click-through that a headless session cannot verify.
+
+**Setup:**
+- "Danger Calls" open
+
+**Steps:**
+1. Locate the Buy Credits button on the Shell toolbar, next to the Collaborator button
+   **Expected:** Visible exactly when the Collaborator button is; tooltip reads "Buy Collaborator Credits"
+
+2. Click the Buy Credits button
+   **Expected:** Buy Credits dialog opens (on a sideloaded dev build with no store license context,
+   the dialog's pack listing may show its failure state instead of products — the assertion is that
+   the button opens the dialog, not that the store answers)
+
+3. Close the dialog without purchasing
+   **Expected:** Dialog closes; no purchase initiated; main window responsive
+
+**Cleanup:**
+- None
+
+---
+
 ## Notes
 
 - **COLLAB_DEBUG=1**: Set this to trigger the debugger-attach dialog on Collaborator open (dev use only).

--- a/StoryCADTests/ManualTests/Collaborator_Test_Plan.md
+++ b/StoryCADTests/ManualTests/Collaborator_Test_Plan.md
@@ -1,8 +1,9 @@
 # Collaborator Manual Test Plan
 
-Tests for the AI Collaborator feature (CollaboratorLib). Requires a valid `COLLAB_PROXY_TOKEN`
-environment variable and a document open in StoryCAD. Set `COLLAB_DEV_ENABLED=1` to bypass
-the purchase gate.
+Tests for the AI Collaborator feature (CollaboratorLib). Requires a document open in StoryCAD
+and a GUID enrolled on the dev Worker's allowlist. Set `COLLAB_DEV_ENABLED=1` to activate
+through that allowlist instead of the platform store (issue #90 D7/D8); it does not bypass the
+purchase gate, which now requires holding a valid activation however obtained.
 
 ## Session Setup (Run Once Before Testing)
 1. Launch StoryCAD
@@ -10,7 +11,7 @@ the purchase gate.
 3. Go to Backup tab; enable Automatic backups with a 1-minute interval
 4. Click OK
 5. Open the sample outline "Danger Calls" (File > Open Sample Outline)
-6. Verify `COLLAB_DEV_ENABLED=1` and `COLLAB_PROXY_TOKEN` are set in your environment
+6. Verify `COLLAB_DEV_ENABLED=1` is set in your environment and your GUID is approved on the allowlist
 
 ## Session Cleanup (After All Tests)
 1. Restore original autosave and backup preferences

--- a/StoryCADTests/Services/PreferenceServiceTests.cs
+++ b/StoryCADTests/Services/PreferenceServiceTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StoryCADLib.Models.Tools;
+using StoryCADLib.Services;
+
+#nullable disable
+
+namespace StoryCADTests.Services;
+
+/// <summary>
+///     Covers <see cref="PreferenceService.EnsureUserGuidProvisionedAsync" />, the explicit
+///     startup step issue #90 D8 (as amended by the design review pass) added so client-side
+///     GUID provisioning is a separate, serialized write rather than a side effect of
+///     <see cref="StoryCADLib.DAL.PreferencesIo.ReadPreferences" />. Uses a fresh
+///     <see cref="PreferenceService" /> instance (not the shared IoC singleton) and an injected
+///     write delegate, so nothing here touches a real preferences file.
+/// </summary>
+[TestClass]
+public class PreferenceServiceTests
+{
+    [TestMethod]
+    public async Task StartupProvisioning_EmptyGuid_GeneratesAndPersists()
+    {
+        var service = new PreferenceService { Model = new PreferencesModel { StoreUserGuid = string.Empty } };
+        var writeCallCount = 0;
+        PreferencesModel written = null;
+
+        await service.EnsureUserGuidProvisionedAsync(model =>
+        {
+            writeCallCount++;
+            written = model;
+            return Task.CompletedTask;
+        });
+
+        Assert.IsFalse(string.IsNullOrEmpty(service.Model.StoreUserGuid),
+            "an empty GUID must be generated");
+        Assert.IsTrue(Guid.TryParse(service.Model.StoreUserGuid, out _),
+            "the generated value must be a valid GUID");
+        Assert.AreEqual(1, writeCallCount, "the write must happen exactly once");
+        Assert.AreSame(service.Model, written, "the write must persist the same model that was updated");
+    }
+
+    [TestMethod]
+    public async Task StartupProvisioning_ExistingGuid_Unchanged()
+    {
+        const string existingGuid = "11111111-1111-1111-1111-111111111111";
+        var service = new PreferenceService { Model = new PreferencesModel { StoreUserGuid = existingGuid } };
+        var writeCallCount = 0;
+
+        await service.EnsureUserGuidProvisionedAsync(_ =>
+        {
+            writeCallCount++;
+            return Task.CompletedTask;
+        });
+
+        Assert.AreEqual(existingGuid, service.Model.StoreUserGuid, "an existing GUID must not be overwritten");
+        Assert.AreEqual(0, writeCallCount, "provisioning must not write when nothing changed");
+    }
+}

--- a/StoryCADTests/Services/Store/ProxyActivationClientTests.cs
+++ b/StoryCADTests/Services/Store/ProxyActivationClientTests.cs
@@ -182,6 +182,33 @@ public class ProxyActivationClientTests
         Assert.IsNull(await client.GetStoreTicketAsync());
     }
 
+    [TestMethod]
+    public async Task GetStoreTicketAsync_DefaultPurpose_NoQueryString()
+    {
+        // issue #90 design section 10 step 10 correction: the default must stay byte-for-byte the
+        // path PR #1470's shipped GetStoreTicketAsync() call already uses, so existing subscription
+        // activation is unaffected by the collections-purpose addition below.
+        var handler = StubHttpMessageHandler.Returning(HttpStatusCode.OK, "{\"ticket\":\"aad-token\"}");
+        var client = CreateClient(handler);
+
+        await client.GetStoreTicketAsync();
+
+        Assert.IsTrue(handler.LastRequest.RequestUri!.AbsolutePath.EndsWith("/store/ticket"));
+        Assert.IsTrue(string.IsNullOrEmpty(handler.LastRequest.RequestUri.Query));
+    }
+
+    [TestMethod]
+    public async Task GetStoreTicketAsync_CollectionsPurpose_AddsQueryString()
+    {
+        var handler = StubHttpMessageHandler.Returning(HttpStatusCode.OK, "{\"ticket\":\"aad-token-collections\"}");
+        var client = CreateClient(handler);
+
+        var ticket = await client.GetStoreTicketAsync("collections");
+
+        Assert.AreEqual("aad-token-collections", ticket);
+        Assert.AreEqual("?purpose=collections", handler.LastRequest.RequestUri!.Query);
+    }
+
     // ── Test double ──────────────────────────────────────────────────────────
 
     private sealed class StubHttpMessageHandler : HttpMessageHandler

--- a/StoryCADTests/Services/Store/StoreActivationServiceTests.cs
+++ b/StoryCADTests/Services/Store/StoreActivationServiceTests.cs
@@ -30,6 +30,10 @@ public class StoreActivationServiceTests
         prefs.Model.StoreActivationJwt = string.Empty;
         prefs.Model.StoreActivationJwtExpiry = DateTime.MinValue;
         prefs.Model.StoreUserGuid = "11111111-1111-1111-1111-111111111111";
+
+        // Defensive reset: guards against a leaked COLLAB_DEV_ENABLED from a prior test or the
+        // outer shell environment leaking into tests that don't expect dev-platform routing.
+        Environment.SetEnvironmentVariable("COLLAB_DEV_ENABLED", null);
     }
 
     private static StoreActivationService CreateService(FakeStoreService store, FakeActivationClient client) =>
@@ -299,6 +303,52 @@ public class StoreActivationServiceTests
         await service.InitializeAsync();
 
         Assert.AreEqual(ActivationState.Active, observed);
+    }
+
+    // ── Dev/tester allowlist activation (issue #90 D7/D8, step 8 item 3) ───────
+
+    [TestMethod]
+    public async Task StoreActivationService_DevEnabled_PostsDevPlatformWithGuid()
+    {
+        Environment.SetEnvironmentVariable("COLLAB_DEV_ENABLED", "1");
+        try
+        {
+            var store = new FakeStoreService { Proof = SampleProof };
+            var client = new FakeActivationClient();
+            var service = CreateService(store, client);
+
+            await service.InitializeAsync();
+
+            Assert.AreEqual(ActivationState.Active, service.State);
+            Assert.AreEqual(1, client.ActivateCallCount);
+            Assert.IsNotNull(client.LastProof);
+            Assert.AreEqual("dev", client.LastProof.Platform);
+            Assert.AreEqual("11111111-1111-1111-1111-111111111111", client.LastProof.UserGuid);
+            Assert.AreEqual(0, store.ProofCallCount,
+                "dev activation must not ask the platform store for proof");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("COLLAB_DEV_ENABLED", null);
+        }
+    }
+
+    [TestMethod]
+    public async Task StoreActivationService_DevDisabled_UsesStoreProof()
+    {
+        // COLLAB_DEV_ENABLED left unset: the default, store-driven path is unchanged.
+        Environment.SetEnvironmentVariable("COLLAB_DEV_ENABLED", null);
+        var store = new FakeStoreService { Proof = SampleProof };
+        var client = new FakeActivationClient();
+        var service = CreateService(store, client);
+
+        await service.InitializeAsync();
+
+        Assert.AreEqual(ActivationState.Active, service.State);
+        Assert.AreEqual(1, store.ProofCallCount, "the platform store must be asked for proof");
+        Assert.IsNotNull(client.LastProof);
+        Assert.AreEqual(SampleProof.Platform, client.LastProof.Platform);
+        Assert.AreNotEqual("dev", client.LastProof.Platform);
     }
 
     // Fakes shared with the other store test classes live in StoreTestDoubles.cs.

--- a/StoryCADTests/Services/Store/StoreActivationServiceTests.cs
+++ b/StoryCADTests/Services/Store/StoreActivationServiceTests.cs
@@ -31,9 +31,9 @@ public class StoreActivationServiceTests
         prefs.Model.StoreActivationJwtExpiry = DateTime.MinValue;
         prefs.Model.StoreUserGuid = "11111111-1111-1111-1111-111111111111";
 
-        // Defensive reset: guards against a leaked COLLAB_DEV_ENABLED from a prior test or the
+        // Defensive reset: guards against a leaked COLLAB_DEV_ACTIVATION from a prior test or the
         // outer shell environment leaking into tests that don't expect dev-platform routing.
-        Environment.SetEnvironmentVariable("COLLAB_DEV_ENABLED", null);
+        Environment.SetEnvironmentVariable("COLLAB_DEV_ACTIVATION", null);
     }
 
     private static StoreActivationService CreateService(FakeStoreService store, FakeActivationClient client) =>
@@ -310,7 +310,7 @@ public class StoreActivationServiceTests
     [TestMethod]
     public async Task StoreActivationService_DevEnabled_PostsDevPlatformWithGuid()
     {
-        Environment.SetEnvironmentVariable("COLLAB_DEV_ENABLED", "1");
+        Environment.SetEnvironmentVariable("COLLAB_DEV_ACTIVATION", "1");
         try
         {
             var store = new FakeStoreService { Proof = SampleProof };
@@ -329,15 +329,15 @@ public class StoreActivationServiceTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("COLLAB_DEV_ENABLED", null);
+            Environment.SetEnvironmentVariable("COLLAB_DEV_ACTIVATION", null);
         }
     }
 
     [TestMethod]
     public async Task StoreActivationService_DevDisabled_UsesStoreProof()
     {
-        // COLLAB_DEV_ENABLED left unset: the default, store-driven path is unchanged.
-        Environment.SetEnvironmentVariable("COLLAB_DEV_ENABLED", null);
+        // COLLAB_DEV_ACTIVATION left unset: the default, store-driven path is unchanged.
+        Environment.SetEnvironmentVariable("COLLAB_DEV_ACTIVATION", null);
         var store = new FakeStoreService { Proof = SampleProof };
         var client = new FakeActivationClient();
         var service = CreateService(store, client);

--- a/StoryCADTests/Services/Store/StoreKitPayloadsTests.cs
+++ b/StoryCADTests/Services/Store/StoreKitPayloadsTests.cs
@@ -123,6 +123,74 @@ public class StoreKitPayloadsTests
         Assert.AreEqual(EntitlementState.Expired, StoreKitPayloads.ParseEntitlements(payload)[0].State);
     }
 
+    // ----- Credit packs (issue #90 design section 10, step 10) -----
+
+    // transactionId and originalTransactionId deliberately differ so a test reading the wrong
+    // field fails loudly (design section 10 step 10 correction: a pack keys on transactionId, not
+    // originalTransactionId -- the two happen to coincide for most real consumables, which would
+    // mask this exact bug if the fixture used the same value for both).
+    private const string ConsumablePurchaseSuccessPayload =
+        """{"ok":true,"status":"success","transactionId":"3000000456","originalTransactionId":"3000000000","productId":"CollabCreditPack500","jws":"pack.header.sig"}""";
+
+    [TestMethod]
+    public void ParseConsumablePurchase_Success_ReturnsProofAndTransactionId()
+    {
+        var result = StoreKitPayloads.ParseConsumablePurchase(ConsumablePurchaseSuccessPayload,
+            "CollabCreditPack500", "11111111-1111-1111-1111-111111111111");
+
+        Assert.AreEqual(PurchaseStatus.Success, result.Status);
+        Assert.AreEqual("3000000456", result.TransactionId);
+        Assert.IsNotNull(result.Proof);
+        Assert.AreEqual("apple", result.Proof.Platform);
+        Assert.AreEqual("pack.header.sig", result.Proof.Payload);
+        Assert.AreEqual("CollabCreditPack500", result.Proof.ProductId);
+        Assert.AreEqual("11111111-1111-1111-1111-111111111111", result.Proof.UserGuid);
+    }
+
+    [TestMethod]
+    public void ParseConsumablePurchase_UserCancelled_ReturnsUserCancelledNoProof()
+    {
+        var result = StoreKitPayloads.ParseConsumablePurchase(PurchaseCancelledPayload, "CollabCreditPack500", "guid");
+
+        Assert.AreEqual(PurchaseStatus.UserCancelled, result.Status);
+        Assert.IsNull(result.Proof);
+        Assert.IsNull(result.TransactionId);
+    }
+
+    [TestMethod]
+    public void ParseConsumablePurchase_ErrorPayload_ReturnsFailedWithMessage()
+    {
+        var result = StoreKitPayloads.ParseConsumablePurchase(ErrorPayload, "CollabCreditPack500", "guid");
+
+        Assert.AreEqual(PurchaseStatus.Failed, result.Status);
+        Assert.AreEqual("Cannot connect to the App Store", result.Error);
+    }
+
+    [TestMethod]
+    public void ParseConsumablePurchase_SuccessMissingJws_ReturnsFailed()
+    {
+        // A malformed shim response (ok:true, status:success, but no jws) must not hand back a
+        // "success" the activation call would then have no proof to send.
+        const string payload = """{"ok":true,"status":"success","transactionId":"1"}""";
+
+        var result = StoreKitPayloads.ParseConsumablePurchase(payload, "CollabCreditPack500", "guid");
+
+        Assert.AreEqual(PurchaseStatus.Failed, result.Status);
+    }
+
+    [TestMethod]
+    public void ParseFinishTransactionOk_OkTrue_ReturnsTrue()
+    {
+        Assert.IsTrue(StoreKitPayloads.ParseFinishTransactionOk("""{"ok":true}"""));
+    }
+
+    [TestMethod]
+    public void ParseFinishTransactionOk_OkFalseOrMalformed_ReturnsFalse()
+    {
+        Assert.IsFalse(StoreKitPayloads.ParseFinishTransactionOk("""{"ok":false,"error":"not found"}"""));
+        Assert.IsFalse(StoreKitPayloads.ParseFinishTransactionOk(MalformedPayload));
+    }
+
     [TestMethod]
     public void SerializeProductIds_TwoIds_ProducesJsonArray()
     {

--- a/StoryCADTests/Services/Store/StoreTestDoubles.cs
+++ b/StoryCADTests/Services/Store/StoreTestDoubles.cs
@@ -26,6 +26,7 @@ internal sealed class FakeStoreService : IStoreService
     public string LastConsumablePurchaseUserGuid;
     public string LastFinishedTransactionId;
     public int FinishConsumableCallCount;
+    public int PurchaseConsumableCallCount;
 
     public bool IsSupported => true;
 
@@ -68,6 +69,7 @@ internal sealed class FakeStoreService : IStoreService
     public Task<ConsumablePurchaseResult> PurchaseConsumableAsync(string productId, string userGuid,
         CancellationToken ct = default)
     {
+        PurchaseConsumableCallCount++;
         LastConsumablePurchaseUserGuid = userGuid;
         return Task.FromResult(ConsumableResult);
     }

--- a/StoryCADTests/Services/Store/StoreTestDoubles.cs
+++ b/StoryCADTests/Services/Store/StoreTestDoubles.cs
@@ -20,9 +20,18 @@ internal sealed class FakeStoreService : IStoreService
     public bool RestoreCalled;
     public IReadOnlyList<StoreEntitlement> Entitlements = Array.Empty<StoreEntitlement>();
 
+    // issue #90 design section 10 "Credit packs" (step 10).
+    public ConsumablePurchaseResult ConsumableResult = new(PurchaseStatus.Success,
+        new PurchaseProof("apple", "pack-jws", "CollabCreditPack500", "user-guid"), "pack-transaction-1");
+    public string LastConsumablePurchaseUserGuid;
+    public string LastFinishedTransactionId;
+    public int FinishConsumableCallCount;
+
     public bool IsSupported => true;
 
     public IReadOnlyList<string> ProductIds { get; set; } = new[] { "org.storycad.collaborator.monthly" };
+
+    public IReadOnlyList<string> CreditPackProductIds { get; set; } = new[] { "CollabCreditPack500" };
 
     public event EventHandler<StoreEntitlement> EntitlementChanged;
 
@@ -56,6 +65,20 @@ internal sealed class FakeStoreService : IStoreService
         return Task.FromResult(Proof);
     }
 
+    public Task<ConsumablePurchaseResult> PurchaseConsumableAsync(string productId, string userGuid,
+        CancellationToken ct = default)
+    {
+        LastConsumablePurchaseUserGuid = userGuid;
+        return Task.FromResult(ConsumableResult);
+    }
+
+    public Task FinishConsumableAsync(string transactionId, CancellationToken ct = default)
+    {
+        FinishConsumableCallCount++;
+        LastFinishedTransactionId = transactionId;
+        return Task.CompletedTask;
+    }
+
     public void RaiseEntitlementChanged() =>
         EntitlementChanged?.Invoke(this, new StoreEntitlement(
             "org.storycad.collaborator.monthly", "t1", "o1", DateTime.UtcNow, null,
@@ -69,6 +92,7 @@ internal sealed class FakeActivationClient : IActivationClient
     public int ActivateCallCount;
     public string Ticket = "aad-service-ticket";
     public int TicketCallCount;
+    public string LastTicketPurpose;
 
     public Task<ActivationResponse> ActivateAsync(PurchaseProof proof, CancellationToken ct = default)
     {
@@ -78,9 +102,10 @@ internal sealed class FakeActivationClient : IActivationClient
             : Task.FromResult(Response);
     }
 
-    public Task<string> GetStoreTicketAsync(CancellationToken ct = default)
+    public Task<string> GetStoreTicketAsync(string purpose = "purchase", CancellationToken ct = default)
     {
         TicketCallCount++;
+        LastTicketPurpose = purpose;
         return Task.FromResult(Ticket);
     }
 }

--- a/StoryCADTests/Services/Store/StoreTestDoubles.cs
+++ b/StoryCADTests/Services/Store/StoreTestDoubles.cs
@@ -92,6 +92,7 @@ internal sealed class FakeActivationClient : IActivationClient
     public ActivationResponse Response = new(true, "jwt-token", DateTime.UtcNow.AddHours(12), null);
     public Exception ThrowOnActivate;
     public int ActivateCallCount;
+    public PurchaseProof LastProof;
     public string Ticket = "aad-service-ticket";
     public int TicketCallCount;
     public string LastTicketPurpose;
@@ -99,6 +100,7 @@ internal sealed class FakeActivationClient : IActivationClient
     public Task<ActivationResponse> ActivateAsync(PurchaseProof proof, CancellationToken ct = default)
     {
         ActivateCallCount++;
+        LastProof = proof;
         return ThrowOnActivate != null
             ? Task.FromException<ActivationResponse>(ThrowOnActivate)
             : Task.FromResult(Response);

--- a/StoryCADTests/Services/Store/WindowsStoreServiceTests.cs
+++ b/StoryCADTests/Services/Store/WindowsStoreServiceTests.cs
@@ -213,6 +213,71 @@ public class WindowsStoreServiceTests
         Assert.IsNotNull(raised);
     }
 
+    // ----- Credit packs (issue #90 design section 10, step 10) -----
+
+    private const string PackProductId = "9PCREDITPAK1";
+
+    [TestMethod]
+    public async Task PurchaseConsumableAsync_Succeeded_ReturnsSuccessWithCollectionsProof()
+    {
+        var adapter = new FakeStoreContextAdapter
+        {
+            PurchaseResult = new StorePurchaseResult(StorePurchaseOutcome.Succeeded),
+            CollectionsId = "collections-key-1"
+        };
+        var client = new FakeActivationClient { Ticket = "aad-collections-ticket" };
+        var service = CreateService(adapter, client);
+
+        var result = await service.PurchaseConsumableAsync(PackProductId, UserGuid);
+
+        Assert.AreEqual(PurchaseStatus.Success, result.Status);
+        Assert.IsNotNull(result.Proof);
+        Assert.AreEqual("microsoft", result.Proof.Platform);
+        Assert.AreEqual("collections-key-1", result.Proof.Payload);
+        Assert.AreEqual(PackProductId, result.Proof.ProductId);
+        Assert.AreEqual(UserGuid, result.Proof.UserGuid);
+        // The collections ticket is a *different* Microsoft Store ID key from the subscription
+        // purchase-audience one (design section 10 step 10 correction).
+        Assert.AreEqual("collections", client.LastTicketPurpose);
+        Assert.AreEqual("aad-collections-ticket", adapter.LastCollectionsServiceTicket);
+        Assert.AreEqual(UserGuid, adapter.LastCollectionsPublisherUserId);
+    }
+
+    [TestMethod]
+    public async Task PurchaseConsumableAsync_NoTicket_ReturnsFailed()
+    {
+        var adapter = new FakeStoreContextAdapter { PurchaseResult = new StorePurchaseResult(StorePurchaseOutcome.Succeeded) };
+        var client = new FakeActivationClient { Ticket = null };
+        var service = CreateService(adapter, client);
+
+        var result = await service.PurchaseConsumableAsync(PackProductId, UserGuid);
+
+        Assert.AreEqual(PurchaseStatus.Failed, result.Status);
+        Assert.IsNull(result.Proof);
+    }
+
+    [TestMethod]
+    public async Task PurchaseConsumableAsync_NotPurchased_ReturnsUserCancelled()
+    {
+        var adapter = new FakeStoreContextAdapter { PurchaseResult = new StorePurchaseResult(StorePurchaseOutcome.NotPurchased) };
+        var service = CreateService(adapter, new FakeActivationClient());
+
+        var result = await service.PurchaseConsumableAsync(PackProductId, UserGuid);
+
+        Assert.AreEqual(PurchaseStatus.UserCancelled, result.Status);
+    }
+
+    [TestMethod]
+    public async Task FinishConsumableAsync_OnWindows_IsNoOp()
+    {
+        // The Worker reports fulfillment itself via the Microsoft collection API (design section
+        // 10 step 10 correction); the Windows client has nothing to call.
+        var service = CreateService(new FakeStoreContextAdapter(), new FakeActivationClient());
+
+        await service.FinishConsumableAsync("some-transaction-id");
+        // No exception, no adapter call to assert on -- the point of this test is that it's a no-op.
+    }
+
     // ----- Fakes -----
 
     private sealed class FakeStoreContextAdapter : IStoreContextAdapter
@@ -221,9 +286,12 @@ public class WindowsStoreServiceTests
         public StorePurchaseResult PurchaseResult = new(StorePurchaseOutcome.Succeeded);
         public IReadOnlyList<StoreLicenseInfo> Licenses = Array.Empty<StoreLicenseInfo>();
         public string PurchaseId = "purchase-id-key";
+        public string CollectionsId = "collections-id-key";
         public string LastServiceTicket;
         public string LastPublisherUserId;
         public string LastPurchaseProductId;
+        public string LastCollectionsServiceTicket;
+        public string LastCollectionsPublisherUserId;
 
         public event Action LicensesChanged;
 
@@ -245,6 +313,14 @@ public class WindowsStoreServiceTests
             LastServiceTicket = serviceTicket;
             LastPublisherUserId = publisherUserId;
             return Task.FromResult(PurchaseId);
+        }
+
+        public Task<string> GetCustomerCollectionsIdAsync(string serviceTicket, string publisherUserId,
+            CancellationToken ct = default)
+        {
+            LastCollectionsServiceTicket = serviceTicket;
+            LastCollectionsPublisherUserId = publisherUserId;
+            return Task.FromResult(CollectionsId);
         }
 
         public void RaiseLicensesChanged() => LicensesChanged?.Invoke();

--- a/StoryCADTests/ViewModels/Store/BuyCreditsDialogViewModelTests.cs
+++ b/StoryCADTests/ViewModels/Store/BuyCreditsDialogViewModelTests.cs
@@ -147,6 +147,75 @@ public class BuyCreditsDialogViewModelTests
     }
 
     [TestMethod]
+    public async Task BuyAsync_RetryAfterActivationUnreachable_ReactivatesHeldProofWithoutRepurchase()
+    {
+        // 2026-07-16 review finding 3: BuyAsync always started with a fresh
+        // PurchaseConsumableAsync, so a retry after the Worker was unreachable purchased AGAIN --
+        // on Apple, a second Product.purchase() on a consumable double-charges or errors on the
+        // unfinished transaction. The money from the first purchase is already spent and the
+        // proof it produced is still good, so a retry must re-activate that held proof instead.
+        var proof = new PurchaseProof("apple", "pack-jws", PackId, "user-guid-1");
+        var store = new FakeStoreService
+        {
+            Products = new[] { Pack500 },
+            ConsumableResult = new ConsumablePurchaseResult(PurchaseStatus.Success, proof, "transaction-1")
+        };
+        var client = new FakeActivationClient { ThrowOnActivate = new Exception("network down") };
+        var vm = Create(store, client);
+        await vm.LoadAsync();
+
+        var firstAttempt = await vm.BuyAsync();
+        Assert.IsFalse(firstAttempt);
+        Assert.AreEqual(1, store.PurchaseConsumableCallCount);
+        Assert.AreEqual(1, client.ActivateCallCount);
+        Assert.AreEqual(0, store.FinishConsumableCallCount);
+
+        // The Worker becomes reachable again; the user clicks Buy a second time.
+        client.ThrowOnActivate = null;
+        client.Response = new ActivationResponse(true, "jwt-token", DateTime.UtcNow.AddHours(12), null);
+
+        var secondAttempt = await vm.BuyAsync();
+
+        Assert.IsTrue(secondAttempt);
+        Assert.AreEqual(1, store.PurchaseConsumableCallCount, "the retry must not purchase a second time");
+        Assert.AreEqual(2, client.ActivateCallCount);
+        Assert.AreEqual(1, store.FinishConsumableCallCount);
+        Assert.AreEqual("transaction-1", store.LastFinishedTransactionId);
+    }
+
+    [TestMethod]
+    public async Task BuyAsync_RetryAfterActivationRefused_ReactivatesHeldProof()
+    {
+        // Same shape as the unreachable-retry test above, for the other retryable reason: a
+        // refusal (the Worker's own 403/503) rather than a transport failure.
+        var proof = new PurchaseProof("apple", "pack-jws", PackId, "user-guid-1");
+        var store = new FakeStoreService
+        {
+            Products = new[] { Pack500 },
+            ConsumableResult = new ConsumablePurchaseResult(PurchaseStatus.Success, proof, "transaction-1")
+        };
+        var client = new FakeActivationClient { Response = new ActivationResponse(false, null, null, "invalid") };
+        var vm = Create(store, client);
+        await vm.LoadAsync();
+
+        var firstAttempt = await vm.BuyAsync();
+        Assert.IsFalse(firstAttempt);
+        Assert.AreEqual(1, store.PurchaseConsumableCallCount);
+        Assert.AreEqual(1, client.ActivateCallCount);
+        Assert.AreEqual(0, store.FinishConsumableCallCount);
+
+        client.Response = new ActivationResponse(true, "jwt-token", DateTime.UtcNow.AddHours(12), null);
+
+        var secondAttempt = await vm.BuyAsync();
+
+        Assert.IsTrue(secondAttempt);
+        Assert.AreEqual(1, store.PurchaseConsumableCallCount, "the retry must not purchase a second time");
+        Assert.AreEqual(2, client.ActivateCallCount);
+        Assert.AreEqual(1, store.FinishConsumableCallCount);
+        Assert.AreEqual("transaction-1", store.LastFinishedTransactionId);
+    }
+
+    [TestMethod]
     public async Task BuyAsync_PurchaseSucceededNoProof_ReturnsFalseWithoutActivating()
     {
         var store = new FakeStoreService

--- a/StoryCADTests/ViewModels/Store/BuyCreditsDialogViewModelTests.cs
+++ b/StoryCADTests/ViewModels/Store/BuyCreditsDialogViewModelTests.cs
@@ -1,0 +1,221 @@
+using System.Threading;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StoryCADLib.Services;
+using StoryCADLib.Services.Logging;
+using StoryCADLib.Services.Store;
+using StoryCADLib.ViewModels.Store;
+using StoryCADTests.Services.Store;
+
+#nullable disable
+
+namespace StoryCADTests.ViewModels.Store;
+
+/// <summary>
+///     Headless logic tests for <see cref="BuyCreditsDialogViewModel" /> (issue #90 design section
+///     10 "Credit packs", step 10) with a fake store and a fake activation client: pack loading,
+///     the buy path (purchase -> activate -> finish, in that order), and the refusal/error paths.
+///     The dialog XAML itself is not exercised here (no UI testing), mirroring
+///     SubscribeDialogViewModelTests.
+/// </summary>
+[TestClass]
+public class BuyCreditsDialogViewModelTests
+{
+    private const string PackId = "CollabCreditPack500";
+    private static readonly StoreProduct Pack500 = new(PackId, "500 Credits", "One-time credit pack", "$5.00", "", false);
+
+    private static BuyCreditsDialogViewModel Create(FakeStoreService store, FakeActivationClient client) =>
+        new(store, client, Ioc.Default.GetRequiredService<PreferenceService>(), Ioc.Default.GetRequiredService<ILogService>());
+
+    [TestMethod]
+    public async Task LoadAsync_WithPacks_PopulatesPacksAndSelectsFirst()
+    {
+        // FakeStoreService.GetProductsAsync (StoreTestDoubles.cs) returns Products regardless of
+        // which id list LoadAsync passes it, so setting Products is what drives this test.
+        var store = new FakeStoreService { Products = new[] { Pack500 } };
+        var vm = Create(store, new FakeActivationClient());
+
+        await vm.LoadAsync();
+
+        Assert.AreEqual(1, vm.Packs.Count);
+        Assert.AreEqual(Pack500, vm.SelectedPack);
+        Assert.IsTrue(vm.HasPacks);
+        Assert.IsFalse(vm.HasError);
+    }
+
+    [TestMethod]
+    public async Task LoadAsync_StoreThrows_SetsError()
+    {
+        var vm = Create(new FakeStoreService { ThrowOnGetProducts = true }, new FakeActivationClient());
+
+        await vm.LoadAsync();
+
+        Assert.IsTrue(vm.HasError);
+        Assert.IsFalse(string.IsNullOrEmpty(vm.StatusMessage));
+        Assert.IsFalse(vm.HasPacks);
+    }
+
+    [TestMethod]
+    public async Task LoadAsync_PacksAlreadyLoaded_SkipsStoreQuery()
+    {
+        var store = new FakeStoreService { Products = new[] { Pack500 } };
+        var vm = Create(store, new FakeActivationClient());
+
+        await vm.LoadAsync();
+        await vm.LoadAsync();
+
+        Assert.AreEqual(1, store.GetProductsCallCount, "packs are static per session; reopen must not refetch");
+        Assert.AreEqual(1, vm.Packs.Count);
+    }
+
+    [TestMethod]
+    public async Task BuyAsync_NoSelectedPack_ReturnsFalse()
+    {
+        var vm = Create(new FakeStoreService(), new FakeActivationClient());
+
+        var ok = await vm.BuyAsync();
+
+        Assert.IsFalse(ok);
+    }
+
+    [TestMethod]
+    public async Task BuyAsync_SuccessAndActivated_ReturnsTrueAndFinishes()
+    {
+        var proof = new PurchaseProof("apple", "pack-jws", PackId, "user-guid-1");
+        var store = new FakeStoreService
+        {
+            Products = new[] { Pack500 },
+            ConsumableResult = new ConsumablePurchaseResult(PurchaseStatus.Success, proof, "transaction-1")
+        };
+        var client = new FakeActivationClient { Response = new ActivationResponse(true, "jwt", DateTime.UtcNow.AddHours(12), null) };
+        var vm = Create(store, client);
+        await vm.LoadAsync();
+
+        var ok = await vm.BuyAsync();
+
+        Assert.IsTrue(ok);
+        Assert.IsFalse(vm.HasError);
+        Assert.IsFalse(vm.IsBusy);
+        Assert.AreEqual(1, client.ActivateCallCount);
+        // The Worker's 200 must be seen (ActivateAsync called) before the transaction is finished
+        // (design section 10: "the client finishes the transaction only after the Worker's 200").
+        Assert.AreEqual(1, store.FinishConsumableCallCount);
+        Assert.AreEqual("transaction-1", store.LastFinishedTransactionId);
+    }
+
+    [TestMethod]
+    public async Task BuyAsync_ActivationRefused_ReturnsFalseAndDoesNotFinish()
+    {
+        var proof = new PurchaseProof("apple", "pack-jws", PackId, "user-guid-1");
+        var store = new FakeStoreService
+        {
+            Products = new[] { Pack500 },
+            ConsumableResult = new ConsumablePurchaseResult(PurchaseStatus.Success, proof, "transaction-1")
+        };
+        var client = new FakeActivationClient { Response = new ActivationResponse(false, null, null, "invalid") };
+        var vm = Create(store, client);
+        await vm.LoadAsync();
+
+        var ok = await vm.BuyAsync();
+
+        Assert.IsFalse(ok);
+        Assert.IsTrue(vm.HasError);
+        // A refused activation must not finish the transaction -- the Worker never credited it, so
+        // there is nothing to consume yet, and finishing early is exactly what design section 10
+        // forbids (a StoreKit-finished transaction cannot be retried).
+        Assert.AreEqual(0, store.FinishConsumableCallCount);
+    }
+
+    [TestMethod]
+    public async Task BuyAsync_ActivationUnreachable_ReturnsFalseAndDoesNotFinish()
+    {
+        var proof = new PurchaseProof("apple", "pack-jws", PackId, "user-guid-1");
+        var store = new FakeStoreService
+        {
+            Products = new[] { Pack500 },
+            ConsumableResult = new ConsumablePurchaseResult(PurchaseStatus.Success, proof, "transaction-1")
+        };
+        var client = new FakeActivationClient { ThrowOnActivate = new Exception("network down") };
+        var vm = Create(store, client);
+        await vm.LoadAsync();
+
+        var ok = await vm.BuyAsync();
+
+        Assert.IsFalse(ok);
+        Assert.IsTrue(vm.HasError);
+        Assert.AreEqual(0, store.FinishConsumableCallCount);
+    }
+
+    [TestMethod]
+    public async Task BuyAsync_PurchaseSucceededNoProof_ReturnsFalseWithoutActivating()
+    {
+        var store = new FakeStoreService
+        {
+            Products = new[] { Pack500 },
+            ConsumableResult = new ConsumablePurchaseResult(PurchaseStatus.Success, null, null)
+        };
+        var client = new FakeActivationClient();
+        var vm = Create(store, client);
+        await vm.LoadAsync();
+
+        var ok = await vm.BuyAsync();
+
+        Assert.IsFalse(ok);
+        Assert.IsTrue(vm.HasError);
+        Assert.AreEqual(0, client.ActivateCallCount, "no proof means nothing to send the Worker");
+    }
+
+    [TestMethod]
+    public async Task BuyAsync_Pending_ShowsInfoAndReturnsFalse()
+    {
+        var store = new FakeStoreService
+        {
+            Products = new[] { Pack500 },
+            ConsumableResult = new ConsumablePurchaseResult(PurchaseStatus.Pending)
+        };
+        var vm = Create(store, new FakeActivationClient());
+        await vm.LoadAsync();
+
+        var ok = await vm.BuyAsync();
+
+        Assert.IsFalse(ok);
+        Assert.IsFalse(vm.HasError, "pending approval is not an error");
+        Assert.IsTrue(vm.HasStatus);
+        Assert.AreEqual(InfoBarSeverity.Informational, vm.StatusSeverity);
+    }
+
+    [TestMethod]
+    public async Task BuyAsync_UserCancelled_NoErrorReturnsFalse()
+    {
+        var store = new FakeStoreService
+        {
+            Products = new[] { Pack500 },
+            ConsumableResult = new ConsumablePurchaseResult(PurchaseStatus.UserCancelled)
+        };
+        var vm = Create(store, new FakeActivationClient());
+        await vm.LoadAsync();
+
+        var ok = await vm.BuyAsync();
+
+        Assert.IsFalse(ok);
+        Assert.IsFalse(vm.HasError, "cancelling is not an error");
+    }
+
+    [TestMethod]
+    public async Task BuyAsync_Failed_SetsErrorReturnsFalse()
+    {
+        var store = new FakeStoreService
+        {
+            Products = new[] { Pack500 },
+            ConsumableResult = new ConsumablePurchaseResult(PurchaseStatus.Failed, Error: "declined")
+        };
+        var vm = Create(store, new FakeActivationClient());
+        await vm.LoadAsync();
+
+        var ok = await vm.BuyAsync();
+
+        Assert.IsFalse(ok);
+        Assert.IsTrue(vm.HasError);
+        Assert.AreEqual("declined", vm.StatusMessage);
+    }
+}

--- a/StoryCADTests/ViewModels/Store/SubscribeDialogViewModelTests.cs
+++ b/StoryCADTests/ViewModels/Store/SubscribeDialogViewModelTests.cs
@@ -240,5 +240,7 @@ public class SubscribeDialogViewModelTests
             State = StateAfterPurchase;
             return Task.CompletedTask;
         }
+
+        public Task ReactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 }

--- a/src/macos/StoreKitShim/StoreKitShim.swift
+++ b/src/macos/StoreKitShim/StoreKitShim.swift
@@ -16,6 +16,27 @@ private var transactionCallback: CompletionCallback?
 private var updatesTask: Task<Void, Never>?
 private let stateLock = NSLock()
 
+// issue #90 design section 10 "Credit packs" (step 10): consumable transactions purchase()
+// deliberately leaves unfinished (see storycad_iap_purchase), keyed by transaction id string so
+// storycad_iap_finish_transaction can find and finish the exact one the Worker just confirmed.
+// In-memory only: an app relaunch before finishing loses the entry (see the Transaction.updates
+// handling below, which -- for a consumable -- leaves a replayed-but-still-unfinished transaction
+// unfinished rather than guessing).
+private var pendingConsumableTransactions: [String: Transaction] = [:]
+private let pendingLock = NSLock()
+
+private func retainPendingConsumable(_ t: Transaction) {
+    pendingLock.lock()
+    pendingConsumableTransactions[String(t.id)] = t
+    pendingLock.unlock()
+}
+
+private func takePendingConsumable(_ transactionId: String) -> Transaction? {
+    pendingLock.lock()
+    defer { pendingLock.unlock() }
+    return pendingConsumableTransactions.removeValue(forKey: transactionId)
+}
+
 private let isoFormatter: ISO8601DateFormatter = {
     let f = ISO8601DateFormatter()
     f.formatOptions = [.withInternetDateTime]
@@ -147,6 +168,17 @@ public func storycad_iap_set_transaction_callback(_ cb: @escaping CompletionCall
                 let dict = await entitlementDict(t, jws: update.jwsRepresentation)
                 let json = jsonString(["ok": true, "entitlements": [dict]])
                 if let callback = currentTransactionCallback() { deliver(callback, -1, json) }
+                // issue #90 design section 10 step 10 correction: a replayed consumable (e.g. one
+                // left unfinished by a crash between purchase and Worker confirmation) must not
+                // auto-finish here either -- finishing before crediting is exactly what this
+                // design forbids. It stays unfinished (StoreKit keeps replaying it via
+                // Transaction.updates on future launches) rather than being silently finished
+                // with nothing credited. A full replay-driven re-credit flow is out of scope for
+                // this step; the entitlementDict/-1 channel above is also subscription-shaped and
+                // is not extended to consumables here.
+                if t.productType == .consumable {
+                    continue
+                }
                 await t.finish()
             }
         }
@@ -218,7 +250,19 @@ public func storycad_iap_purchase(_ requestId: Int64, _ productId: UnsafePointer
                         "productId": t.productID,
                         "jws": verification.jwsRepresentation,
                     ]))
-                    await t.finish()
+                    // issue #90 design section 10 "Credit packs" (step 10): a consumable's
+                    // transaction is not finished here. Finishing early risks losing the ability
+                    // to retry crediting if the Worker's /activate call fails, since StoreKit will
+                    // not replay a finished transaction; the client must finish only after the
+                    // Worker's 200 (storycad_iap_finish_transaction below). Every other product
+                    // type (subscriptions, non-consumables) keeps the existing immediate-finish
+                    // behavior unchanged -- it is what already makes Transaction.updates below
+                    // stop replaying them.
+                    if product.type == .consumable {
+                        retainPendingConsumable(t)
+                    } else {
+                        await t.finish()
+                    }
                 case .unverified(_, let verificationError):
                     deliver(cb, requestId, failureJson("transaction failed StoreKit verification", code: String(describing: verificationError)))
                 }
@@ -232,6 +276,23 @@ public func storycad_iap_purchase(_ requestId: Int64, _ productId: UnsafePointer
         } catch {
             deliver(cb, requestId, failureJson(error.localizedDescription, code: String(describing: error)))
         }
+    }
+}
+
+// issue #90 design section 10 "Credit packs" (step 10): finishes a consumable transaction
+// storycad_iap_purchase deliberately left open, once the caller (StoryCADLib's
+// FinishConsumableAsync) has confirmed the Worker credited it. A transaction not found -- already
+// finished, unknown, or lost to a relaunch before this was called -- is not an error: the tracking
+// id can be resubmitted indefinitely and a "nothing to finish" outcome is harmless, so this
+// delivers {"ok":true} either way rather than making the caller handle a distinct failure case.
+@_cdecl("storycad_iap_finish_transaction")
+public func storycad_iap_finish_transaction(_ requestId: Int64, _ transactionId: UnsafePointer<CChar>, _ cb: @escaping CompletionCallback) {
+    let id = String(cString: transactionId)
+    Task {
+        if let t = takePendingConsumable(id) {
+            await t.finish()
+        }
+        deliver(cb, requestId, jsonString(["ok": true]))
     }
 }
 


### PR DESCRIPTION
## What changed

StoryCAD client half of Collaborator Worker billing and store activation (paired with Collaborator branch `issue-90-worker-billing` / issue storybuilder-org/Collaborator#90), plus the #94 client resilience fix.

- Client GUID provisioning and store activation path (dev allowlist routing via `COLLAB_DEV_ACTIVATION`)
- Credit-pack purchase flow and out-of-credits messaging
- Credential cleanup: purchase gate is a real activation, not a client bypass; 401 refresh-and-retry on workflows
- `KernelFactory` dev-activation JWT override for PromptTestRunner / tooling hosts
- Rename `COLLAB_DEV_ENABLED` → `COLLAB_DEV_ACTIVATION` (routing hint only)
- SSE truncation detection (`data: [DONE]`), one retry on a fresh connection, fail-loud on second truncation (Collaborator#94)

## Why

Implements the StoryCAD side of Collaborator#90 (purchase-issued JWT activation, balance/credits UX, GUID). Collaborator#94: silent incomplete workflow answers when streams die mid-flight; client must not treat truncated SSE as success.

## How to test

**Automated (already green on this branch, 2026-07-17):** StoryCADTests 1248 / 1234 pass / 14 skip. Collaborator-side suites and 22 live integration tests run from the Collaborator repo against the dev Worker.

**Manual (lane A, before merge — Terry):** `StoryCADTests/ManualTests/Collaborator_Test_Plan.md` TC-110 through TC-120 with:
- `COLLAB_DEV_ACTIVATION=1`
- approved allowlist GUID
- `COLLAB_PROXY_URL` pointing at the dev Worker

Paid-path store purchase (TC-300) is lane B and is not required for this PR merge.

## Pairing

- Collaborator Worker/docs/tests: branch `issue-90-worker-billing` (must land with or before production use of this client).
- Issues: storybuilder-org/Collaborator#90, storybuilder-org/Collaborator#94 (closes when #90 PRs merge per kickoff ruling).

## Notes

- Draft until CI is green and TC-110–120 is recorded on Collaborator#90.
- Milestone: Release 4.3 is capability + free beta, not Collaborator for sale.
- Do not Submit Collaborator for sale (lane C) from this PR.

Related: storybuilder-org/Collaborator#90, storybuilder-org/Collaborator#94