### PR TITLE
feat(#106): full gathered elements and declared collections

### DIFF
--- a/CollaboratorLib/Models/CollectionInput.cs
+++ b/CollaboratorLib/Models/CollectionInput.cs
@@ -1,0 +1,17 @@
+using StoryCADLib.Models;
+
+namespace StoryCollaborator.Models;
+
+/// <summary>
+/// Declared request for many elements of one kind (issue #106).
+/// Not inferred from output WriteVia modes.
+/// </summary>
+public sealed class CollectionInput
+{
+    /// <summary>Key on the request / placeholder name (e.g. CharacterChoices).</summary>
+    public required string RequestName { get; init; }
+
+    public StoryItemType ElementType { get; init; }
+
+    public ElementProjection Projection { get; init; }
+}

--- a/CollaboratorLib/Models/ElementProjection.cs
+++ b/CollaboratorLib/Models/ElementProjection.cs
@@ -1,0 +1,16 @@
+namespace StoryCollaborator.Models;
+
+/// <summary>
+/// How much of each element is sent for a declared collection input (issue #106).
+/// </summary>
+public enum ElementProjection
+{
+    /// <summary>GUID + Name only (today's CharacterChoices shape).</summary>
+    IdAndName = 0,
+
+    /// <summary>GUID, Name, ElementDescription, Type only.</summary>
+    BaseStoryElement = 1,
+
+    /// <summary>Full runtime model (same as gathered elements).</summary>
+    FullModel = 2
+}

--- a/CollaboratorLib/Models/WorkflowIO.cs
+++ b/CollaboratorLib/Models/WorkflowIO.cs
@@ -28,5 +28,11 @@ namespace StoryCollaborator.Models
         /// EnrichWithExamples reads this instead of scanning the template text.
         /// </summary>
         public List<string> ExampleLists { get; set; } = new();
+
+        /// <summary>
+        /// Declared collection inputs (issue #106). Runner builds each list from GetElementsByType
+        /// at the declared projection; does not invent lists from WriteVia.
+        /// </summary>
+        public List<CollectionInput> CollectionInputs { get; set; } = new();
     }
 }

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -4,12 +4,14 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using CollaboratorLib.Context;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.SemanticKernel;
+using StoryCADLib.DAL;
 using StoryCADLib.Models;
 using StoryCADLib.Services.API;
 using StoryCADLib.Services.Collaborator.Contracts;
