### PR TITLE
fix(#117): ElementPicker create, list refresh, and sequential pickers

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -854,10 +854,10 @@ public class Collaborator : ICollaborator
             }
         }
 
-        // Show ElementPicker - pass currentGuid for pre-selection if available
+        // Show ElementPicker - pass API so Create works; currentGuid for pre-selection
         var pickerVM = new ElementPickerVM();
         var selectedGuid = await pickerVM.ShowPicker(_storyModel!, xamlRoot,
-            requirement.ElementType, requirement.ElementLabel, currentGuid);
+            requirement.ElementType, requirement.ElementLabel, currentGuid, _storyApi);
 
         if (string.IsNullOrEmpty(selectedGuid))
         {

--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -859,6 +859,11 @@ public class Collaborator : ICollaborator
         var selectedGuid = await pickerVM.ShowPicker(_storyModel!, xamlRoot,
             requirement.ElementType, requirement.ElementLabel, currentGuid, _storyApi);
 
+        // WinUI: sequential ContentDialogs can swallow the next ShowAsync if the previous
+        // dialog has not fully torn down. Brief yield so Problem → Protagonist → Antagonist
+        // each actually appear.
+        await Task.Delay(100);
+
         if (string.IsNullOrEmpty(selectedGuid))
         {
             // User cancelled

--- a/StoryCADLib/Collaborator/ViewModels/ElementPickerVM.cs
+++ b/StoryCADLib/Collaborator/ViewModels/ElementPickerVM.cs
@@ -57,6 +57,12 @@ public class ElementPickerVM
     public IStoryCADAPI StoryApi { get; set; }
 
     /// <summary>
+    ///     Invoked after a successful create so the page can rebuild the list
+    ///     (ItemsSource is a snapshot via ToList, not a live binding).
+    /// </summary>
+    public Action AfterCreate { get; set; }
+
+    /// <summary>
     ///     Spawns an instance of the picker.
     /// </summary>
     /// <param name="Model">StoryModel to show elements from</param>
@@ -145,11 +151,22 @@ public class ElementPickerVM
         var addResult = StoryApi.AddElement(type, overview.Uuid.ToString(), name);
         if (!addResult.IsSuccess) return;
 
-        var lookupResult = StoryApi.GetStoryElement(addResult.Payload);
-        if (lookupResult?.IsSuccess == true && lookupResult.Payload != null)
+        // Prefer the live model instance so list refresh and selection match the tree.
+        StoryElement created = null;
+        if (StoryModel.StoryElements.StoryElementGuids.TryGetValue(addResult.Payload, out var fromModel))
+            created = fromModel;
+        else
         {
-            SelectedElement = lookupResult.Payload;
-            dialog?.Hide();
+            var lookupResult = StoryApi.GetStoryElement(addResult.Payload);
+            if (lookupResult?.IsSuccess == true)
+                created = lookupResult.Payload;
         }
+
+        if (created == null) return;
+
+        SelectedElement = created;
+        NewNodeName = "";
+        AfterCreate?.Invoke();
+        dialog?.Hide();
     }
 }

--- a/StoryCADLib/Collaborator/ViewModels/ElementPickerVM.cs
+++ b/StoryCADLib/Collaborator/ViewModels/ElementPickerVM.cs
@@ -16,8 +16,6 @@ public class ElementPickerVM
     /// </summary>
     private ContentDialog dialog;
 
-    private IStoryCADAPI? _storyApi;
-
     /// <summary>
     ///     Currently selected item
     /// </summary>
@@ -54,6 +52,11 @@ public class ElementPickerVM
     public Guid? CurrentSelection { get; set; }
 
     /// <summary>
+    ///     API used to create new elements from the picker. Set by <see cref="ShowPicker"/>.
+    /// </summary>
+    public IStoryCADAPI StoryApi { get; set; }
+
+    /// <summary>
     ///     Spawns an instance of the picker.
     /// </summary>
     /// <param name="Model">StoryModel to show elements from</param>
@@ -61,10 +64,11 @@ public class ElementPickerVM
     /// <param name="Type">Only allow elements of this type to be picked</param>
     /// <param name="label">Descriptive label for what we're picking (e.g., "Protagonist")</param>
     /// <param name="currentSelection">GUID of currently selected element for pre-selection</param>
-    /// <returns>The GUID of element the user picked</returns>
+    /// <param name="storyApi">API used when the user creates a new element</param>
+    /// <returns>The GUID of element the user picked, or null if cancelled / nothing selected</returns>
     public async Task<string> ShowPicker(StoryModel Model,
         XamlRoot XAMLRoot, StoryItemType? Type = null, string label = null, Guid? currentSelection = null,
-        IStoryCADAPI? storyApi = null)
+        IStoryCADAPI storyApi = null)
     {
         //Reset VM
         SelectedType = null;
@@ -74,7 +78,7 @@ public class ElementPickerVM
         StoryModel = Model;
         PickerLabel = label;
         CurrentSelection = currentSelection;
-        _storyApi = storyApi;
+        StoryApi = storyApi;
 
         //Spawn new picker, passing this VM so Page uses the same instance
         var ui = new Views.ElementPicker(this);
@@ -96,13 +100,21 @@ public class ElementPickerVM
             XamlRoot = XAMLRoot
         };
 
