### PR TITLE
fix(#120): InnerOuter full form outputs and structural inject

### DIFF
--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -167,6 +167,10 @@ namespace StoryCollaborator
                 foreach (var pending in outputResult.PendingUpdates)
                     result.PendingUpdates.Add(pending);
 
+                // #120: structural fields the model must not invent (list value + GUIDs).
+                if (workflowModel.Label == "InnerOuterProblems")
+                    EnrichInnerOuterStructuralFields(result, gatheredElements);
+
                 if (!outputResult.Success)
                 {
                     result.Success = false;
@@ -284,6 +288,60 @@ namespace StoryCollaborator
                 ElementDescription = description,
                 Type = element.ElementType.ToString()
             };
+        }
+
+        /// <summary>
+        /// Issue #120: after JSON extract, set Inner Problem structure the model must not invent.
+        /// ConflictType is always Person vs. Self (Lists.json). Protagonist and Antagonist GUIDs
+        /// both equal the gathered Protagonist (self vs self). ProblemType Decision|Discover
+        /// comes from the model via PropertiesToUpdate.
+        /// </summary>
+        internal void EnrichInnerOuterStructuralFields(
+            WorkflowResult result,
+            Dictionary<string, StoryElement> gatheredElements)
+        {
+            if (!gatheredElements.TryGetValue("InnerProblem", out var inner))
+            {
+                result.StatusMessages.Add("InnerOuter structural enrich skipped: InnerProblem not gathered");
+                return;
+            }
+
+            // Fixed list value — do not trust free model text for ConflictType.
+            const string personVsSelf = "Person vs. Self";
+            AddOrReplaceScalarUpdate(result, "InnerProblem", inner.Uuid, "ConflictType", personVsSelf);
+
+            if (!gatheredElements.TryGetValue("Protagonist", out var protagonist))
+            {
+                result.StatusMessages.Add("InnerOuter structural enrich: Protagonist not gathered; links not set");
+                return;
+            }
+
+            var protGuid = protagonist.Uuid.ToString();
+            AddOrReplaceScalarUpdate(result, "InnerProblem", inner.Uuid, "Protagonist", protGuid);
+            AddOrReplaceScalarUpdate(result, "InnerProblem", inner.Uuid, "Antagonist", protGuid);
+            result.StatusMessages.Add(
+                $"InnerOuter structural enrich: ConflictType={personVsSelf}; Protagonist=Antagonist={protGuid}");
+        }
+
+        /// <summary>
+        /// Injects or replaces a scalar PendingUpdate and its UpdatedProperties display entry.
+        /// </summary>
+        private static void AddOrReplaceScalarUpdate(
+            WorkflowResult result,
+            string elementLabel,
+            Guid elementUuid,
+            string property,
+            string value)
+        {
+            var key = $"{elementLabel}.{property}";
+            result.PendingUpdates.RemoveAll(u =>
+                u.ElementLabel == elementLabel && u.Spec.Property == property);
+            result.PendingUpdates.Add(new PendingUpdate(
+                elementLabel,
+                elementUuid,
+                new PropertySpec(property),
+                value));
+            result.UpdatedProperties[key] = value;
         }
 
         /// <summary>

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -334,6 +334,9 @@ namespace StoryCollaborator.Workflows
                         },
                         Outputs = new List<ElementOutput>
                         {
+                            // #120: full Inner Problem form + Protagonist.Flaw.
+                            // ConflictType + Protagonist/Antagonist GUIDs are injected after
+                            // extract (Person vs. Self; both links = gathered Protagonist).
                             new ElementOutput
                             {
                                 ElementType = StoryItemType.Problem,
@@ -343,7 +346,25 @@ namespace StoryCollaborator.Workflows
                                     new PropertySpec("Description", JsonKey: "InnerProblemDescription"),
                                     new PropertySpec("Theme", JsonKey: "theme_connection"),
                                     new PropertySpec("Method", JsonKey: "resolution_path"),
-                                    new PropertySpec("Notes", JsonKey: "explanation")
+                                    new PropertySpec("Notes", JsonKey: "explanation"),
+                                    // Craft: inner problem is usually something to decide or discover
+                                    // (Defining_Problems / Problem and Character Process).
+                                    new PropertySpec("ProblemType"),
+                                    new PropertySpec("ProtGoal"),
+                                    new PropertySpec("ProtMotive"),
+                                    new PropertySpec("ProtConflict"),
+                                    new PropertySpec("AntagGoal"),
+                                    new PropertySpec("AntagMotive"),
+                                    new PropertySpec("AntagConflict")
+                                }
+                            },
+                            new ElementOutput
+                            {
+                                ElementType = StoryItemType.Character,
+                                ElementLabel = "Protagonist",
+                                PropertiesToUpdate = new List<PropertySpec>
+                                {
+                                    new PropertySpec("Flaw")
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- Expand InnerOuterProblems outputs: ProblemType, six GMC fields, Protagonist.Flaw
- After extract, inject ConflictType = Person vs. Self and Protagonist = Antagonist = gathered Protagonist UUID
- Client-side structural apply so the model cannot invent list values or GUIDs

## Test plan
- [x] StoryCAD solution builds (Debug/x64)
- [x] Collaborator tests: registry contract + EnrichInnerOuterStructuralFields (with/without Protagonist)
- [x] EveryScalarOutput_IsWritableApiProperty
- [x] Manual: Accept All InnerOuterProblems with Outer + Inner + Protagonist; verify ConflictType, links, GMC, Flaw (needs Collaborator Worker deploy)

Depends on Collaborator PR for Worker prompt/schema + tests.