@@ -20,6 +22,15 @@ using StoryCollaborator.Workflows;
 namespace StoryCollaborator
 {
     public sealed record WorkflowRunOutcome(WorkflowResult Result, int AppliedCount);
+
+    /// <summary>
+    /// Client request body for POST /v1/workflow after issue #106.
+    /// </summary>
+    internal sealed class WorkflowProxyBody
+    {
+        public Dictionary<string, string> Args { get; init; } = new();
+        public Dictionary<string, JsonObject> Elements { get; init; } = new();
+    }
 
     internal class WorkflowRunner
     {
@@ -111,20 +122,20 @@ namespace StoryCollaborator
             {
                 result.StatusMessages.Add($"Starting workflow: {workflowModel.Title}");
 
-                var kernelArgs = BuildKernelArguments(gatheredElements);
-                result.StatusMessages.Add($"Built arguments from {gatheredElements.Count} elements");
+                var body = BuildWorkflowRequestBody(gatheredElements);
+                result.StatusMessages.Add($"Built request body from {gatheredElements.Count} elements");
 
-                EnrichWithStoryContext(kernelArgs, gatheredElements, workflowIO);
-                ApplySettings(kernelArgs);
+                EnrichWithStoryContext(body.Args, gatheredElements, workflowIO);
+                ApplySettings(body.Args);
 
                 if (workflowIO.ExampleLists.Count > 0)
-                    EnrichWithExamples(kernelArgs);
+                    EnrichWithExamples(body.Args);
 
                 // Issue #90 step 8 item 5: the direct-to-OpenAI fallback retired along with
                 // OPENAI_API_KEY on the client. A proxy failure now propagates to the outer
                 // catch clauses below rather than retrying against OpenAI directly.
                 result.AssembledPrompt = null;
-                var (proxyContent, proxyHash, proxyCost, proxyComplete) = await PostToProxyAsync(kernelArgs);
+                var (proxyContent, proxyHash, proxyCost, proxyComplete) = await PostToProxyAsync(body);
                 result.RemoteTemplateHash = proxyHash;
                 result.Cost = proxyCost;
 
@@ -181,85 +192,98 @@ namespace StoryCollaborator
             }
         }
 
-        /// <summary>
-        /// Builds KernelArguments from gathered elements and injects candidate lists
-        /// for GUID-based mechanisms (CastMembers, Relationships, BeatSheet).
-        /// </summary>
-        internal KernelArguments BuildKernelArguments(Dictionary<string, StoryElement> elements)
+        private static readonly JsonSerializerOptions ElementSerializeOptions = new()
         {
-            var kernelArgs = new KernelArguments();
-            var rtfStripper = new RichTextStripper();
+            WriteIndented = false,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Converters =
+            {
+                new EmptyGuidConverter(),
+                new StoryElementConverter(),
+                new JsonStringEnumConverter()
+            }
+        };
 
-            foreach (var (label, element) in elements)
+        /// <summary>
+        /// Builds the #106 request body: full gathered elements (RTF stripped on outbound copy only)
+        /// plus pass-through args and declared collection lists. Does not flatten Label_Property keys
+        /// and does not invent lists from WriteVia.
+        /// </summary>
+        internal WorkflowProxyBody BuildWorkflowRequestBody(Dictionary<string, StoryElement> gatheredElements)
+        {
+            var body = new WorkflowProxyBody();
+
+            foreach (var (label, element) in gatheredElements)
             {
                 if (element == null) continue;
-
-                kernelArgs[label] = JsonSerializer.Serialize(element, new JsonSerializerOptions
-                {
-                    WriteIndented = true,
-                    DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-                });
-
-                var elementType = element.GetType();
-                foreach (var prop in elementType.GetProperties())
-                {
-                    if (prop.CanRead)
-                    {
-                        var value = prop.GetValue(element);
-                        var stringValue = value?.ToString() ?? string.Empty;
-
-                        if (stringValue.StartsWith(@"{\rtf"))
-                        {
-                            stringValue = rtfStripper.StripRichTextFormat(stringValue);
-                        }
-
-                        kernelArgs[$"{label}_{prop.Name}"] = stringValue;
-                    }
-                }
+                body.Elements[label] = SerializeElementOutbound(element);
             }
-
-            // Inject candidate lists for GUID-based mechanisms
-            var allSpecs = workflowModel.GetIO().Outputs
-                .SelectMany(o => o.PropertiesToUpdate)
-                .ToList();
-
-            bool needsCharacters = allSpecs.Any(s =>
-                s.WriteVia == WriteVia.CastMembers || s.WriteVia == WriteVia.Relationships);
-            bool needsBeatElements = allSpecs.Any(s => s.WriteVia == WriteVia.BeatSheet);
 
             var serOpts = new JsonSerializerOptions { WriteIndented = false };
-
-            if (needsCharacters)
+            foreach (var collection in workflowModel.GetIO().CollectionInputs)
             {
-                var chars = _storyApi.GetElementsByType(StoryItemType.Character);
-                if (chars.IsSuccess)
-                {
-                    kernelArgs["CharacterChoices"] = JsonSerializer.Serialize(
-                        chars.Payload?.Select(e => new { GUID = e.Uuid, Name = e.Name }) ?? Enumerable.Empty<object>(),
-                        serOpts);
-                }
+                var listResult = _storyApi.GetElementsByType(collection.ElementType);
+                if (!listResult.IsSuccess) continue;
+
+                var projected = (listResult.Payload ?? Enumerable.Empty<StoryElement>())
+                    .Select(e => ProjectCollectionElement(e, collection.Projection))
+                    .ToList();
+                body.Args[collection.RequestName] = JsonSerializer.Serialize(projected, serOpts);
             }
 
-            if (needsBeatElements)
-            {
-                var problems = _storyApi.GetElementsByType(StoryItemType.Problem);
-                if (problems.IsSuccess)
-                {
-                    kernelArgs["ProblemChoices"] = JsonSerializer.Serialize(
-                        problems.Payload?.Select(e => new { GUID = e.Uuid, Name = e.Name }) ?? Enumerable.Empty<object>(),
-                        serOpts);
-                }
+            return body;
+        }
 
-                var scenes = _storyApi.GetElementsByType(StoryItemType.Scene);
-                if (scenes.IsSuccess)
+        /// <summary>
+        /// Serialize runtime type to a JSON object, then strip RTF on that copy only.
+        /// Never mutates the live outline element.
+        /// </summary>
+        internal JsonObject SerializeElementOutbound(StoryElement element)
+        {
+            // StoryElementConverter writes Type discriminator using runtime type.
+            var json = JsonSerializer.Serialize<StoryElement>(element, ElementSerializeOptions);
+            var node = JsonNode.Parse(json)!.AsObject();
+            StripRtfOnTopLevelStrings(node);
+            return node;
+        }
+
+        private static void StripRtfOnTopLevelStrings(JsonObject obj)
+        {
+            var stripper = new RichTextStripper();
+            foreach (var key in obj.Select(p => p.Key).ToList())
+            {
+                if (obj[key] is JsonValue jv && jv.TryGetValue<string>(out var s)
+                    && s != null && s.StartsWith(@"{\rtf", StringComparison.Ordinal))
                 {
-                    kernelArgs["SceneChoices"] = JsonSerializer.Serialize(
-                        scenes.Payload?.Select(e => new { GUID = e.Uuid, Name = e.Name }) ?? Enumerable.Empty<object>(),
-                        serOpts);
+                    obj[key] = stripper.StripRichTextFormat(s);
                 }
             }
+        }
 
-            return kernelArgs;
+        private object ProjectCollectionElement(StoryElement element, ElementProjection projection)
+        {
+            return projection switch
+            {
+                ElementProjection.IdAndName => new { GUID = element.Uuid, Name = element.Name },
+                ElementProjection.BaseStoryElement => BuildBaseProjection(element),
+                ElementProjection.FullModel => SerializeElementOutbound(element),
+                _ => new { GUID = element.Uuid, Name = element.Name }
+            };
+        }
+
+        private object BuildBaseProjection(StoryElement element)
+        {
+            var description = element.Description ?? string.Empty;
+            if (description.StartsWith(@"{\rtf", StringComparison.Ordinal))
+                description = new RichTextStripper().StripRichTextFormat(description);
+
+            return new
+            {
+                GUID = element.Uuid,
+                Name = element.Name,
+                ElementDescription = description,
+                Type = element.ElementType.ToString()
+            };
         }
 
         /// <summary>
@@ -654,9 +678,9 @@ namespace StoryCollaborator
         }
 
         /// <summary>
-        /// Fetches examples for each name declared in the workflow's ExampleLists and adds them to kernel args.
+        /// Fetches examples for each name declared in the workflow's ExampleLists and adds them to args.
         /// </summary>
-        internal void EnrichWithExamples(KernelArguments kernelArgs)
+        internal void EnrichWithExamples(Dictionary<string, string> args)
         {
             foreach (var propertyName in workflowModel.GetIO().ExampleLists)
             {
@@ -664,7 +688,7 @@ namespace StoryCollaborator
                 if (result.IsSuccess && result.Payload != null && result.Payload.Any())
                 {
                     var formatted = string.Join(", ", result.Payload);
-                    kernelArgs[$"{propertyName}_examples"] = formatted;
+                    args[$"{propertyName}_examples"] = formatted;
                     _logger?.LogInformation($"Injected examples for {propertyName}: {result.Payload.Count()} items");
                 }
                 else
@@ -675,9 +699,9 @@ namespace StoryCollaborator
         }
 
         /// <summary>
-        /// Enriches kernel arguments with story context.
+        /// Enriches args with story context (still client-built for #106).
         /// </summary>
-        internal void EnrichWithStoryContext(KernelArguments kernelArgs, Dictionary<string, StoryElement> gatheredElements, WorkflowIO workflowIO)
+        internal void EnrichWithStoryContext(Dictionary<string, string> args, Dictionary<string, StoryElement> gatheredElements, WorkflowIO workflowIO)
         {
             try
             {
@@ -713,7 +737,7 @@ namespace StoryCollaborator
                 var builder = new StoryContextBuilder(_storyApi);
                 var context = builder.BuildContext(targetElement, spec, storyModel);
 
-                kernelArgs["StoryContext"] = !string.IsNullOrWhiteSpace(context) ? context : string.Empty;
+                args["StoryContext"] = !string.IsNullOrWhiteSpace(context) ? context : string.Empty;
 
                 if (!string.IsNullOrWhiteSpace(context))
                     _logger?.LogInformation($"Enriched with story context ({context.Length} chars) for {workflowModel.Label} workflow");
@@ -723,14 +747,14 @@ namespace StoryCollaborator
             catch (Exception ex)
             {
                 _logger?.LogWarning($"Failed to enrich story context: {ex.Message}");
-                kernelArgs["StoryContext"] = string.Empty;
+                args["StoryContext"] = string.Empty;
             }
         }
 
         /// <summary>
         /// Applies user settings to the prompt as instructions.
         /// </summary>
-        internal void ApplySettings(KernelArguments kernelArgs)
+        internal void ApplySettings(Dictionary<string, string> args)
         {
             var instructions = new List<string>();
 
@@ -757,7 +781,7 @@ namespace StoryCollaborator
                 instructions.Add($"Avoid suggesting these story forms: {_settings.StoryFormDislikes}");
 
             var result = string.Join(" ", instructions.Where(s => !string.IsNullOrEmpty(s)));
-            kernelArgs["UserSettings"] = result;
+            args["UserSettings"] = result;
 
             if (!string.IsNullOrEmpty(result))
                 _logger?.LogInformation("Applied settings: {Settings}", result);
@@ -770,16 +794,17 @@ namespace StoryCollaborator
         /// the cost reported by the proxy's collab_cost event (null when absent), and whether the
         /// returned stream (after the retry, if one occurred) is complete.
         /// </summary>
-        private async Task<(string Content, string? TemplateHash, ProxyCostInfo? Cost, bool Complete)> PostToProxyAsync(KernelArguments kernelArgs)
+        private async Task<(string Content, string? TemplateHash, ProxyCostInfo? Cost, bool Complete)> PostToProxyAsync(WorkflowProxyBody body)
         {
             var proxyBaseUrl = Environment.GetEnvironmentVariable("COLLAB_PROXY_URL")
                 ?? KernelFactory.DefaultProxyBaseUrl;
 
-            var args = new Dictionary<string, string>();
-            foreach (var kvp in kernelArgs)
-                args[kvp.Key] = kvp.Value is string s ? s : kvp.Value?.ToString() ?? string.Empty;
-
-            var payload = JsonSerializer.Serialize(new { workflowId = workflowModel.Label, args });
+            var payload = JsonSerializer.Serialize(new
+            {
+                workflowId = workflowModel.Label,
+                args = body.Args,
+                elements = body.Elements
+            });
 
             return await ExecuteWithTruncationRetryAsync(
                 () => PostToProxyOnceAsync(proxyBaseUrl, payload), ResetHttpClient);

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -223,6 +223,7 @@ namespace StoryCollaborator.Workflows
                                 "and the obstacles that challenge the protagonist's progress.",
                     workflowIO: new WorkflowIO
                     {
+                        // Full characters so Worker can fill Protagonist_Name / Antagonist_Name (issue #106).
                         RequiredInputs = new List<ElementRequirement>
                         {
                             new ElementRequirement
@@ -230,16 +231,6 @@ namespace StoryCollaborator.Workflows
                                 ElementType = StoryItemType.Problem,
                                 ElementLabel = "Problem",
                                 RequiredProperties = new List<PropertySpec>(),
-                                CreateIfMissing = false
-                            }
-                        },
-                        OptionalInputs = new List<ElementRequirement>
-                        {
-                            new ElementRequirement
-                            {
-                                ElementType = StoryItemType.Problem,
-                                ElementLabel = "Problem",
-                                RequiredProperties = new List<PropertySpec> { new PropertySpec("Protagonist"), new PropertySpec("Antagonist") },
                                 CreateIfMissing = false
                             },
                             new ElementRequirement
@@ -320,14 +311,13 @@ namespace StoryCollaborator.Workflows
                                 ElementLabel = "InnerProblem",
                                 RequiredProperties = new List<PropertySpec>(),
                                 CreateIfMissing = true
-                            }
-                        },
-                        OptionalInputs = new List<ElementRequirement>
-                        {
+                            },
+                            // Full protagonist for Protagonist_Name / Flaw / BackStory placeholders (#106).
                             new ElementRequirement
                             {
                                 ElementType = StoryItemType.Character,
                                 ElementLabel = "Protagonist",
+                                ReferencedElementLabel = "OuterProblem.Protagonist",
                                 RequiredProperties = new List<PropertySpec>(),
                                 CreateIfMissing = false
                             }
@@ -461,16 +451,53 @@ namespace StoryCollaborator.Workflows
                                 "remember but which controls them still.",
                     outputProperties: new List<PropertySpec> { new PropertySpec("BackStory") }),
                 new Workflow(
-                    "Relationship", "Character Relationship",
-                    "Develop the dynamics, history, and tension between two characters.",
-                    StoryItemType.Character,
+                    label: "Relationship",
+                    title: "Character Relationship",
+                    description: "Develop the dynamics, history, and tension between two characters.",
                     explanation: "Relationships create conflict, reveal character, and drive plot. This workflow " +
                                 "explores how two characters relate—their shared history, what they want from each " +
                                 "other, sources of tension, and how the relationship might change through the story.",
-                    // RelationshipList is List<RelationshipModel>; recipient GUID injected via CharacterChoices.
-                    outputProperties: new List<PropertySpec>
+                    workflowIO: new WorkflowIO
                     {
-                        new PropertySpec("RelationshipList", WriteVia.Relationships, JsonKey: "relationship")
+                        // Primary + Partner full elements for Partner_* placeholders (#106).
+                        RequiredInputs = new List<ElementRequirement>
+                        {
+                            new ElementRequirement
+                            {
+                                ElementType = StoryItemType.Character,
+                                ElementLabel = "Character",
+                                RequiredProperties = new List<PropertySpec>(),
+                                CreateIfMissing = false
+                            },
+                            new ElementRequirement
+                            {
+                                ElementType = StoryItemType.Character,
+                                ElementLabel = "Partner",
+                                RequiredProperties = new List<PropertySpec>(),
+                                CreateIfMissing = false
+                            }
+                        },
+                        Outputs = new List<ElementOutput>
+                        {
+                            new ElementOutput
+                            {
+                                ElementType = StoryItemType.Character,
+                                ElementLabel = "Character",
+                                PropertiesToUpdate = new List<PropertySpec>
+                                {
+                                    new PropertySpec("RelationshipList", WriteVia.Relationships, JsonKey: "relationship")
+                                }
+                            }
+                        },
+                        CollectionInputs = new List<CollectionInput>
+                        {
+                            new CollectionInput
+                            {
+                                RequestName = "CharacterChoices",
+                                ElementType = StoryItemType.Character,
+                                Projection = ElementProjection.IdAndName
+                            }
+                        }
                     }),
 
                 // === Setting Workflows (scene-specific) ===
@@ -549,18 +576,56 @@ namespace StoryCollaborator.Workflows
                         new PropertySpec("Realization")
                     }),
                 new Workflow(
-                    "SceneConflict", "Scene Conflict",
-                    "Structure the conflict within a scene—the protagonist's goal, the opposition they face, " +
-                    "and the outcome.",
-                    StoryItemType.Scene,
+                    label: "SceneConflict",
+                    title: "Scene Conflict",
+                    description: "Structure the conflict within a scene—the protagonist's goal, the opposition they face, " +
+                                 "and the outcome.",
                     explanation: "A scene is a small story with goal, conflict, and outcome. This workflow uses the " +
                                 "Actor's Studio method to define what the scene protagonist wants, what opposes them, " +
                                 "and how the scene ends—usually in a way that makes things worse.",
-                    outputProperties: new List<PropertySpec>
+                    workflowIO: new WorkflowIO
                     {
-                        new PropertySpec("ProtagGoal"),
-                        new PropertySpec("Opposition"),
-                        new PropertySpec("Outcome")
+                        // Scene + full characters for Protagonist_Name / Antagonist_Name (#106).
+                        RequiredInputs = new List<ElementRequirement>
+                        {
+                            new ElementRequirement
+                            {
+                                ElementType = StoryItemType.Scene,
+                                ElementLabel = "Scene",
+                                RequiredProperties = new List<PropertySpec>(),
+                                CreateIfMissing = false
+                            },
+                            new ElementRequirement
+                            {
+                                ElementType = StoryItemType.Character,
+                                ElementLabel = "Protagonist",
+                                ReferencedElementLabel = "Scene.Protagonist",
+                                RequiredProperties = new List<PropertySpec>(),
+                                CreateIfMissing = false
+                            },
+                            new ElementRequirement
+                            {
+                                ElementType = StoryItemType.Character,
+                                ElementLabel = "Antagonist",
+                                ReferencedElementLabel = "Scene.Antagonist",
+                                RequiredProperties = new List<PropertySpec>(),
+                                CreateIfMissing = false
+                            }
+                        },
+                        Outputs = new List<ElementOutput>
+                        {
+                            new ElementOutput
+                            {
+                                ElementType = StoryItemType.Scene,
+                                ElementLabel = "Scene",
+                                PropertiesToUpdate = new List<PropertySpec>
+                                {
+                                    new PropertySpec("ProtagGoal"),
+                                    new PropertySpec("Opposition"),
+                                    new PropertySpec("Outcome")
+                                }
+                            }
+                        }
                     }),
                 new Workflow(
                     "Sequel", "Sequel (Reaction)",
@@ -588,12 +653,7 @@ namespace StoryCollaborator.Workflows
                 Projection = ElementProjection.IdAndName
             };
             GetFrom(list, "CastSceneRoles")!.GetIO().CollectionInputs.Add(characterChoices);
-            GetFrom(list, "Relationship")!.GetIO().CollectionInputs.Add(new CollectionInput
-            {
-                RequestName = "CharacterChoices",
-                ElementType = StoryItemType.Character,
-                Projection = ElementProjection.IdAndName
-            });
+            // Relationship CollectionInputs are declared on its WorkflowIO above.
 
             return list;
         }

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -29,7 +29,7 @@ namespace StoryCollaborator.Workflows
         /// </summary>
         private static List<Workflow> CreateWorkflows()
         {
-            return new List<Workflow>
+            var list = new List<Workflow>
             {
                 // === Overview Workflows ===
 
@@ -579,6 +579,26 @@ namespace StoryCollaborator.Workflows
                     }),
                 // SceneCreateImage removed; preserved on branch issue-76-image-workflows (issue #76).
             };
