### PR TITLE
fix: chat sidebar picks up refreshed activation JWT per call

### DIFF
--- a/CollaboratorLib/Models/ActivationJwtHandler.cs
+++ b/CollaboratorLib/Models/ActivationJwtHandler.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace StoryCollaborator.Models;
+
+/// <summary>
+/// HTTP pipeline handler for Semantic Kernel chat: stamps the current activation JWT on each
+/// request, and on 401 reactivates once and retries once (Collaborator #95). Matches the
+/// workflow path's per-call credential + single retry policy without rebuilding the kernel.
+/// </summary>
+internal sealed class ActivationJwtHandler : DelegatingHandler
+{
+    private readonly Func<string?> _resolveCredential;
+    private readonly Func<Task> _reactivate;
+
+    public ActivationJwtHandler(Func<string?> resolveCredential, Func<Task> reactivate)
+    {
+        _resolveCredential = resolveCredential ?? throw new ArgumentNullException(nameof(resolveCredential));
+        _reactivate = reactivate ?? throw new ArgumentNullException(nameof(reactivate));
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        // Buffer body once so a retry can resend (HttpRequestMessage content is single-use).
+        byte[]? body = null;
+        MediaTypeHeaderValue? contentType = null;
+        if (request.Content is not null)
+        {
+            contentType = request.Content.Headers.ContentType;
+            body = await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            request.Content = CreateContent(body, contentType);
+        }
+
+        var response = await SendAttemptAsync(request, cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode != HttpStatusCode.Unauthorized)
+            return response;
+
+        response.Dispose();
+        await _reactivate().ConfigureAwait(false);
+
+        using var retry = CloneRequest(request, body, contentType);
+        return await SendAttemptAsync(retry, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<HttpResponseMessage> SendAttemptAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var credential = _resolveCredential();
+        if (string.IsNullOrWhiteSpace(credential))
+            return new HttpResponseMessage(HttpStatusCode.Unauthorized);
+
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", credential);
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static HttpRequestMessage CloneRequest(
+        HttpRequestMessage original, byte[]? body, MediaTypeHeaderValue? contentType)
+    {
+        var clone = new HttpRequestMessage(original.Method, original.RequestUri)
+        {
+            Version = original.Version
+        };
+
+        foreach (var header in original.Headers)
+            clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+
+        if (body is not null)
+            clone.Content = CreateContent(body, contentType);
+
+        return clone;
+    }
+
+    private static ByteArrayContent CreateContent(byte[] body, MediaTypeHeaderValue? contentType)
+    {
+        var content = new ByteArrayContent(body);
+        if (contentType is not null)
+            content.Headers.ContentType = contentType;
+        return content;
+    }
+}

--- a/CollaboratorLib/Models/KernelFactory.cs
+++ b/CollaboratorLib/Models/KernelFactory.cs
@@ -96,8 +96,36 @@ namespace StoryCollaborator.Models
         }
 
         /// <summary>
+        /// Production chat HTTP handler: resolves the activation JWT on every request through
+        /// <see cref="ResolveWorkflowCredential"/> (so <see cref="DevActivationJwtProvider"/> stays
+        /// first) and reactivates once on 401 (Collaborator #95). Caller sets
+        /// <see cref="DelegatingHandler.InnerHandler"/> (tests: scripted handler; Build: HttpClientHandler).
+        /// </summary>
+        internal static ActivationJwtHandler CreateChatHandler() =>
+            new(() => ResolveWorkflowCredential(), ReactivateAsync);
+
+        /// <summary>
+        /// Re-activation trigger for the 401-refresh-once-and-retry policy (workflow and chat).
+        /// No-op if IoC has no activation service (PromptTestRunner, unit tests).
+        /// </summary>
+        internal static Task ReactivateAsync()
+        {
+            try
+            {
+                var service = Ioc.Default.GetService<IStoreActivationService>();
+                return service?.ReactivateAsync() ?? Task.CompletedTask;
+            }
+            catch (InvalidOperationException)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>
         /// Builds and returns a configured Kernel. Always logs the active path and endpoint
         /// host to both the supplied loggerFactory and Debug output (D6 always-on requirement).
+        /// Chat traffic uses <see cref="ActivationJwtHandler"/> so a process-lifetime kernel
+        /// still picks up a refreshed JWT (Collaborator #95).
         /// </summary>
         public static Kernel Build(ILoggerFactory? loggerFactory = null)
         {
@@ -113,7 +141,18 @@ namespace StoryCollaborator.Models
             if (loggerFactory is not null)
                 builder.Services.AddSingleton(loggerFactory);
 
-            builder.AddOpenAIChatCompletion(config.ModelId, new Uri(config.Endpoint), config.Credential);
+            var handler = CreateChatHandler();
+            handler.InnerHandler = new HttpClientHandler();
+            var httpClient = new HttpClient(handler);
+
+            // SK still takes an apiKey at construction; the handler overwrites Authorization per request.
+            builder.AddOpenAIChatCompletion(
+                config.ModelId,
+                new Uri(config.Endpoint),
+                config.Credential,
+                orgId: null,
+                serviceId: null,
+                httpClient: httpClient);
 
             return builder.Build();
         }

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -794,7 +794,7 @@ namespace StoryCollaborator
         private async Task<(string Content, string? TemplateHash, ProxyCostInfo? Cost, bool Complete)> PostToProxyOnceAsync(string proxyBaseUrl, string payload)
         {
             var response = await SendWithReactivationRetryAsync(
-                () => SendWorkflowRequestAsync(proxyBaseUrl, payload), ReactivateAsync);
+                () => SendWorkflowRequestAsync(proxyBaseUrl, payload), KernelFactory.ReactivateAsync);
 
             if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
             {
@@ -837,29 +837,14 @@ namespace StoryCollaborator
             return await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
         }
 
-        // Re-activation trigger for the 401-refresh-once-and-retry policy (issue #90 step 8 item
-        // 7). No-op if IoC has no activation service configured (PromptTestRunner, tests) --
-        // matches KernelFactory.GetActivationJwt's InvalidOperationException guard for the same host.
-        private static Task ReactivateAsync()
-        {
-            try
-            {
-                var service = Ioc.Default.GetService<StoryCADLib.Services.Store.IStoreActivationService>();
-                return service?.ReactivateAsync() ?? Task.CompletedTask;
-            }
-            catch (InvalidOperationException)
-            {
-                return Task.CompletedTask;
-            }
-        }
-
         /// <summary>
         /// 401-refresh-once-and-retry (issue #90 step 8 item 7 / design section 11's expired-token
         /// row): a workflow call that comes back 401 refreshes the activation once through
         /// re-activation and retries with the refreshed credential before failing. Exactly one
         /// retry -- a second 401 is returned as-is so the caller's handling surfaces it rather than
-        /// looping. internal static and testable without a live HTTP transport or activation flow:
-        /// sendRequest and reactivate are injected, matching CreateWorkflowRequest/
+        /// looping. Reactivation is <see cref="KernelFactory.ReactivateAsync"/> (shared with chat,
+        /// Collaborator #95). internal static and testable without a live HTTP transport: sendRequest
+        /// and reactivate are injected, matching CreateWorkflowRequest/
         /// EnsureNotOutOfCredits's existing testable-without-network pattern in this class.
         /// </summary>
         internal static async Task<HttpResponseMessage> SendWithReactivationRetryAsync(

--- a/StoryCADTests/Collaborator/ActivationJwtHandlerTests.cs
+++ b/StoryCADTests/Collaborator/ActivationJwtHandlerTests.cs
@@ -1,0 +1,155 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StoryCollaborator.Models;
+
+#nullable disable
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>
+/// Collaborator #95: chat HTTP pipeline stamps the current activation JWT per request and
+/// heals once on 401. Offline tests with a scripted inner handler and injected delegates
+/// (same pattern as CollaboratorTests/WorkflowRunner401Tests; no Moq).
+/// </summary>
+[TestClass]
+public class ActivationJwtHandlerTests
+{
+    [TestMethod]
+    public async Task SendAsync_UsesLatestCredentialOnEveryRequest()
+    {
+        var tokens = new Queue<string>(new[] { "A", "B" });
+        var inner = new ScriptedHandler(HttpStatusCode.OK, HttpStatusCode.OK);
+        using var handler = new ActivationJwtHandler(() => tokens.Dequeue(), () => Task.CompletedTask)
+        {
+            InnerHandler = inner
+        };
+        using var client = new HttpClient(handler);
+
+        using var r1 = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://example.test/1"));
+        using var r2 = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://example.test/2"));
+
+        Assert.AreEqual(HttpStatusCode.OK, r1.StatusCode);
+        Assert.AreEqual(HttpStatusCode.OK, r2.StatusCode);
+        Assert.AreEqual(2, inner.Requests.Count);
+        Assert.AreEqual("Bearer A", inner.Requests[0].Authorization);
+        Assert.AreEqual("Bearer B", inner.Requests[1].Authorization);
+    }
+
+    [TestMethod]
+    public async Task SendAsync_On401_ReactivatesOnceAndRetries()
+    {
+        var credential = "stale";
+        var reactivateCount = 0;
+        var body = "{\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}";
+        var inner = new ScriptedHandler(HttpStatusCode.Unauthorized, HttpStatusCode.OK);
+        using var handler = new ActivationJwtHandler(
+            () => credential,
+            () =>
+            {
+                reactivateCount++;
+                credential = "fresh";
+                return Task.CompletedTask;
+            })
+        {
+            InnerHandler = inner
+        };
+        using var client = new HttpClient(handler);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test/v1/chat/completions")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+        using var response = await client.SendAsync(request);
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.AreEqual(1, reactivateCount, "reactivation must run once before the retry");
+        Assert.AreEqual(2, inner.Requests.Count, "exactly one retry: two sends total");
+        Assert.AreEqual("Bearer stale", inner.Requests[0].Authorization);
+        Assert.AreEqual("Bearer fresh", inner.Requests[1].Authorization);
+        Assert.AreEqual(HttpMethod.Post, inner.Requests[0].Method);
+        Assert.AreEqual(HttpMethod.Post, inner.Requests[1].Method);
+        Assert.AreEqual(inner.Requests[0].Uri, inner.Requests[1].Uri);
+        Assert.AreEqual(body, inner.Requests[0].Body);
+        Assert.AreEqual(body, inner.Requests[1].Body,
+            "retry must resend the same JSON body");
+    }
+
+    [TestMethod]
+    public async Task SendAsync_Second401_DoesNotReactivateAgain()
+    {
+        var reactivateCount = 0;
+        var inner = new ScriptedHandler(HttpStatusCode.Unauthorized, HttpStatusCode.Unauthorized);
+        using var handler = new ActivationJwtHandler(
+            () => "token",
+            () =>
+            {
+                reactivateCount++;
+                return Task.CompletedTask;
+            })
+        {
+            InnerHandler = inner
+        };
+        using var client = new HttpClient(handler);
+
+        using var response = await client.SendAsync(
+            new HttpRequestMessage(HttpMethod.Get, "https://example.test/chat"));
+
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.AreEqual(1, reactivateCount, "reactivation must happen once, never loop");
+        Assert.AreEqual(2, inner.Requests.Count, "exactly one retry: two sends total, never more");
+    }
+
+    [TestMethod]
+    public async Task SendAsync_NoCredential_Returns401WithoutNetwork()
+    {
+        var inner = new ScriptedHandler(HttpStatusCode.OK);
+        using var handler = new ActivationJwtHandler(() => null, () => Task.CompletedTask)
+        {
+            InnerHandler = inner
+        };
+        using var client = new HttpClient(handler);
+
+        using var response = await client.SendAsync(
+            new HttpRequestMessage(HttpMethod.Get, "https://example.test/chat"));
+
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.AreEqual(0, inner.Requests.Count, "must not call the network without a credential");
+    }
+
+    /// <summary>
+    /// Records every request that reaches the transport; returns scripted status codes in order.
+    /// </summary>
+    private sealed class ScriptedHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpStatusCode> _statuses;
+
+        public List<RecordedRequest> Requests { get; } = new();
+
+        public ScriptedHandler(params HttpStatusCode[] statuses)
+        {
+            _statuses = new Queue<HttpStatusCode>(statuses);
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string body = null;
+            if (request.Content is not null)
+                body = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            Requests.Add(new RecordedRequest(
+                request.Method,
+                request.RequestUri?.ToString(),
+                request.Headers.Authorization?.ToString(),
+                body));
+
+            var status = _statuses.Count > 0 ? _statuses.Dequeue() : HttpStatusCode.OK;
+            return new HttpResponseMessage(status);
+        }
+    }
+
+    private sealed record RecordedRequest(
+        HttpMethod Method, string Uri, string Authorization, string Body);
+}

--- a/StoryCADTests/Collaborator/KernelFactoryTests.cs
+++ b/StoryCADTests/Collaborator/KernelFactoryTests.cs
@@ -89,4 +89,49 @@ public class KernelFactoryTests
         Assert.ThrowsExactly<InvalidOperationException>(
             () => KernelFactory.ResolveConfig(Env("OPENAI_API_KEY", "sk-key"), () => null));
     }
+
+    // ── CreateChatHandler (Collaborator #95) ─────────────────────────────────
+
+    [TestMethod]
+    public async Task CreateChatHandler_UsesDevActivationJwtProvider()
+    {
+        var previous = KernelFactory.DevActivationJwtProvider;
+        try
+        {
+            KernelFactory.DevActivationJwtProvider = () => "dev-jwt";
+
+            var inner = new RecordingHandler(System.Net.HttpStatusCode.OK);
+            using var handler = KernelFactory.CreateChatHandler();
+            handler.InnerHandler = inner;
+            using var client = new System.Net.Http.HttpClient(handler);
+
+            using var response = await client.SendAsync(
+                new System.Net.Http.HttpRequestMessage(
+                    System.Net.Http.HttpMethod.Get, "https://example.test/chat"));
+
+            Assert.AreEqual(System.Net.HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual(1, inner.AuthorizationHeaders.Count);
+            Assert.AreEqual("Bearer dev-jwt", inner.AuthorizationHeaders[0],
+                "CreateChatHandler must resolve through GetActivationJwt / DevActivationJwtProvider");
+        }
+        finally
+        {
+            KernelFactory.DevActivationJwtProvider = previous;
+        }
+    }
+
+    private sealed class RecordingHandler : System.Net.Http.HttpMessageHandler
+    {
+        private readonly System.Net.HttpStatusCode _status;
+        public List<string> AuthorizationHeaders { get; } = new();
+
+        public RecordingHandler(System.Net.HttpStatusCode status) => _status = status;
+
+        protected override Task<System.Net.Http.HttpResponseMessage> SendAsync(
+            System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
+        {
+            AuthorizationHeaders.Add(request.Headers.Authorization?.ToString());
+            return Task.FromResult(new System.Net.Http.HttpResponseMessage(_status));
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Chat sidebar was freezing the Worker activation JWT into Semantic Kernel at kernel build time. After ~12 hours, every chat message got 401 until restart while workflows still worked.

- Add `ActivationJwtHandler`: stamp current JWT on each chat HTTP request; on 401 reactivate once and retry once
- `KernelFactory.Build` wires the handler into SK via `HttpClient`
- Hoist `ReactivateAsync` to `KernelFactory`; `WorkflowRunner` uses the shared entry point
- Unit tests: 4 handler + 1 `DevActivationJwtProvider` wiring (offline)

Fixes storybuilder-org/Collaborator#95

## Design

Collaborator `devdocs/issue_95_design_v2.md`

## Test plan

- [x] `StoryCADTests.Collaborator` via vstest: 98 passed, 10 skipped (includes new tests)
- [x] CI green
- [x] Manual: open Collaborator chat sidebar, send one message (SYS-111)
- [x] After merge: Collaborator PR live heal test with `COLLAB_DEV_GUID` + `COLLAB_RUN_INTEGRATION_TESTS=1`

## Notes

Merge this before Collaborator `issue-95-chat-live-tests` (project-reference to CollaboratorLib).