### PR TITLE
fix(#118): StoryProblem links + Resolution (Outcome/Method/Theme)

### DIFF
--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -119,6 +119,9 @@ namespace StoryCollaborator.Workflows
                                 CreateIfMissing = false
                             }
                         },
+                        // Gather order: Problem, then cast. ReferencedElementLabel writes structural
+                        // GUID links at pick/create time (Collaborator #118): Overview.StoryProblem,
+                        // Problem.Protagonist, Problem.Antagonist — same path as GMC's references.
                         OptionalInputs = new List<ElementRequirement>
                         {
                             new ElementRequirement
@@ -126,21 +129,24 @@ namespace StoryCollaborator.Workflows
                                 ElementType = StoryItemType.Problem,
                                 ElementLabel = "Problem",
                                 RequiredProperties = new List<PropertySpec>(),
-                                CreateIfMissing = true
+                                CreateIfMissing = true,
+                                ReferencedElementLabel = "Overview.StoryProblem"
                             },
                             new ElementRequirement
                             {
                                 ElementType = StoryItemType.Character,
                                 ElementLabel = "Protagonist",
                                 RequiredProperties = new List<PropertySpec>(),
-                                CreateIfMissing = true
+                                CreateIfMissing = true,
+                                ReferencedElementLabel = "Problem.Protagonist"
                             },
                             new ElementRequirement
                             {
                                 ElementType = StoryItemType.Character,
                                 ElementLabel = "Antagonist",
                                 RequiredProperties = new List<PropertySpec>(),
-                                CreateIfMissing = true
+                                CreateIfMissing = true,
+                                ReferencedElementLabel = "Problem.Antagonist"
                             }
                         },
                         Outputs = new List<ElementOutput>
@@ -166,7 +172,11 @@ namespace StoryCollaborator.Workflows
                                     new PropertySpec("AntagGoal"),
                                     new PropertySpec("AntagMotive"),
                                     new PropertySpec("AntagConflict"),
-                                    new PropertySpec("Premise")
+                                    new PropertySpec("Premise"),
+                                    // Resolution tab (#118 option A)
+                                    new PropertySpec("Outcome"),
+                                    new PropertySpec("Method"),
+                                    new PropertySpec("Theme")
                                 },
         
                             },

--- a/StoryCADTests/Collaborator/StoryProblemRegistryTests.cs
+++ b/StoryCADTests/Collaborator/StoryProblemRegistryTests.cs
@@ -1,0 +1,67 @@
+using StoryCADLib.Models;
+using StoryCollaborator.Workflows;
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>
+/// Registry contract for Story Problem gather links (Collaborator #118).
+/// </summary>
+[TestClass]
+public class StoryProblemRegistryTests
+{
+    [TestMethod]
+    public void StoryProblem_OptionalInputs_WriteStructuralLinksOnGather()
+    {
+        var workflow = WorkflowRegistry.Get("StoryProblem");
+        Assert.IsNotNull(workflow);
+
+        var io = workflow.GetIO();
+        Assert.IsNotNull(io);
+
+        var problem = io.OptionalInputs.Single(i => i.ElementLabel == "Problem");
+        var protagonist = io.OptionalInputs.Single(i => i.ElementLabel == "Protagonist");
+        var antagonist = io.OptionalInputs.Single(i => i.ElementLabel == "Antagonist");
+
+        Assert.AreEqual("Overview.StoryProblem", problem.ReferencedElementLabel);
+        Assert.AreEqual(StoryItemType.Problem, problem.ElementType);
+
+        Assert.AreEqual("Problem.Protagonist", protagonist.ReferencedElementLabel);
+        Assert.AreEqual(StoryItemType.Character, protagonist.ElementType);
+
+        Assert.AreEqual("Problem.Antagonist", antagonist.ReferencedElementLabel);
+        Assert.AreEqual(StoryItemType.Character, antagonist.ElementType);
+    }
+
+    [TestMethod]
+    public void StoryProblem_GatherOrder_ProblemBeforeCast()
+    {
+        var io = WorkflowRegistry.Get("StoryProblem")!.GetIO();
+        var labels = io.OptionalInputs.Select(i => i.ElementLabel).ToList();
+
+        Assert.IsTrue(labels.IndexOf("Problem") < labels.IndexOf("Protagonist"));
+        Assert.IsTrue(labels.IndexOf("Protagonist") < labels.IndexOf("Antagonist"));
+    }
+
+    [TestMethod]
+    public void StoryProblem_RequiredOverview_HasNoStoryProblemReferenceCycle()
+    {
+        var io = WorkflowRegistry.Get("StoryProblem")!.GetIO();
+        var overview = io.RequiredInputs.Single(i => i.ElementLabel == "Overview");
+
+        Assert.AreEqual(StoryItemType.StoryOverview, overview.ElementType);
+        Assert.IsTrue(string.IsNullOrEmpty(overview.ReferencedElementLabel));
+    }
+
+    [TestMethod]
+    public void StoryProblem_ProblemOutputs_IncludeResolutionFields()
+    {
+        var io = WorkflowRegistry.Get("StoryProblem")!.GetIO();
+        var problemOut = io.Outputs.Single(o => o.ElementLabel == "Problem");
+        var props = problemOut.PropertiesToUpdate.Select(p => p.Property).ToHashSet();
+
+        Assert.IsTrue(props.Contains("Outcome"), "Outcome (Resolution tab)");
+        Assert.IsTrue(props.Contains("Method"), "Method (Resolution tab)");
+        Assert.IsTrue(props.Contains("Theme"), "Theme (Resolution tab)");
+        Assert.IsTrue(props.Contains("Premise"), "Premise stays on Problem outputs");
+    }
+}


### PR DESCRIPTION
## Summary

Collaborator **#118** (StoryCAD-side):

1. **Structural links** — StoryProblem optional inputs set `ReferencedElementLabel` so gather writes:
   - `Overview.StoryProblem`
   - `Problem.Protagonist` / `Problem.Antagonist`
2. **Resolution (option A)** — Problem outputs include `Outcome`, `Method`, `Theme`.

Worker prompt updates ship in a companion Collaborator PR (deploy required for live Resolution text).

## Tests
- `StoryProblemRegistryTests` (4)

## Test plan
- [x] Registry unit tests
- [ ] Manual Story Problem: links on Overview/Problem after pick/create
- [ ] After Worker deploy: Accept fills Resolution tab
- [ ] CI green

Closes part of storybuilder-org/Collaborator#118 (client half).