+
+            // Issue #106: declared collection inputs (not inferred from WriteVia).
+            var characterChoices = new CollectionInput
+            {
+                RequestName = "CharacterChoices",
+                ElementType = StoryItemType.Character,
+                Projection = ElementProjection.IdAndName
+            };
+            GetFrom(list, "CastSceneRoles")!.GetIO().CollectionInputs.Add(characterChoices);
+            GetFrom(list, "Relationship")!.GetIO().CollectionInputs.Add(new CollectionInput
+            {
+                RequestName = "CharacterChoices",
+                ElementType = StoryItemType.Character,
+                Projection = ElementProjection.IdAndName
+            });
+
+            return list;
         }
+
+        private static Workflow? GetFrom(List<Workflow> list, string label) =>
+            list.FirstOrDefault(w => w.Label == label);
     }
 }


### PR DESCRIPTION
## Summary
- `BuildWorkflowRequestBody` sends `{ workflowId, args, elements }` with full runtime-type element JSON.
- RTF strip on outbound copy only; never mutates the live outline.
- `CollectionInput` / `ElementProjection`; CastSceneRoles and Relationship declare `CharacterChoices`.

## Companion
Collaborator Worker PR for merge rules and tests.

## Test plan
- [x] CollaboratorTests offline (payload, RTF non-mutation, collections)
- [x] Live suite 22/22 with #106 Worker on dev

Related: storybuilder-org/Collaborator#106