-        //interpret result
+        //interpret result — cancel or empty selection both return null (no crash)
         if (await dialog.ShowAsync() != ContentDialogResult.Secondary)
         {
-            return (SelectedElement as StoryElement).Uuid.ToString();
+            return ResolveSelectedGuid();
         }
 
-        return null; //Return unknown if dialog is closed or element isn't selected.
+        return null;
+    }
+
+    /// <summary>
+    ///     GUID of the selected element, or null when nothing is selected.
+    /// </summary>
+    public string ResolveSelectedGuid()
+    {
+        return (SelectedElement as StoryElement)?.Uuid.ToString();
     }
 
     /// <summary>
@@ -110,7 +122,7 @@ public class ElementPickerVM
     /// </summary>
     public void CreateNode()
     {
-        if (_storyApi == null || StoryModel == null)
+        if (StoryApi == null || StoryModel == null)
             return;
 
         StoryItemType type;
@@ -130,10 +142,10 @@ public class ElementPickerVM
         if (overview == null) return;
 
         var name = string.IsNullOrWhiteSpace(NewNodeName) ? $"New {type}" : NewNodeName;
-        var addResult = _storyApi.AddElement(type, overview.Uuid.ToString(), name);
+        var addResult = StoryApi.AddElement(type, overview.Uuid.ToString(), name);
         if (!addResult.IsSuccess) return;
 
-        var lookupResult = _storyApi.GetStoryElement(addResult.Payload);
+        var lookupResult = StoryApi.GetStoryElement(addResult.Payload);
         if (lookupResult?.IsSuccess == true && lookupResult.Payload != null)
         {
             SelectedElement = lookupResult.Payload;

--- a/StoryCADLib/Collaborator/ViewModels/ElementPickerVM.cs
+++ b/StoryCADLib/Collaborator/ViewModels/ElementPickerVM.cs
@@ -6,77 +6,42 @@ using StoryCADLib.Services.Collaborator.Contracts;
 namespace StoryCADLib.Collaborator.ViewModels;
 
 /// <summary>
-///     ViewModel for the Element Picker
+/// ViewModel for the Collaborator Element Picker dialog.
 /// </summary>
 [Microsoft.UI.Xaml.Data.Bindable]
 public class ElementPickerVM
 {
-    /// <summary>
-    ///     Instance of element picker
-    /// </summary>
     private ContentDialog dialog;
 
-    /// <summary>
-    ///     Currently selected item
-    /// </summary>
     public StoryModel StoryModel { get; set; }
-
-    /// <summary>
-    ///     Currently selected item
-    /// </summary>
     public object SelectedType { get; set; }
-
-    /// <summary>
-    ///     Currently selected item
-    /// </summary>
     public object SelectedElement { get; set; }
-
-    /// <summary>
-    ///     Text for new node textbox.
-    /// </summary>
     public string NewNodeName { get; set; }
-
-    /// <summary>
-    ///     Type the picker forces the user to pick
-    /// </summary>
     public StoryItemType? ForcedType { get; set; }
-
-    /// <summary>
-    ///     Descriptive label for what we're picking (e.g., "Protagonist", "Story Problem")
-    /// </summary>
     public string PickerLabel { get; set; }
-
-    /// <summary>
-    ///     GUID of the currently selected element (for pre-selection when changing)
-    /// </summary>
     public Guid? CurrentSelection { get; set; }
 
     /// <summary>
-    ///     API used to create new elements from the picker. Set by <see cref="ShowPicker"/>.
+    /// API used to create new elements. Set by <see cref="ShowPicker"/>.
     /// </summary>
     public IStoryCADAPI StoryApi { get; set; }
 
     /// <summary>
-    ///     Invoked after a successful create so the page can rebuild the list
-    ///     (ItemsSource is a snapshot via ToList, not a live binding).
+    /// Page rebuilds the list after create (ItemsSource is a ToList snapshot).
     /// </summary>
     public Action AfterCreate { get; set; }
 
     /// <summary>
-    ///     Spawns an instance of the picker.
+    /// Shows the picker. Returns selected element GUID, or null if cancelled / nothing selected.
     /// </summary>
-    /// <param name="Model">StoryModel to show elements from</param>
-    /// <param name="XAMLRoot">XamlRoot for the dialog</param>
-    /// <param name="Type">Only allow elements of this type to be picked</param>
-    /// <param name="label">Descriptive label for what we're picking (e.g., "Protagonist")</param>
-    /// <param name="currentSelection">GUID of currently selected element for pre-selection</param>
-    /// <param name="storyApi">API used when the user creates a new element</param>
-    /// <returns>The GUID of element the user picked, or null if cancelled / nothing selected</returns>
-    public async Task<string> ShowPicker(StoryModel Model,
-        XamlRoot XAMLRoot, StoryItemType? Type = null, string label = null, Guid? currentSelection = null,
+    public async Task<string> ShowPicker(
+        StoryModel Model,
+        XamlRoot XAMLRoot,
+        StoryItemType? Type = null,
+        string label = null,
+        Guid? currentSelection = null,
         IStoryCADAPI storyApi = null)
     {
-        //Reset VM
         SelectedType = null;
         SelectedElement = null;
         NewNodeName = "";
@@ -86,37 +51,41 @@ public class ElementPickerVM
         CurrentSelection = currentSelection;
         StoryApi = storyApi;
 
-        //Spawn new picker, passing this VM so Page uses the same instance
         var ui = new Views.ElementPicker(this);
 
-        // Build dialog title - "Change" if there's a current selection, "Select" otherwise
         var hasCurrentSelection = currentSelection.HasValue && currentSelection.Value != Guid.Empty;
         var actionVerb = hasCurrentSelection ? "Change" : "Select";
         var title = !string.IsNullOrEmpty(label)
             ? $"{actionVerb} {label}"
-            : $"{actionVerb} {Type.ToString()} element";
+            : $"{actionVerb} {Type} element";
 
-        //create and show dialog
         dialog = new ContentDialog
         {
             Title = title,
             PrimaryButtonText = "Select",
             SecondaryButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Primary,
             Content = ui,
-            XamlRoot = XAMLRoot
+            XamlRoot = XAMLRoot,
+            // Keep dialog wide enough for list + Create; avoid a tiny “abbreviated” shell.
+            MinWidth = 400
         };
 
-        //interpret result — cancel or empty selection both return null (no crash)
-        if (await dialog.ShowAsync() != ContentDialogResult.Secondary)
-        {
-            return ResolveSelectedGuid();
-        }
+        // Pre-select when changing an existing reference
+        if (hasCurrentSelection)
+            CurrentSelection = currentSelection;
 
-        return null;
+        UpdatePrimaryEnabled();
+
+        var result = await dialog.ShowAsync();
+        if (result == ContentDialogResult.Secondary)
+            return null;
+
+        return ResolveSelectedGuid();
     }
 
     /// <summary>
-    ///     GUID of the selected element, or null when nothing is selected.
+    /// GUID of the selected element, or null when nothing is selected.
     /// </summary>
     public string ResolveSelectedGuid()
     {
@@ -124,7 +93,22 @@ public class ElementPickerVM
     }
 
     /// <summary>
-    ///     Creates a new node of the type the user selected
+    /// Called by the page when list selection changes so Primary can enable/disable.
+    /// </summary>
+    public void NotifySelectionChanged()
+    {
+        UpdatePrimaryEnabled();
+    }
+
+    private void UpdatePrimaryEnabled()
+    {
+        if (dialog != null)
+            dialog.IsPrimaryButtonEnabled = SelectedElement is StoryElement;
+    }
+
+    /// <summary>
+    /// Creates a new element of the forced/selected type, selects it in the list,
+    /// and leaves the dialog open for the user to confirm with Select.
     /// </summary>
     public void CreateNode()
     {
@@ -147,11 +131,10 @@ public class ElementPickerVM
             .FirstOrDefault(e => e.ElementType == StoryItemType.StoryOverview);
         if (overview == null) return;
 
-        var name = string.IsNullOrWhiteSpace(NewNodeName) ? $"New {type}" : NewNodeName;
+        var name = string.IsNullOrWhiteSpace(NewNodeName) ? $"New {type}" : NewNodeName.Trim();
         var addResult = StoryApi.AddElement(type, overview.Uuid.ToString(), name);
         if (!addResult.IsSuccess) return;
 
-        // Prefer the live model instance so list refresh and selection match the tree.
         StoryElement created = null;
         if (StoryModel.StoryElements.StoryElementGuids.TryGetValue(addResult.Payload, out var fromModel))
             created = fromModel;
@@ -166,7 +149,8 @@ public class ElementPickerVM
 
         SelectedElement = created;
         NewNodeName = "";
+        // Refresh list + selection; do NOT close the dialog — user confirms with Select.
         AfterCreate?.Invoke();
-        dialog?.Hide();
+        UpdatePrimaryEnabled();
     }
 }

--- a/StoryCADLib/Collaborator/Views/ElementPicker.xaml
+++ b/StoryCADLib/Collaborator/Views/ElementPicker.xaml
@@ -6,13 +6,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel>
+    <!-- Create is above the list so ContentDialog never clips it under a tall ScrollViewer. -->
+    <StackPanel Spacing="8" Padding="0,0,0,8">
 
-        <!-- ElementType Picker -->
-        <!-- No Header (PlaceholderText only): explicit Name required per convention.
-             This is a near-clone of Services/Dialogs/ElementPicker.xaml (Unit 6), sharing the same
-             x:Name values (TypeBox/ElementBox/NewButton); ids here take a distinct CollabPicker
-             prefix throughout so they don't collide with Unit 6's ElementPickerTypeCombo etc. -->
+        <!-- ElementType Picker (hidden when ForcedType is set) -->
         <ComboBox SelectedItem="{x:Bind PickerVM.SelectedType, Mode=TwoWay}"
                   Name="TypeBox"
                   PlaceholderText="Click here to select an element type" HorizontalAlignment="Center"
@@ -25,22 +22,7 @@
             <ComboBoxItem Content="Scene" />
         </ComboBox>
 
-        <!-- Element Picker -->
-        <ScrollViewer Height="450">
-            <!-- No Header: accessible name pinned explicitly (founder ruling, PR #1458). -->
-            <ListView Name="ElementBox" IsEnabled="False" HorizontalAlignment="Center"
-                      SelectedItem="{x:Bind PickerVM.SelectedElement, Mode=TwoWay}"
-                      DisplayMemberPath="Name" Margin="0,10,0,0"
-                      MinWidth="200" SelectionMode="Single"
-                      AutomationProperties.AutomationId="CollabPickerList"
-                      AutomationProperties.Name="Elements" />
-        </ScrollViewer>
-
-        <Border Margin="30,10" HorizontalAlignment="Stretch"
-                BorderBrush="Gray" BorderThickness="1" />
-
-        <!-- Create new element UI -->
-        <!-- Create stays available whenever a type is known (empty or non-empty list). -->
+        <!-- Create always visible when a type is known (empty or non-empty list). -->
         <Button HorizontalAlignment="Center" Content="+ Create a new element"
                 Name="NewButton" IsEnabled="True"
                 AutomationProperties.AutomationId="CollabPickerAddNewElementButton">
@@ -57,5 +39,18 @@
                 </Flyout>
             </Button.Flyout>
         </Button>
+
+        <Border Margin="0,4" HorizontalAlignment="Stretch"
+                BorderBrush="Gray" BorderThickness="1" />
+
+        <!-- MaxHeight not Height: empty list must not reserve 450px and hide Create. -->
+        <ScrollViewer MaxHeight="320" VerticalScrollBarVisibility="Auto">
+            <ListView Name="ElementBox" IsEnabled="False" HorizontalAlignment="Stretch"
+                      SelectedItem="{x:Bind PickerVM.SelectedElement, Mode=TwoWay}"
+                      DisplayMemberPath="Name"
+                      MinWidth="200" MinHeight="40" SelectionMode="Single"
+                      AutomationProperties.AutomationId="CollabPickerList"
+                      AutomationProperties.Name="Elements" />
+        </ScrollViewer>
     </StackPanel>
 </Page>

--- a/StoryCADLib/Collaborator/Views/ElementPicker.xaml
+++ b/StoryCADLib/Collaborator/Views/ElementPicker.xaml
@@ -40,8 +40,9 @@
                 BorderBrush="Gray" BorderThickness="1" />
 
         <!-- Create new element UI -->
+        <!-- Create stays available whenever a type is known (empty or non-empty list). -->
         <Button HorizontalAlignment="Center" Content="+ Create a new element"
-                Name="NewButton" IsEnabled="False"
+                Name="NewButton" IsEnabled="True"
                 AutomationProperties.AutomationId="CollabPickerAddNewElementButton">
             <Button.Flyout>
                 <Flyout AutomationProperties.AutomationId="CollabPickerAddNewElementFlyout">

--- a/StoryCADLib/Collaborator/Views/ElementPicker.xaml
+++ b/StoryCADLib/Collaborator/Views/ElementPicker.xaml
@@ -6,14 +6,20 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <!-- Create is above the list so ContentDialog never clips it under a tall ScrollViewer. -->
-    <StackPanel Spacing="8" Padding="0,0,0,8">
+    <!--
+      Layout: list, then Create at the bottom (classic picker shape).
+      ScrollViewer uses MaxHeight (not fixed Height) so an empty list does not
+      push Create off-screen inside ContentDialog.
+    -->
+    <StackPanel MinWidth="340" Spacing="10" Padding="4,0,4,4">
 
-        <!-- ElementType Picker (hidden when ForcedType is set) -->
+        <!-- Hidden when ForcedType is set (workflow already chose Problem/Character/…). -->
         <ComboBox SelectedItem="{x:Bind PickerVM.SelectedType, Mode=TwoWay}"
                   Name="TypeBox"
-                  PlaceholderText="Click here to select an element type" HorizontalAlignment="Center"
-                  MinWidth="200" SelectionChanged="Selector_OnSelectionChanged"
+                  PlaceholderText="Click here to select an element type"
+                  HorizontalAlignment="Stretch"
+                  MinWidth="200"
+                  SelectionChanged="Selector_OnSelectionChanged"
                   AutomationProperties.AutomationId="CollabPickerTypeCombo"
                   AutomationProperties.Name="Element type">
             <ComboBoxItem Content="Problem" />
@@ -22,35 +28,47 @@
             <ComboBoxItem Content="Scene" />
         </ComboBox>
 
-        <!-- Create always visible when a type is known (empty or non-empty list). -->
-        <Button HorizontalAlignment="Center" Content="+ Create a new element"
-                Name="NewButton" IsEnabled="True"
+        <ScrollViewer MaxHeight="280"
+                      MinHeight="120"
+                      VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollBarVisibility="Disabled">
+            <ListView Name="ElementBox"
+                      IsEnabled="False"
+                      HorizontalAlignment="Stretch"
+                      SelectedItem="{x:Bind PickerVM.SelectedElement, Mode=TwoWay}"
+                      SelectionChanged="ElementBox_OnSelectionChanged"
+                      DisplayMemberPath="Name"
+                      MinHeight="100"
+                      SelectionMode="Single"
+                      AutomationProperties.AutomationId="CollabPickerList"
+                      AutomationProperties.Name="Elements" />
+        </ScrollViewer>
+
+        <Border HorizontalAlignment="Stretch"
+                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                BorderThickness="0,1,0,0"
+                Margin="0,2,0,0" />
+
+        <!-- Always available: empty outline or existing elements that are not the one wanted. -->
+        <Button HorizontalAlignment="Stretch"
+                Content="+ Create a new element"
+                Name="NewButton"
+                IsEnabled="True"
                 AutomationProperties.AutomationId="CollabPickerAddNewElementButton">
             <Button.Flyout>
-                <Flyout AutomationProperties.AutomationId="CollabPickerAddNewElementFlyout">
-                    <StackPanel>
-                        <TextBox Header="Element name:" Width="200"
+                <Flyout AutomationProperties.AutomationId="CollabPickerAddNewElementFlyout"
+                        Placement="Top">
+                    <StackPanel Spacing="8" MinWidth="220">
+                        <TextBox Header="Element name:"
                                  Text="{x:Bind PickerVM.NewNodeName, Mode=TwoWay}"
                                  AutomationProperties.AutomationId="CollabPickerNewElementNameTextBox" />
-                        <Button Content="Create" HorizontalAlignment="Center"
-                                Margin="0,20,0,0" Click="{x:Bind PickerVM.CreateNode}"
+                        <Button Content="Create"
+                                HorizontalAlignment="Stretch"
+                                Click="{x:Bind PickerVM.CreateNode}"
                                 AutomationProperties.AutomationId="CollabPickerCreateElementButton" />
                     </StackPanel>
                 </Flyout>
             </Button.Flyout>
         </Button>
-
-        <Border Margin="0,4" HorizontalAlignment="Stretch"
-                BorderBrush="Gray" BorderThickness="1" />
-
-        <!-- MaxHeight not Height: empty list must not reserve 450px and hide Create. -->
-        <ScrollViewer MaxHeight="320" VerticalScrollBarVisibility="Auto">
-            <ListView Name="ElementBox" IsEnabled="False" HorizontalAlignment="Stretch"
-                      SelectedItem="{x:Bind PickerVM.SelectedElement, Mode=TwoWay}"
-                      DisplayMemberPath="Name"
-                      MinWidth="200" MinHeight="40" SelectionMode="Single"
-                      AutomationProperties.AutomationId="CollabPickerList"
-                      AutomationProperties.Name="Elements" />
-        </ScrollViewer>
     </StackPanel>
 </Page>

--- a/StoryCADLib/Collaborator/Views/ElementPicker.xaml.cs
+++ b/StoryCADLib/Collaborator/Views/ElementPicker.xaml.cs
@@ -18,6 +18,7 @@ public sealed partial class ElementPicker : Page
     {
         InitializeComponent();
         PickerVM = viewModel;
+        PickerVM.AfterCreate = OnAfterCreate;
 
         if (PickerVM.ForcedType != null)
         {
@@ -28,30 +29,66 @@ public sealed partial class ElementPicker : Page
     }
 
     /// <summary>
+    ///     After Create: close the flyout, rebuild the list (was a dead ToList snapshot),
+    ///     select the new element. Dialog hide is handled by the VM.
+    /// </summary>
+    private void OnAfterCreate()
+    {
+        NewButton.Flyout?.Hide();
+        RefreshElementList(preserveSelection: true);
+    }
+
+    /// <summary>
     ///     This just handles the UI when the type Combobox is changed
     /// </summary>
     public void Selector_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
     {
+        PickerVM.SelectedElement = null;
+        RefreshElementList(preserveSelection: false);
+
+        // Pre-select current element if one is specified (Change flow)
+        if (ElementBox.ItemsSource is System.Collections.IEnumerable items
+            && PickerVM.CurrentSelection.HasValue
+            && PickerVM.CurrentSelection.Value != Guid.Empty)
+        {
+            var currentElement = items.Cast<object>().FirstOrDefault(e =>
+                e is StoryElement se && se.Uuid == PickerVM.CurrentSelection.Value);
+            if (currentElement != null)
+            {
+                ElementBox.SelectedItem = currentElement;
+                PickerVM.SelectedElement = currentElement;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Rebuild ElementBox from the live model collections.
+    ///     Count &lt;= 1 means only the "(none)" placeholder — treat as empty.
+    /// </summary>
+    private void RefreshElementList(bool preserveSelection)
+    {
+        var preserve = preserveSelection ? PickerVM.SelectedElement as StoryElement : null;
+
         StoryItemType type;
         if (PickerVM.ForcedType == null)
         {
-            //Get elements
-            var Type = PickerVM.SelectedType as ComboBoxItem;
-            type = Enum.Parse<StoryItemType>(Type.Content.ToString()!,
-                true);
+            var typeItem = PickerVM.SelectedType as ComboBoxItem;
+            if (typeItem == null)
+            {
+                ElementBox.ItemsSource = null;
+                ElementBox.IsEnabled = false;
+                return;
+            }
+
+            type = Enum.Parse<StoryItemType>(typeItem.Content.ToString()!, true);
         }
         else
         {
             type = (StoryItemType)PickerVM.ForcedType;
         }
 
-
-        // Reset selection; Create stays enabled for empty and non-empty lists.
-        PickerVM.SelectedElement = null;
-        ElementBox.ItemsSource = null;
         NewButton.IsEnabled = true;
 
-        // Use pre-filtered collections from StoryElementCollection for efficiency
         var elements = type switch
         {
             StoryItemType.Problem => PickerVM.StoryModel.StoryElements.Problems,
@@ -61,29 +98,25 @@ public sealed partial class ElementPicker : Page
             _ => null
         };
 
-        // Note: filtered collections include a "(none)" placeholder at index 0
-        // Real elements start at index 1, so check for Count > 1
+        // Filtered collections include a "(none)" placeholder at index 0
         if (elements == null || elements.Count <= 1)
         {
+            ElementBox.ItemsSource = null;
             ElementBox.IsEnabled = false;
+            return;
         }
-        else
-        {
-            //Update element box with elements (skip the "(none)" placeholder)
-            ElementBox.IsEnabled = true;
-            var elementList = elements.Skip(1).ToList();
-            ElementBox.ItemsSource = elementList;
 
-            // Pre-select current element if one is specified
-            if (PickerVM.CurrentSelection.HasValue && PickerVM.CurrentSelection.Value != Guid.Empty)
+        ElementBox.IsEnabled = true;
+        var elementList = elements.Skip(1).ToList();
+        ElementBox.ItemsSource = elementList;
+
+        if (preserve != null)
+        {
+            var match = elementList.FirstOrDefault(e => e.Uuid == preserve.Uuid);
+            if (match != null)
             {
-                var currentElement = elementList.FirstOrDefault(e =>
-                    e is StoryElement se && se.Uuid == PickerVM.CurrentSelection.Value);
-                if (currentElement != null)
-                {
-                    ElementBox.SelectedItem = currentElement;
-                    PickerVM.SelectedElement = currentElement;
-                }
+                ElementBox.SelectedItem = match;
+                PickerVM.SelectedElement = match;
             }
         }
     }

--- a/StoryCADLib/Collaborator/Views/ElementPicker.xaml.cs
+++ b/StoryCADLib/Collaborator/Views/ElementPicker.xaml.cs
@@ -1,20 +1,18 @@
 using System.Linq;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using StoryCADLib.Collaborator.ViewModels;
 using StoryCADLib.Models;
 
 namespace StoryCADLib.Collaborator.Views;
 
 /// <summary>
-///     A simple picker allowing a user to pick the
-///     type of element they want
+/// Collaborator element picker: choose an existing element or create one.
 /// </summary>
 public sealed partial class ElementPicker : Page
 {
-    public Collaborator.ViewModels.ElementPickerVM PickerVM;
+    public ViewModels.ElementPickerVM PickerVM;
 
-    public ElementPicker(Collaborator.ViewModels.ElementPickerVM viewModel)
+    public ElementPicker(ViewModels.ElementPickerVM viewModel)
     {
         InitializeComponent();
         PickerVM = viewModel;
@@ -29,76 +27,69 @@ public sealed partial class ElementPicker : Page
     }
 
     /// <summary>
-    ///     After Create: close the flyout, rebuild the list (was a dead ToList snapshot),
-    ///     select the new element. Dialog hide is handled by the VM.
+    /// After Create: close flyout, rebuild list, leave dialog open so user can Select.
     /// </summary>
     private void OnAfterCreate()
     {
         NewButton.Flyout?.Hide();
         RefreshElementList(preserveSelection: true);
+        PickerVM.NotifySelectionChanged();
     }
 
-    /// <summary>
-    ///     This just handles the UI when the type Combobox is changed
-    /// </summary>
     public void Selector_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         PickerVM.SelectedElement = null;
         RefreshElementList(preserveSelection: false);
 
-        // Pre-select current element if one is specified (Change flow)
+        // Pre-select when changing an existing linked element
         if (ElementBox.ItemsSource is System.Collections.IEnumerable items
             && PickerVM.CurrentSelection.HasValue
             && PickerVM.CurrentSelection.Value != Guid.Empty)
         {
-            var currentElement = items.Cast<object>().FirstOrDefault(e =>
-                e is StoryElement se && se.Uuid == PickerVM.CurrentSelection.Value);
-            if (currentElement != null)
+            var current = items.Cast<object>().FirstOrDefault(o =>
+                o is StoryElement se && se.Uuid == PickerVM.CurrentSelection.Value);
+            if (current != null)
             {
-                ElementBox.SelectedItem = currentElement;
-                PickerVM.SelectedElement = currentElement;
+                ElementBox.SelectedItem = current;
+                PickerVM.SelectedElement = current;
             }
         }
+
+        PickerVM.NotifySelectionChanged();
+    }
+
+    private void ElementBox_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        PickerVM.NotifySelectionChanged();
     }
 
     /// <summary>
-    ///     Rebuild ElementBox from the live model collections.
-    ///     Count &lt;= 1 means only the "(none)" placeholder — treat as empty.
+    /// Rebuild list from live model collections (ItemsSource is a snapshot).
+    /// Count &lt;= 1 means only the "(none)" placeholder.
     /// </summary>
     private void RefreshElementList(bool preserveSelection)
     {
         var preserve = preserveSelection ? PickerVM.SelectedElement as StoryElement : null;
 
-        StoryItemType type;
-        if (PickerVM.ForcedType == null)
+        if (!TryGetForcedOrSelectedType(out var type))
         {
-            var typeItem = PickerVM.SelectedType as ComboBoxItem;
-            if (typeItem == null)
-            {
-                ElementBox.ItemsSource = null;
-                ElementBox.IsEnabled = false;
-                return;
-            }
-
-            type = Enum.Parse<StoryItemType>(typeItem.Content.ToString()!, true);
-        }
-        else
-        {
-            type = (StoryItemType)PickerVM.ForcedType;
+            ElementBox.ItemsSource = null;
+            ElementBox.IsEnabled = false;
+            NewButton.IsEnabled = false;
+            return;
         }
 
         NewButton.IsEnabled = true;
 
         var elements = type switch
         {
-            StoryItemType.Problem => PickerVM.StoryModel.StoryElements.Problems,
-            StoryItemType.Character => PickerVM.StoryModel.StoryElements.Characters,
-            StoryItemType.Setting => PickerVM.StoryModel.StoryElements.Settings,
-            StoryItemType.Scene => PickerVM.StoryModel.StoryElements.Scenes,
+            StoryItemType.Problem => PickerVM.StoryModel?.StoryElements.Problems,
+            StoryItemType.Character => PickerVM.StoryModel?.StoryElements.Characters,
+            StoryItemType.Setting => PickerVM.StoryModel?.StoryElements.Settings,
+            StoryItemType.Scene => PickerVM.StoryModel?.StoryElements.Scenes,
             _ => null
         };
 
-        // Filtered collections include a "(none)" placeholder at index 0
         if (elements == null || elements.Count <= 1)
         {
             ElementBox.ItemsSource = null;
@@ -106,8 +97,8 @@ public sealed partial class ElementPicker : Page
             return;
         }
 
-        ElementBox.IsEnabled = true;
         var elementList = elements.Skip(1).ToList();
+        ElementBox.IsEnabled = true;
         ElementBox.ItemsSource = elementList;
 
         if (preserve != null)
@@ -119,5 +110,23 @@ public sealed partial class ElementPicker : Page
                 PickerVM.SelectedElement = match;
             }
         }
+    }
+
+    private bool TryGetForcedOrSelectedType(out StoryItemType type)
+    {
+        if (PickerVM.ForcedType != null)
+        {
+            type = (StoryItemType)PickerVM.ForcedType;
+            return true;
+        }
+
+        if (PickerVM.SelectedType is ComboBoxItem item && item.Content != null)
+        {
+            type = Enum.Parse<StoryItemType>(item.Content.ToString()!, true);
+            return true;
+        }
+
+        type = default;
+        return false;
     }
 }

--- a/StoryCADLib/Collaborator/Views/ElementPicker.xaml.cs
+++ b/StoryCADLib/Collaborator/Views/ElementPicker.xaml.cs
@@ -46,7 +46,7 @@ public sealed partial class ElementPicker : Page
         }
 
 
-        //Reset the UIs, so we can't enter an invalid state
+        // Reset selection; Create stays enabled for empty and non-empty lists.
         PickerVM.SelectedElement = null;
         ElementBox.ItemsSource = null;
         NewButton.IsEnabled = true;

--- a/StoryCADTests/Collaborator/ViewModels/ElementPickerVMTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/ElementPickerVMTests.cs
@@ -1,12 +1,17 @@
+using CommunityToolkit.Mvvm.DependencyInjection;
 using StoryCADLib.Collaborator.ViewModels;
 using StoryCADLib.Models;
+using StoryCADLib.Models.Tools;
+using StoryCADLib.Services.API;
+using StoryCADLib.Services.Outline;
+using ControlData = StoryCADLib.ViewModels.ControlData;
 
 #nullable disable
 
 namespace StoryCADTests.Collaborator.ViewModels;
 
 /// <summary>
-/// Unit tests for ElementPickerVM
+/// Unit tests for Collaborator ElementPickerVM
 /// </summary>
 [TestClass]
 public class ElementPickerVMTests
@@ -459,42 +464,116 @@ public class ElementPickerVMTests
 
     #endregion
 
+    #region ResolveSelectedGuid Tests
+
+    [TestMethod]
+    public void ResolveSelectedGuid_WhenNothingSelected_ReturnsNull()
+    {
+        _viewModel.SelectedElement = null;
+
+        Assert.IsNull(_viewModel.ResolveSelectedGuid());
+    }
+
+    [TestMethod]
+    public void ResolveSelectedGuid_WhenElementSelected_ReturnsUuidString()
+    {
+        var character = new CharacterModel("Hero", _storyModel, null);
+        _viewModel.SelectedElement = character;
+
+        Assert.AreEqual(character.Uuid.ToString(), _viewModel.ResolveSelectedGuid());
+    }
+
+    #endregion
+
     #region CreateNode Method Tests
 
     [TestMethod]
-    public void CreateNode_WhenCalled_DoesNotThrow()
+    public void CreateNode_WithoutApi_DoesNotThrow()
     {
-        // Arrange - CreateNode has commented-out implementation
         _viewModel.StoryModel = _storyModel;
         _viewModel.ForcedType = StoryItemType.Character;
         _viewModel.NewNodeName = "Test Node";
 
-        // Act & Assert - should not throw
         _viewModel.CreateNode();
+
+        Assert.IsNull(_viewModel.SelectedElement);
     }
 
     [TestMethod]
     public void CreateNode_WithoutForcedType_DoesNotThrow()
     {
-        // Arrange
         _viewModel.StoryModel = _storyModel;
         _viewModel.ForcedType = null;
         _viewModel.NewNodeName = "Test Node";
 
-        // Act & Assert
         _viewModel.CreateNode();
     }
 
     [TestMethod]
     public void CreateNode_WithoutStoryModel_DoesNotThrow()
     {
-        // Arrange
         _viewModel.StoryModel = null;
         _viewModel.ForcedType = StoryItemType.Scene;
         _viewModel.NewNodeName = "Test Scene";
 
-        // Act & Assert
         _viewModel.CreateNode();
+    }
+
+    [TestMethod]
+    public async Task CreateNode_WithApi_EmptyOutline_CreatesProblemAndSelectsIt()
+    {
+        var api = CreateApi();
+        var create = await api.CreateEmptyOutline("Picker Test", "Author", "0");
+        Assert.IsTrue(create.IsSuccess);
+        var model = api.CurrentModel;
+        var problemCountBefore = model.StoryElements.Count(e => e.ElementType == StoryItemType.Problem);
+
+        _viewModel.StoryModel = model;
+        _viewModel.ForcedType = StoryItemType.Problem;
+        _viewModel.NewNodeName = "Main Problem";
+        _viewModel.StoryApi = api;
+
+        _viewModel.CreateNode();
+
+        Assert.IsNotNull(_viewModel.SelectedElement);
+        var selected = (StoryElement)_viewModel.SelectedElement;
+        Assert.AreEqual("Main Problem", selected.Name);
+        Assert.AreEqual(StoryItemType.Problem, selected.ElementType);
+        Assert.AreEqual(problemCountBefore + 1,
+            model.StoryElements.Count(e => e.ElementType == StoryItemType.Problem));
+        Assert.AreEqual(selected.Uuid.ToString(), _viewModel.ResolveSelectedGuid());
+    }
+
+    [TestMethod]
+    public async Task CreateNode_WithApi_WhenProblemsExist_StillCreatesAnother()
+    {
+        var api = CreateApi();
+        var create = await api.CreateEmptyOutline("Picker Test 2", "Author", "0");
+        Assert.IsTrue(create.IsSuccess);
+        var model = api.CurrentModel;
+        var overview = model.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var existing = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "Existing Problem");
+        Assert.IsTrue(existing.IsSuccess);
+
+        _viewModel.StoryModel = model;
+        _viewModel.ForcedType = StoryItemType.Problem;
+        _viewModel.NewNodeName = "New Problem";
+        _viewModel.StoryApi = api;
+
+        _viewModel.CreateNode();
+
+        Assert.IsNotNull(_viewModel.SelectedElement);
+        Assert.AreEqual("New Problem", ((StoryElement)_viewModel.SelectedElement).Name);
+        Assert.AreEqual(2, model.StoryElements.Count(e => e.ElementType == StoryItemType.Problem));
+    }
+
+    private static StoryCADApi CreateApi()
+    {
+        return new StoryCADApi(
+            Ioc.Default.GetRequiredService<OutlineService>(),
+            Ioc.Default.GetRequiredService<ListData>(),
+            Ioc.Default.GetRequiredService<ControlData>(),
+            Ioc.Default.GetRequiredService<ToolsData>());
     }
 
     #endregion

--- a/StoryCADTests/Collaborator/ViewModels/ElementPickerVMTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/ElementPickerVMTests.cs
@@ -532,6 +532,8 @@ public class ElementPickerVMTests
         _viewModel.ForcedType = StoryItemType.Problem;
         _viewModel.NewNodeName = "Main Problem";
         _viewModel.StoryApi = api;
+        var afterCreateCalls = 0;
+        _viewModel.AfterCreate = () => afterCreateCalls++;
 
         _viewModel.CreateNode();
 
@@ -542,6 +544,8 @@ public class ElementPickerVMTests
         Assert.AreEqual(problemCountBefore + 1,
             model.StoryElements.Count(e => e.ElementType == StoryItemType.Problem));
         Assert.AreEqual(selected.Uuid.ToString(), _viewModel.ResolveSelectedGuid());
+        // Page uses this hook to rebuild the list (ItemsSource is a snapshot, not live binding).
+        Assert.AreEqual(1, afterCreateCalls);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

Fixes Collaborator **ElementPicker** for greenfield and normal picks (Collaborator #117).

### Problems fixed
1. **Create did nothing** — `GatherElementAsync` never passed `IStoryCADAPI` into `ShowPicker`.
2. **Select with empty selection crashed** — NRE on null `SelectedElement`.
3. **Create added to outline but list stayed empty** — list used a dead `ToList()` snapshot; empty list left the box disabled.
4. **Create button clipped / layout broken** — fixed-height ScrollViewer and intermediate layout thrash; restored list + Create at bottom with `MaxHeight`.
5. **Protagonist / Antagonist pickers skipped** — sequential `ContentDialog`s need a brief yield between shows.

### Behavior now
- **+ Create a new element** always available when a type is known (empty or non-empty list).
- Create refreshes the list, selects the new item, **leaves the dialog open**; user confirms with **Select**.
- **Select** disabled until an element is chosen.
- 100ms gap between pickers so Story Problem → Protagonist → Antagonist all appear.

Closes storybuilder-org/Collaborator#117 (product issue; code in StoryCAD).

### Not in this PR
- #118 StoryProblem links / Resolution fields  
- #115 Review Each, #116 overwrite policy, #120 InnerOuter  

## Manual test (verified by Terry)
1. Overview-only outline → Story Problem  
2. Create problem → appears selected → Select  
3. Protagonist and Antagonist pickers appear; create/select each  
4. Workflow runs only after those picks  

## Automated tests
- `ElementPickerVMTests`: create empty outline, create when items exist, null selection GUID, AfterCreate hook  

## Test plan
- [x] Manual greenfield Story Problem path  
- [x] ElementPickerVMTests green  
- [ ] CI on PR  