### PR TITLE
fix(#115): Review Each does not skip pending properties

### DIFF
--- a/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
@@ -349,22 +349,31 @@ public partial class WorkflowViewModel : ObservableRecipient
         ClearPendingUpdates();
     }
 
+    /// <summary>
+    /// After accept/skip, Collaborator removes the current key from PendingUpdates.
+    /// The next remaining item slides into the same index — do not increment, or we skip it.
+    /// </summary>
     private void AdvanceReview()
     {
-        if (CurrentReviewIndex >= PendingUpdates.Count - 1 || PendingUpdates.Count == 0)
+        if (PendingUpdates == null || PendingUpdates.Count == 0)
         {
-            // Done reviewing
             IsInReviewMode = false;
             ClearPendingUpdates();
+            return;
         }
-        else
+
+        // If index is past the end (accepted the last remaining item), finish.
+        if (CurrentReviewIndex >= PendingUpdates.Count)
         {
-            // Move to next
-            CurrentReviewIndex++;
-            OnPropertyChanged(nameof(CurrentReviewKey));
-            OnPropertyChanged(nameof(CurrentReviewValue));
-            OnPropertyChanged(nameof(ReviewProgress));
+            IsInReviewMode = false;
+            ClearPendingUpdates();
+            return;
         }
+
+        // Still have an item at CurrentReviewIndex (the next after remove). Refresh UI only.
+        OnPropertyChanged(nameof(CurrentReviewKey));
+        OnPropertyChanged(nameof(CurrentReviewValue));
+        OnPropertyChanged(nameof(ReviewProgress));
     }
 
     public void ClearPendingUpdates()

--- a/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
@@ -402,6 +402,108 @@ public class WorkflowViewModelTests
 
     #endregion
 
+    #region Review Each (issue #115)
+
+    /// <summary>
+    /// Simulates Collaborator: accept/skip removes the key then SetPendingUpdates.
+    /// </summary>
+    private void WireRemoveOnAcceptOrSkip(Dictionary<string, object> store)
+    {
+        _viewModel.OnAcceptProperty = key =>
+        {
+            store.Remove(key);
+            _viewModel.SetPendingUpdates(store);
+        };
+        _viewModel.OnSkipProperty = key =>
+        {
+            store.Remove(key);
+            _viewModel.SetPendingUpdates(store);
+        };
+    }
+
+    [TestMethod]
+    public void ReviewEach_AcceptCurrent_DoesNotSkipMiddleProperty()
+    {
+        // Arrange — three updates (Ideation: Description, Concept, Premise)
+        var store = new Dictionary<string, object>
+        {
+            ["Overview.Description"] = "idea",
+            ["Overview.Concept"] = "concept",
+            ["Overview.Premise"] = "premise"
+        };
+        _viewModel.SetPendingUpdates(store);
+        WireRemoveOnAcceptOrSkip(store);
+        _viewModel.ReviewEachCommand.Execute(null);
+
+        Assert.AreEqual("Overview.Description", _viewModel.CurrentReviewKey);
+
+        // Act — accept first, then whatever is shown next
+        _viewModel.AcceptCurrentCommand.Execute(null);
+        var secondKey = _viewModel.CurrentReviewKey;
+        _viewModel.AcceptCurrentCommand.Execute(null);
+        var thirdKey = _viewModel.CurrentReviewKey;
+
+        // Assert — middle must be offered; nothing silently dropped
+        Assert.AreEqual("Overview.Concept", secondKey, "After first accept, next should be Concept (not Premise).");
+        Assert.AreEqual("Overview.Premise", thirdKey, "After second accept, next should be Premise.");
+        Assert.IsTrue(_viewModel.IsInReviewMode);
+        Assert.AreEqual(1, store.Count);
+
+        _viewModel.AcceptCurrentCommand.Execute(null);
+        Assert.IsFalse(_viewModel.IsInReviewMode);
+        Assert.AreEqual(0, store.Count, "All three accepts must leave nothing discarded.");
+    }
+
+    [TestMethod]
+    public void ReviewEach_SkipCurrent_DoesNotDropRemaining()
+    {
+        var store = new Dictionary<string, object>
+        {
+            ["Overview.Description"] = "idea",
+            ["Overview.Concept"] = "concept",
+            ["Overview.Premise"] = "premise"
+        };
+        _viewModel.SetPendingUpdates(store);
+        WireRemoveOnAcceptOrSkip(store);
+        _viewModel.ReviewEachCommand.Execute(null);
+
+        _viewModel.SkipCurrentCommand.Execute(null); // skip Description
+        Assert.AreEqual("Overview.Concept", _viewModel.CurrentReviewKey);
+        Assert.AreEqual(2, store.Count);
+
+        _viewModel.AcceptCurrentCommand.Execute(null); // accept Concept
+        Assert.AreEqual("Overview.Premise", _viewModel.CurrentReviewKey);
+        Assert.AreEqual(1, store.Count);
+
+        _viewModel.AcceptCurrentCommand.Execute(null);
+        Assert.AreEqual(0, store.Count);
+        Assert.IsFalse(_viewModel.IsInReviewMode);
+    }
+
+    [TestMethod]
+    public void ReviewEach_AcceptLastOfTwo_DoesNotClearUnreviewed()
+    {
+        // Secondary bug: accept first of two remaining while index logic treated "done" early
+        var store = new Dictionary<string, object>
+        {
+            ["A"] = 1,
+            ["B"] = 2
+        };
+        _viewModel.SetPendingUpdates(store);
+        WireRemoveOnAcceptOrSkip(store);
+        _viewModel.ReviewEachCommand.Execute(null);
+
+        _viewModel.AcceptCurrentCommand.Execute(null);
+        Assert.AreEqual("B", _viewModel.CurrentReviewKey);
+        Assert.AreEqual(1, store.Count);
+        Assert.IsTrue(store.ContainsKey("B"));
+
+        _viewModel.AcceptCurrentCommand.Execute(null);
+        Assert.AreEqual(0, store.Count);
+    }
+
+    #endregion
+
     #region ObservableRecipient Tests
 
     [TestMethod]


### PR DESCRIPTION
## Summary

Fixes Collaborator **#115**: Review Each skipped/dropped property updates after Accept or Skip.

### Cause
`OnAcceptProperty` / `OnSkipProperty` remove the current key from `PendingUpdates`, then `AdvanceReview()` did `CurrentReviewIndex++`. The next item had already slid into that index, so ++ skipped it. Accepting near the end could also `ClearPendingUpdates()` and discard leftovers.

### Fix
After remove, **stay at the same index** and refresh the UI. Finish only when the pending set is empty (or the index is past the end).

### Tests
- `ReviewEach_AcceptCurrent_DoesNotSkipMiddleProperty`
- `ReviewEach_SkipCurrent_DoesNotDropRemaining`
- `ReviewEach_AcceptLastOfTwo_DoesNotClearUnreviewed`

### Manual check
Ideation with three updates (Description, Concept, Premise) → Review Each → Accept each → all three applied; none left empty without an explicit Skip.

Closes storybuilder-org/Collaborator#115 (code in StoryCAD).

## Test plan
- [x] Unit tests above
- [ ] Manual Review Each on Ideation (optional)
- [ ] CI green