### PR TITLE
fix(#116): protect user-owned fields; craft-backed ConflictType

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -43,6 +44,13 @@ public class Collaborator : ICollaborator
     private Window? _hostWindow;
     private bool _disposed;
     private StoryCADLib.Services.Logging.ILogService? _auditLogger;
+
+    /// <summary>
+    /// Issue #116: fields Collaborator successfully wrote this plugin session
+    /// (SessionTouchKey = "{uuid:N}.{Property}"). Not persisted across app restarts.
+    /// </summary>
+    private readonly HashSet<string> _sessionTouchedFields =
+        new(StringComparer.OrdinalIgnoreCase);
 
     // Settings
     private CollaboratorSettings _settings = CollaboratorSettings.Default;
@@ -505,16 +513,23 @@ public class Collaborator : ICollaborator
                 $"Workflow started: {workflow.Title} with {gatheredElements.Count} elements");
             var result = await runner.RunAsync(gatheredElements);
 
+            // #116: classify scalars against live outline + session-touch (after extract/enrich).
+            if (result.Success)
+                runner.ClassifyScalarUpdates(result, _sessionTouchedFields, workflow.Label);
+
             // Hide progress
             viewModel.ProgressVisibility = Microsoft.UI.Xaml.Visibility.Collapsed;
 
             if (result.Success)
             {
-                // Show status messages
+                // Show status messages (omit noisy per-field classify lines from chat)
                 viewModel.ConversationList.Add(ChatMessage.FromCollaborator($"Workflow completed successfully."));
 
                 foreach (var msg in result.StatusMessages)
                 {
+                    if (msg.StartsWith("Classified ", StringComparison.Ordinal)
+                        || msg.StartsWith("No-op ", StringComparison.Ordinal))
+                        continue;
                     viewModel.ConversationList.Add(ChatMessage.FromCollaborator($"  {msg}"));
                 }
 
@@ -529,50 +544,93 @@ public class Collaborator : ICollaborator
                 }
 
                 // If there are property updates, populate the pending updates panel
-                if (result.UpdatedProperties.Count > 0)
+                if (result.PendingUpdates.Count > 0)
                 {
-                    // Populate ViewModel's pending updates panel
-                    viewModel.SetPendingUpdates(result.UpdatedProperties);
+                    PushPendingToViewModel(viewModel, result);
 
                     // Wire up command callbacks using closures (captures local state)
                     viewModel.OnAcceptAll = () =>
                     {
                         try
                         {
-                            var count = runner.ApplyUpdates(result, gatheredElements);
+                            var free = result.PendingUpdates.Where(WorkflowRunner.AcceptAllMayApply).ToList();
+                            var protect = result.PendingUpdates
+                                .Where(u => u.Kind == UpdateKind.Protect)
+                                .ToList();
 
-                            // Build detailed message listing applied updates for chat log
-                            var sb = new System.Text.StringBuilder();
-                            sb.AppendLine($"Applied {count} property updates to your outline:");
-                            sb.AppendLine();
-                            foreach (var kvp in result.UpdatedProperties)
+                            var applySlice = WorkflowResult.Succeeded();
+                            foreach (var u in free)
+                                applySlice.PendingUpdates.Add(u);
+
+                            var count = free.Count == 0
+                                ? 0
+                                : runner.ApplyUpdates(applySlice, gatheredElements);
+
+                            foreach (var u in free)
+                                _sessionTouchedFields.Add(u.SessionTouchKey);
+
+                            // Rebuild remaining pending = Protect only
+                            result.PendingUpdates.Clear();
+                            result.UpdatedProperties.Clear();
+                            foreach (var u in protect)
                             {
-                                var valuePreview = kvp.Value?.ToString() ?? "(empty)";
-                                // Truncate long values for readability
-                                if (valuePreview.Length > 200)
-                                    valuePreview = valuePreview.Substring(0, 200) + "...";
-                                sb.AppendLine($"**{kvp.Key}**: {valuePreview}");
-                                sb.AppendLine();
+                                result.PendingUpdates.Add(u);
+                                result.UpdatedProperties[u.Key] = u.Value ?? string.Empty;
                             }
+
+                            var sb = new System.Text.StringBuilder();
+                            if (count > 0)
+                            {
+                                sb.AppendLine($"Applied {count} update(s) to your outline:");
+                                sb.AppendLine();
+                                foreach (var u in free)
+                                {
+                                    var valuePreview = TruncateForChat(u.Value?.ToString());
+                                    sb.AppendLine($"**{u.Key}**: {valuePreview}");
+                                    sb.AppendLine();
+                                }
+                            }
+                            else
+                            {
+                                sb.AppendLine("No free updates to apply (nothing empty or already written by Collaborator this session).");
+                            }
+
+                            if (protect.Count > 0)
+                            {
+                                sb.AppendLine();
+                                sb.AppendLine(
+                                    $"Left {protect.Count} alone because those fields already have your content. " +
+                                    "Use Review Each to keep or replace them.");
+                                foreach (var u in protect)
+                                {
+                                    sb.AppendLine($"- **{u.Key}** (yours vs proposed)");
+                                    if (!string.IsNullOrWhiteSpace(u.CraftExplanation))
+                                        sb.AppendLine($"  {u.CraftExplanation}");
+                                }
+                            }
+
                             viewModel.ConversationList.Add(ChatMessage.FromCollaborator(sb.ToString().TrimEnd()));
-                            _logger?.LogInformation("AcceptAll: Applied {Count} property updates", count);
+                            _logger?.LogInformation(
+                                "AcceptAll: Applied {Count}, protected {Protected}", count, protect.Count);
                             _auditLogger?.Log(StoryCADLib.Services.Logging.LogLevel.Info,
                                 $"Applied {count} updates from workflow: {workflow.Title}");
 
-                            // Mark updates as applied (keeps panel visible in applied state)
-                            viewModel.MarkUpdatesApplied();
+                            if (protect.Count == 0)
+                            {
+                                viewModel.MarkUpdatesApplied();
+                            }
+                            else
+                            {
+                                PushPendingToViewModel(viewModel, result);
+                            }
 
-                            // Refresh StoryCAD UI to show changes
                             _storyModel?.RefreshCurrentView();
 
-                            // Auto-save to bypass ViewModel flush (Issue #55)
                             _ = Task.Run(async () =>
                             {
                                 var saved = await SaveAsync();
                                 if (saved)
-                                {
                                     _logger?.LogInformation("Auto-save completed after Accept All");
-                                }
                             });
                         }
                         catch (Exception ex)
@@ -588,8 +646,6 @@ public class Collaborator : ICollaborator
                         {
                             viewModel.ClearPendingUpdates();
                             viewModel.ConversationList.Add(ChatMessage.FromCollaborator("Re-running workflow..."));
-
-                            // Re-execute with the same elements
                             await ExecuteWorkflowWithFeedback(viewModel, workflow, gatheredElements);
                         }
                         catch (Exception ex)
@@ -609,50 +665,38 @@ public class Collaborator : ICollaborator
 
                         try
                         {
-                            if (!result.UpdatedProperties.TryGetValue(propertyKey, out var value))
+                            var pending = result.PendingUpdates
+                                .FirstOrDefault(u => string.Equals(u.Key, propertyKey, StringComparison.OrdinalIgnoreCase));
+                            if (pending == null)
                             {
                                 _logger?.LogWarning("Property key not found in pending updates: {Key}", propertyKey);
                                 return;
                             }
 
-                            // Parse key format: "ElementLabel.PropertyName"
-                            var parts = propertyKey.Split('.', 2);
-                            if (parts.Length != 2)
+                            var single = WorkflowResult.Succeeded();
+                            single.PendingUpdates.Add(pending);
+                            var applied = runner.ApplyUpdates(single, gatheredElements);
+
+                            if (applied > 0)
                             {
-                                _logger?.LogWarning("Invalid property key format: {Key}", propertyKey);
-                                return;
-                            }
-
-                            var elementLabel = parts[0];
-                            var propName = parts[1];
-
-                            if (!gatheredElements.TryGetValue(elementLabel, out var element))
-                            {
-                                _logger?.LogWarning("Element not found for property update: {Label}", elementLabel);
-                                return;
-                            }
-
-                            // Apply via API
-                            var updateResult = _storyApi?.UpdateElementProperty(element.Uuid, propName, value);
-
-                            if (updateResult?.IsSuccess == true)
-                            {
+                                _sessionTouchedFields.Add(pending.SessionTouchKey);
                                 viewModel.ConversationList.Add(ChatMessage.FromCollaborator($"Applied {propertyKey}"));
                                 _logger?.LogInformation("AcceptProperty: Applied {Key}", propertyKey);
                                 _auditLogger?.Log(StoryCADLib.Services.Logging.LogLevel.Info,
                                     $"Applied update: {propertyKey}");
 
-                                // Remove from pending updates to prevent duplicate application
+                                result.PendingUpdates.RemoveAll(u =>
+                                    string.Equals(u.Key, propertyKey, StringComparison.OrdinalIgnoreCase));
                                 result.UpdatedProperties.Remove(propertyKey);
-                                viewModel.SetPendingUpdates(result.UpdatedProperties);
+                                PushPendingToViewModel(viewModel, result);
 
-                                // Refresh StoryCAD UI to show changes
                                 _storyModel?.RefreshCurrentView();
                             }
                             else
                             {
-                                viewModel.ConversationList.Add(ChatMessage.Error($"Failed to apply {propertyKey}: {updateResult?.ErrorMessage}"));
-                                _logger?.LogWarning("Failed to apply {Key}: {Error}", propertyKey, updateResult?.ErrorMessage);
+                                viewModel.ConversationList.Add(
+                                    ChatMessage.Error($"Failed to apply {propertyKey}"));
+                                _logger?.LogWarning("Failed to apply {Key}", propertyKey);
                             }
                         }
                         catch (Exception ex)
@@ -672,14 +716,14 @@ public class Collaborator : ICollaborator
 
                         try
                         {
-                            // Remove from pending updates without applying
-                            if (result.UpdatedProperties.Remove(propertyKey))
+                            var removed = result.PendingUpdates.RemoveAll(u =>
+                                string.Equals(u.Key, propertyKey, StringComparison.OrdinalIgnoreCase));
+                            result.UpdatedProperties.Remove(propertyKey);
+                            if (removed > 0)
                             {
                                 viewModel.ConversationList.Add(ChatMessage.FromCollaborator($"Skipped {propertyKey}"));
                                 _logger?.LogInformation("SkipProperty: Skipped {Key}", propertyKey);
-
-                                // Update the pending updates panel
-                                viewModel.SetPendingUpdates(result.UpdatedProperties);
+                                PushPendingToViewModel(viewModel, result);
                             }
                             else
                             {
@@ -693,8 +737,57 @@ public class Collaborator : ICollaborator
                         }
                     };
 
+                    // Accept Remaining: only free rows (Fill/Refresh/Unclassified); leave Protect.
+                    viewModel.OnAcceptRemainingFree = () =>
+                    {
+                        try
+                        {
+                            var free = result.PendingUpdates.Where(WorkflowRunner.AcceptAllMayApply).ToList();
+                            if (free.Count == 0)
+                            {
+                                viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
+                                    "No remaining free updates. Use Accept or Skip on each protected field."));
+                                return;
+                            }
+
+                            var applySlice = WorkflowResult.Succeeded();
+                            foreach (var u in free)
+                                applySlice.PendingUpdates.Add(u);
+                            var count = runner.ApplyUpdates(applySlice, gatheredElements);
+                            foreach (var u in free)
+                                _sessionTouchedFields.Add(u.SessionTouchKey);
+
+                            var freeKeys = free.Select(u => u.Key).ToHashSet(StringComparer.OrdinalIgnoreCase);
+                            result.PendingUpdates.RemoveAll(u => freeKeys.Contains(u.Key));
+                            foreach (var key in freeKeys)
+                                result.UpdatedProperties.Remove(key);
+
+                            viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
+                                $"Applied {count} free update(s). " +
+                                (result.PendingUpdates.Count > 0
+                                    ? $"{result.PendingUpdates.Count} protected field(s) still need Accept or Skip."
+                                    : "All done.")));
+
+                            if (result.PendingUpdates.Count == 0)
+                                viewModel.MarkUpdatesApplied();
+                            else
+                                PushPendingToViewModel(viewModel, result);
+
+                            _storyModel?.RefreshCurrentView();
+                        }
+                        catch (Exception ex)
+                        {
+                            viewModel.ConversationList.Add(ChatMessage.Error($"Error applying remaining: {ex.Message}"));
+                            _logger?.LogError(ex, "Error in AcceptRemainingFree handler");
+                        }
+                    };
+
+                    var fillCount = result.PendingUpdates.Count(u => u.Kind is UpdateKind.Fill or UpdateKind.Refresh or UpdateKind.Unclassified);
+                    var protectCount = result.PendingUpdates.Count(u => u.Kind == UpdateKind.Protect);
                     viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
-                        $"Found {result.UpdatedProperties.Count} property updates. Review them above and choose Accept All, Review Each, or Try Again."));
+                        $"Found {result.PendingUpdates.Count} property update(s) " +
+                        $"({fillCount} ready for Accept All, {protectCount} need your OK because the field already has text). " +
+                        "Choose Accept All, Review Each, or Try Again."));
                 }
                 else
                 {
@@ -721,6 +814,55 @@ public class Collaborator : ICollaborator
             viewModel.ConversationList.Add(ChatMessage.Error($"Error executing workflow: {ex.Message}"));
             _logger?.LogError(ex, "Error executing workflow {Workflow}", workflow.Title);
         }
+    }
+
+    /// <summary>
+    /// Pushes classified pending updates into the workflow panel (issue #116).
+    /// </summary>
+    private static void PushPendingToViewModel(
+        StoryCADLib.Collaborator.ViewModels.WorkflowViewModel viewModel,
+        WorkflowResult result)
+    {
+        var items = result.PendingUpdates.Select(ToPendingUpdateItem).ToList();
+        viewModel.SetPendingUpdates(items);
+    }
+
+    private static PendingUpdateItem ToPendingUpdateItem(PendingUpdate u)
+    {
+        var proposed = TruncateForChat(u.Value?.ToString() ?? string.Empty, 300);
+        var current = TruncateForChat(u.CurrentDisplay ?? string.Empty, 300);
+        var kindLabel = u.Kind switch
+        {
+            UpdateKind.Fill => "New",
+            UpdateKind.Refresh => "Refresh",
+            UpdateKind.Protect => "Has your text",
+            UpdateKind.Unclassified => "Update",
+            _ => u.Kind.ToString()
+        };
+        var summary = u.Kind == UpdateKind.Protect
+            ? $"{kindLabel} — review before replace"
+            : kindLabel;
+        if (!string.IsNullOrWhiteSpace(u.CraftExplanation) && u.Kind == UpdateKind.Protect)
+            summary += " (craft note)";
+
+        return new PendingUpdateItem
+        {
+            Key = u.Key,
+            ProposedDisplay = string.IsNullOrEmpty(proposed) ? "(empty)" : proposed,
+            CurrentDisplay = current,
+            KindLabel = kindLabel,
+            IsProtected = u.Kind == UpdateKind.Protect,
+            CraftExplanation = u.CraftExplanation,
+            SummaryLine = summary
+        };
+    }
+
+    private static string TruncateForChat(string? text, int max = 200)
+    {
+        var value = text ?? "(empty)";
+        if (value.Length > max)
+            return value.Substring(0, max) + "...";
+        return value;
     }
 
     /// <summary>

--- a/CollaboratorLib/Models/CraftFieldHints.cs
+++ b/CollaboratorLib/Models/CraftFieldHints.cs
@@ -1,0 +1,49 @@
+namespace StoryCollaborator.Models;
+
+/// <summary>
+/// Optional craft recommendation for a workflow output field (issue #116).
+/// Not every short-list field is craft-backed — only entries listed here.
+/// Preferred values must already exist in StoryCAD Lists.json.
+/// </summary>
+public sealed record CraftFieldHint(
+    string WorkflowId,
+    string ElementLabel,
+    string Property,
+    IReadOnlyList<string> PreferredValues,
+    string Explanation);
+
+/// <summary>
+/// Static craft hints. Keep small and explicit; do not auto-derive from all short-lists.
+/// </summary>
+public static class CraftFieldHints
+{
+    public static readonly CraftFieldHint InnerProblemConflictType = new(
+        WorkflowId: "InnerOuterProblems",
+        ElementLabel: "InnerProblem",
+        Property: "ConflictType",
+        PreferredValues: new[] { "Person vs. Self" },
+        Explanation:
+            "Inner problems are often Person vs. Self because the main struggle is inside the character. " +
+            "Another list value can still be right when the dilemma is about a person or group " +
+            "(for example orders, loyalty, or shame in front of others). Keep your value, or use the craft default.");
+
+    private static readonly CraftFieldHint[] All =
+    {
+        InnerProblemConflictType
+    };
+
+    public static CraftFieldHint? Find(string workflowId, string elementLabel, string property)
+    {
+        foreach (var hint in All)
+        {
+            if (string.Equals(hint.WorkflowId, workflowId, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(hint.ElementLabel, elementLabel, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(hint.Property, property, StringComparison.OrdinalIgnoreCase))
+            {
+                return hint;
+            }
+        }
+
+        return null;
+    }
+}

--- a/CollaboratorLib/Models/PropertySpec.cs
+++ b/CollaboratorLib/Models/PropertySpec.cs
@@ -30,16 +30,47 @@ namespace StoryCollaborator.Models
         Type? ListEntryType = null);
 
     /// <summary>
+    /// How a scalar pending update relates to the live outline field (issue #116).
+    /// Non-scalar updates stay <see cref="Unclassified"/> and Accept All may apply them.
+    /// </summary>
+    public enum UpdateKind
+    {
+        /// <summary>Not classified (non-scalar or pre-classify).</summary>
+        Unclassified = 0,
+        /// <summary>Target empty — Accept All may fill.</summary>
+        Fill,
+        /// <summary>Collaborator wrote this field earlier this session — Accept All may refresh.</summary>
+        Refresh,
+        /// <summary>User-owned non-empty differs — Review Each only; Accept All skips.</summary>
+        Protect,
+        /// <summary>Proposed equals current — dropped from pending.</summary>
+        NoOp
+    }
+
+    /// <summary>
     /// Carries one extracted output value between ExtractOutputs and ApplyUpdates.
     /// Value type by WriteVia: Scalar=string, SimpleList=List&lt;string&gt;,
     /// BeatSheet=List&lt;BeatInfo&gt;, CastMembers=List&lt;Guid&gt;,
     /// Relationships=List&lt;RelationshipInfo&gt;, TypedList=null.
+    /// Optional classification fields are set by <c>ClassifyScalarUpdates</c> (#116).
     /// </summary>
     public sealed record PendingUpdate(
         string ElementLabel,
         Guid ElementUuid,
         PropertySpec Spec,
-        object? Value);
+        object? Value,
+        UpdateKind Kind = UpdateKind.Unclassified,
+        string? CurrentDisplay = null,
+        string? CraftExplanation = null)
+    {
+        public string Key => $"{ElementLabel}.{Spec.Property}";
+
+        /// <summary>Stable session key: element UUID + property (survives label renames).</summary>
+        public string SessionTouchKey => $"{ElementUuid:N}.{Spec.Property}";
+
+        public bool AcceptAllMayApply =>
+            Kind is UpdateKind.Fill or UpdateKind.Refresh or UpdateKind.Unclassified;
+    }
 
     /// <summary>
     /// One beat in a BeatSheet output.

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -304,7 +304,9 @@ namespace StoryCollaborator
         {
             if (!gatheredElements.TryGetValue("InnerProblem", out var inner))
             {
-                result.StatusMessages.Add("InnerOuter structural enrich skipped: InnerProblem not gathered");
+                const string skip = "InnerOuter structural enrich skipped: InnerProblem not gathered";
+                result.StatusMessages.Add(skip);
+                _logger?.LogInformation("{Message}", skip);
                 return;
             }
 
@@ -314,15 +316,21 @@ namespace StoryCollaborator
 
             if (!gatheredElements.TryGetValue("Protagonist", out var protagonist))
             {
-                result.StatusMessages.Add("InnerOuter structural enrich: Protagonist not gathered; links not set");
+                var partial =
+                    $"InnerOuter structural enrich: ConflictType proposed={personVsSelf}; Protagonist not gathered; links not set";
+                result.StatusMessages.Add(partial);
+                _logger?.LogInformation("{Message}", partial);
                 return;
             }
 
             var protGuid = protagonist.Uuid.ToString();
             AddOrReplaceScalarUpdate(result, "InnerProblem", inner.Uuid, "Protagonist", protGuid);
             AddOrReplaceScalarUpdate(result, "InnerProblem", inner.Uuid, "Antagonist", protGuid);
-            result.StatusMessages.Add(
-                $"InnerOuter structural enrich: ConflictType={personVsSelf}; Protagonist=Antagonist={protGuid}");
+            var enrichMsg =
+                $"InnerOuter structural enrich: ConflictType proposed={personVsSelf}; Protagonist=Antagonist={protGuid}";
+            result.StatusMessages.Add(enrichMsg);
+            // Preferences log (not chat): durable record for #116 craft/overwrite diagnosis.
+            _logger?.LogInformation("{Message}", enrichMsg);
         }
 
         /// <summary>
@@ -341,6 +349,14 @@ namespace StoryCollaborator
 
             var kept = new List<PendingUpdate>();
             var display = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            var noOpCount = 0;
+            var protectCount = 0;
+            var fillCount = 0;
+            var refreshCount = 0;
+
+            _logger?.LogInformation(
+                "ClassifyScalarUpdates start: workflow={Workflow} pending={Count} sessionTouched={Touched}",
+                workflowId, result.PendingUpdates.Count, sessionTouched.Count);
 
             foreach (var update in result.PendingUpdates)
             {
@@ -348,6 +364,9 @@ namespace StoryCollaborator
                 {
                     kept.Add(update);
                     display[update.Key] = FormatDisplayValue(update);
+                    _logger?.LogInformation(
+                        "Classify {Key} kind=Unclassified (non-scalar WriteVia={WriteVia})",
+                        update.Key, update.Spec.WriteVia);
                     continue;
                 }
 
@@ -365,10 +384,26 @@ namespace StoryCollaborator
                 else
                     kind = UpdateKind.Protect;
 
+                // Preferences log: kind + values so NoOp/Protect is diagnosable without chat.
+                _logger?.LogInformation(
+                    "Classify {Key} kind={Kind} current=\"{Current}\" proposed=\"{Proposed}\"",
+                    update.Key,
+                    kind,
+                    TruncateForLog(current),
+                    TruncateForLog(proposed));
+
                 if (kind == UpdateKind.NoOp)
                 {
+                    noOpCount++;
                     result.StatusMessages.Add($"No-op (unchanged): {update.Key}");
                     continue;
+                }
+
+                switch (kind)
+                {
+                    case UpdateKind.Fill: fillCount++; break;
+                    case UpdateKind.Refresh: refreshCount++; break;
+                    case UpdateKind.Protect: protectCount++; break;
                 }
 
                 string? craft = null;
@@ -392,6 +427,19 @@ namespace StoryCollaborator
             result.UpdatedProperties.Clear();
             foreach (var kvp in display)
                 result.UpdatedProperties[kvp.Key] = kvp.Value;
+
+            _logger?.LogInformation(
+                "ClassifyScalarUpdates done: kept={Kept} fill={Fill} refresh={Refresh} protect={Protect} noop={NoOp}",
+                kept.Count, fillCount, refreshCount, protectCount, noOpCount);
+        }
+
+        /// <summary>Shorten long prose for the Preferences log; keep list values intact when short.</summary>
+        private static string TruncateForLog(string? text, int max = 120)
+        {
+            if (string.IsNullOrEmpty(text))
+                return "";
+            var t = text.Replace('\r', ' ').Replace('\n', ' ');
+            return t.Length <= max ? t : t.Substring(0, max) + "...";
         }
 
         /// <summary>

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -168,6 +168,7 @@ namespace StoryCollaborator
                     result.PendingUpdates.Add(pending);
 
                 // #120: structural fields the model must not invent (list value + GUIDs).
+                // Proposes into pending only; #116 classify decides Fill vs Protect (never silent force).
                 if (workflowModel.Label == "InnerOuterProblems")
                     EnrichInnerOuterStructuralFields(result, gatheredElements);
 
@@ -291,10 +292,11 @@ namespace StoryCollaborator
         }
 
         /// <summary>
-        /// Issue #120: after JSON extract, set Inner Problem structure the model must not invent.
-        /// ConflictType is always Person vs. Self (Lists.json). Protagonist and Antagonist GUIDs
-        /// both equal the gathered Protagonist (self vs self). ProblemType Decision|Discover
-        /// comes from the model via PropertiesToUpdate.
+        /// Issue #120 / #116: after JSON extract, propose Inner Problem structure the model must not invent.
+        /// ConflictType is proposed as Person vs. Self (Lists.json craft default). Protagonist and
+        /// Antagonist GUIDs both equal the gathered Protagonist (self vs self). These land in pending
+        /// only; <see cref="ClassifyScalarUpdates"/> decides Fill vs Protect — Accept never silent-forces
+        /// a user-owned different value. ProblemType Decision|Discover comes from the model.
         /// </summary>
         internal void EnrichInnerOuterStructuralFields(
             WorkflowResult result,
@@ -306,7 +308,7 @@ namespace StoryCollaborator
                 return;
             }
 
-            // Fixed list value — do not trust free model text for ConflictType.
+            // Craft default list value — do not trust free model text for ConflictType.
             const string personVsSelf = "Person vs. Self";
             AddOrReplaceScalarUpdate(result, "InnerProblem", inner.Uuid, "ConflictType", personVsSelf);
 
@@ -321,6 +323,129 @@ namespace StoryCollaborator
             AddOrReplaceScalarUpdate(result, "InnerProblem", inner.Uuid, "Antagonist", protGuid);
             result.StatusMessages.Add(
                 $"InnerOuter structural enrich: ConflictType={personVsSelf}; Protagonist=Antagonist={protGuid}");
+        }
+
+        /// <summary>
+        /// Issue #116: classify scalar pending updates against live outline values and session-touch set.
+        /// Drops NoOps. Attaches craft explanation on Protect when a <see cref="CraftFieldHints"/> entry exists.
+        /// Non-scalar updates stay <see cref="UpdateKind.Unclassified"/>.
+        /// </summary>
+        /// <param name="sessionTouched">Keys from <see cref="PendingUpdate.SessionTouchKey"/> applied this Collaborator session.</param>
+        internal void ClassifyScalarUpdates(
+            WorkflowResult result,
+            ISet<string>? sessionTouched,
+            string? workflowId = null)
+        {
+            workflowId ??= workflowModel.Label;
+            sessionTouched ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            var kept = new List<PendingUpdate>();
+            var display = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var update in result.PendingUpdates)
+            {
+                if (update.Spec.WriteVia != WriteVia.Scalar)
+                {
+                    kept.Add(update);
+                    display[update.Key] = FormatDisplayValue(update);
+                    continue;
+                }
+
+                var currentRaw = ReadCurrentScalarDisplay(update.ElementUuid, update.Spec.Property);
+                var current = NormalizeCompareText(currentRaw);
+                var proposed = NormalizeCompareText(FormatDisplayValue(update));
+
+                UpdateKind kind;
+                if (string.Equals(current, proposed, StringComparison.OrdinalIgnoreCase))
+                    kind = UpdateKind.NoOp;
+                else if (string.IsNullOrEmpty(current))
+                    kind = UpdateKind.Fill;
+                else if (sessionTouched.Contains(update.SessionTouchKey))
+                    kind = UpdateKind.Refresh;
+                else
+                    kind = UpdateKind.Protect;
+
+                if (kind == UpdateKind.NoOp)
+                {
+                    result.StatusMessages.Add($"No-op (unchanged): {update.Key}");
+                    continue;
+                }
+
+                string? craft = null;
+                var hint = CraftFieldHints.Find(workflowId, update.ElementLabel, update.Spec.Property);
+                if (hint != null && kind == UpdateKind.Protect)
+                    craft = hint.Explanation;
+
+                var classified = update with
+                {
+                    Kind = kind,
+                    CurrentDisplay = string.IsNullOrEmpty(currentRaw) ? string.Empty : currentRaw,
+                    CraftExplanation = craft
+                };
+                kept.Add(classified);
+                display[classified.Key] = FormatDisplayValue(classified);
+                result.StatusMessages.Add($"Classified {classified.Key} as {kind}");
+            }
+
+            result.PendingUpdates.Clear();
+            result.PendingUpdates.AddRange(kept);
+            result.UpdatedProperties.Clear();
+            foreach (var kvp in display)
+                result.UpdatedProperties[kvp.Key] = kvp.Value;
+        }
+
+        /// <summary>
+        /// True when Accept All may apply this update without an explicit per-field accept.
+        /// </summary>
+        internal static bool AcceptAllMayApply(PendingUpdate update) => update.AcceptAllMayApply;
+
+        private string ReadCurrentScalarDisplay(Guid elementUuid, string propertyName)
+        {
+            var got = _storyApi.GetStoryElement(elementUuid);
+            if (!got.IsSuccess || got.Payload == null)
+                return string.Empty;
+
+            var element = got.Payload;
+            var property = element.GetType().GetProperty(propertyName);
+            if (property == null || !property.CanRead)
+                return string.Empty;
+
+            var value = property.GetValue(element);
+            if (value == null)
+                return string.Empty;
+
+            if (value is Guid g)
+                return g == Guid.Empty ? string.Empty : g.ToString();
+
+            var text = value.ToString() ?? string.Empty;
+            if (text.StartsWith(@"{\rtf", StringComparison.Ordinal))
+                text = new RichTextStripper().StripRichTextFormat(text) ?? string.Empty;
+
+            return text.Trim();
+        }
+
+        private static string NormalizeCompareText(string? text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+                return string.Empty;
+            return text.Trim();
+        }
+
+        private static string FormatDisplayValue(PendingUpdate update)
+        {
+            if (update.Value == null)
+                return string.Empty;
+
+            return update.Spec.WriteVia switch
+            {
+                WriteVia.Scalar => update.Value.ToString() ?? string.Empty,
+                WriteVia.SimpleList when update.Value is System.Collections.ICollection c => $"{c.Count} items",
+                WriteVia.BeatSheet when update.Value is System.Collections.ICollection c => $"{c.Count} beats",
+                WriteVia.CastMembers when update.Value is System.Collections.ICollection c => $"{c.Count} cast members",
+                WriteVia.Relationships when update.Value is System.Collections.ICollection c => $"{c.Count} relationships",
+                WriteVia.TypedList when update.Value is System.Collections.ICollection c => $"{c.Count} entries",
+                _ => update.Value.ToString() ?? string.Empty
+            };
         }
 
         /// <summary>

--- a/StoryCADLib/Collaborator/Models/PendingUpdateItem.cs
+++ b/StoryCADLib/Collaborator/Models/PendingUpdateItem.cs
@@ -1,0 +1,33 @@
+namespace StoryCADLib.Collaborator.Models;
+
+/// <summary>
+/// Display model for one pending workflow property update in the Collaborator panel (issue #116).
+/// Mutable properties (not init-only) so WinUI XamlTypeInfo can generate setters.
+/// </summary>
+public sealed class PendingUpdateItem
+{
+    /// <summary>ElementLabel.PropertyName</summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>Proposed value (truncated for display).</summary>
+    public string ProposedDisplay { get; set; } = string.Empty;
+
+    /// <summary>Current outline value, or empty.</summary>
+    public string CurrentDisplay { get; set; } = string.Empty;
+
+    /// <summary>Fill, Refresh, or Protect (display label).</summary>
+    public string KindLabel { get; set; } = string.Empty;
+
+    /// <summary>True when Accept All will not apply this row without Review.</summary>
+    public bool IsProtected { get; set; }
+
+    /// <summary>Optional craft recommendation text when kind is Protect.</summary>
+    public string CraftExplanation { get; set; }
+
+    /// <summary>One-line list summary.</summary>
+    public string SummaryLine { get; set; } = string.Empty;
+
+    public bool HasCraftExplanation => !string.IsNullOrWhiteSpace(CraftExplanation);
+
+    public bool HasCurrentValue => !string.IsNullOrWhiteSpace(CurrentDisplay);
+}

--- a/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using StoryCADLib.Collaborator.Models;
@@ -19,7 +21,7 @@ public partial class WorkflowViewModel : ObservableRecipient
     public WorkflowViewModel()
     {
         ConversationList = new ObservableCollection<ChatMessage>();
-        PendingUpdates = new Dictionary<string, object>();
+        PendingUpdateItems = new ObservableCollection<PendingUpdateItem>();
 
         // Existing commands
         AcceptCommand = new RelayCommand(SaveOutputs);
@@ -95,28 +97,21 @@ public partial class WorkflowViewModel : ObservableRecipient
     #region Pending Updates Properties
 
     /// <summary>
-    /// Property updates extracted from workflow but not yet applied.
-    /// Key format: "ElementLabel.PropertyName", Value: new value
+    /// Classified property updates for the panel (issue #116).
     /// </summary>
-    public Dictionary<string, object> PendingUpdates { get; set; }
+    public ObservableCollection<PendingUpdateItem> PendingUpdateItems { get; set; }
 
-    /// <summary>
-    /// True if there are updates to display (pending or applied).
-    /// </summary>
-    public bool HasUpdates => PendingUpdates?.Count > 0;
+    /// <summary>True if there are updates to display (pending or applied).</summary>
+    public bool HasUpdates => PendingUpdateItems?.Count > 0;
 
-    /// <summary>
-    /// True if updates exist and haven't been applied yet.
-    /// </summary>
+    /// <summary>True if updates exist and haven't been fully applied yet.</summary>
     public bool HasPendingUpdates => HasUpdates && !UpdatesApplied;
 
     public Microsoft.UI.Xaml.Visibility ReviewModeVisibility =>
         IsInReviewMode ? Microsoft.UI.Xaml.Visibility.Visible : Microsoft.UI.Xaml.Visibility.Collapsed;
 
     private bool _isInReviewMode;
-    /// <summary>
-    /// True when user is reviewing updates one at a time.
-    /// </summary>
+    /// <summary>True when user is reviewing updates one at a time.</summary>
     public bool IsInReviewMode
     {
         get => _isInReviewMode;
@@ -130,64 +125,57 @@ public partial class WorkflowViewModel : ObservableRecipient
     }
 
     private int _currentReviewIndex;
-    /// <summary>
-    /// Index of the property currently being reviewed (0-based).
-    /// </summary>
+    /// <summary>Index of the property currently being reviewed (0-based).</summary>
     public int CurrentReviewIndex
     {
         get => _currentReviewIndex;
         set => SetProperty(ref _currentReviewIndex, value);
     }
 
-    /// <summary>
-    /// Display key of the property currently being reviewed.
-    /// </summary>
-    public string CurrentReviewKey => IsInReviewMode && PendingUpdates?.Count > CurrentReviewIndex
-        ? PendingUpdates.Keys.ElementAt(CurrentReviewIndex)
-        : string.Empty;
+    public string CurrentReviewKey =>
+        IsInReviewMode && PendingUpdateItems?.Count > CurrentReviewIndex
+            ? PendingUpdateItems[CurrentReviewIndex].Key
+            : string.Empty;
 
-    /// <summary>
-    /// Value of the property currently being reviewed.
-    /// </summary>
-    public string CurrentReviewValue => IsInReviewMode && PendingUpdates?.Count > CurrentReviewIndex
-        ? PendingUpdates.Values.ElementAt(CurrentReviewIndex)?.ToString() ?? "(empty)"
-        : string.Empty;
+    /// <summary>Proposed value for the row under review.</summary>
+    public string CurrentReviewValue =>
+        IsInReviewMode && PendingUpdateItems?.Count > CurrentReviewIndex
+            ? PendingUpdateItems[CurrentReviewIndex].ProposedDisplay
+            : string.Empty;
 
-    /// <summary>
-    /// Progress text for review mode (e.g., "2 of 5").
-    /// </summary>
+    /// <summary>Current outline value for the row under review.</summary>
+    public string CurrentReviewExisting =>
+        IsInReviewMode && PendingUpdateItems?.Count > CurrentReviewIndex
+            ? (string.IsNullOrEmpty(PendingUpdateItems[CurrentReviewIndex].CurrentDisplay)
+                ? "(empty)"
+                : PendingUpdateItems[CurrentReviewIndex].CurrentDisplay)
+            : string.Empty;
+
+    public string CurrentReviewCraft =>
+        IsInReviewMode && PendingUpdateItems?.Count > CurrentReviewIndex
+            ? PendingUpdateItems[CurrentReviewIndex].CraftExplanation ?? string.Empty
+            : string.Empty;
+
+    public bool CurrentReviewHasCraft => !string.IsNullOrWhiteSpace(CurrentReviewCraft);
+
+    public Microsoft.UI.Xaml.Visibility CurrentReviewCraftVisibility =>
+        CurrentReviewHasCraft ? Microsoft.UI.Xaml.Visibility.Visible : Microsoft.UI.Xaml.Visibility.Collapsed;
+
     public string ReviewProgress => IsInReviewMode
-        ? $"{CurrentReviewIndex + 1} of {PendingUpdates?.Count ?? 0}"
+        ? $"{CurrentReviewIndex + 1} of {PendingUpdateItems?.Count ?? 0}"
         : string.Empty;
 
-    /// <summary>
-    /// Callback invoked when user clicks Accept All.
-    /// Collaborator sets this to apply all pending updates.
-    /// </summary>
     public Action OnAcceptAll { get; set; }
-
-    /// <summary>
-    /// Callback invoked when user clicks Try Again.
-    /// Collaborator sets this to re-execute the workflow.
-    /// </summary>
     public Func<Task> OnTryAgain { get; set; }
-
-    /// <summary>
-    /// Callback invoked when user accepts a single property in review mode.
-    /// Parameter is the property key (e.g., "Overview.Premise").
-    /// </summary>
     public Action<string> OnAcceptProperty { get; set; }
-
-    /// <summary>
-    /// Callback invoked when user skips a single property in review mode.
-    /// Parameter is the property key (e.g., "Overview.Premise").
-    /// </summary>
     public Action<string> OnSkipProperty { get; set; }
 
-    private bool _updatesApplied;
     /// <summary>
-    /// True when updates have been applied (disables action buttons via CanExecute).
+    /// Accept remaining Fill/Refresh only; leave Protect rows (issue #116).
     /// </summary>
+    public Action OnAcceptRemainingFree { get; set; }
+
+    private bool _updatesApplied;
     public bool UpdatesApplied
     {
         get => _updatesApplied;
@@ -289,8 +277,8 @@ public partial class WorkflowViewModel : ObservableRecipient
     {
         if (!HasPendingUpdates) return;
 
+        // Collaborator applies free rows, may leave Protect, and updates this collection.
         OnAcceptAll?.Invoke();
-        ClearPendingUpdates();
     }
 
     private void ExecuteReviewEach()
@@ -299,9 +287,7 @@ public partial class WorkflowViewModel : ObservableRecipient
 
         CurrentReviewIndex = 0;
         IsInReviewMode = true;
-        OnPropertyChanged(nameof(CurrentReviewKey));
-        OnPropertyChanged(nameof(CurrentReviewValue));
-        OnPropertyChanged(nameof(ReviewProgress));
+        NotifyReviewProperties();
     }
 
     private async Task ExecuteTryAgain()
@@ -310,9 +296,7 @@ public partial class WorkflowViewModel : ObservableRecipient
 
         ClearPendingUpdates();
         if (OnTryAgain != null)
-        {
             await OnTryAgain();
-        }
     }
 
     private void ExecuteAcceptCurrent()
@@ -329,9 +313,7 @@ public partial class WorkflowViewModel : ObservableRecipient
         if (!IsInReviewMode || !HasPendingUpdates) return;
 
         var key = CurrentReviewKey;
-        // Notify Collaborator to remove from its pending updates
         OnSkipProperty?.Invoke(key);
-        // Note: Collaborator calls SetPendingUpdates which updates our PendingUpdates
         AdvanceReview();
     }
 
@@ -339,70 +321,102 @@ public partial class WorkflowViewModel : ObservableRecipient
     {
         if (!IsInReviewMode) return;
 
-        // Accept all remaining updates
-        var remainingKeys = PendingUpdates.Keys.Skip(CurrentReviewIndex).ToList();
-        foreach (var key in remainingKeys)
+        // #116: only free updates; Protect stays for Accept/Skip.
+        if (OnAcceptRemainingFree != null)
+            OnAcceptRemainingFree.Invoke();
+        else
         {
-            OnAcceptProperty?.Invoke(key);
+            // Fallback: accept free-looking rows only (no Protect label).
+            var keys = PendingUpdateItems
+                .Where(i => !i.IsProtected)
+                .Select(i => i.Key)
+                .ToList();
+            foreach (var key in keys)
+                OnAcceptProperty?.Invoke(key);
         }
 
-        ClearPendingUpdates();
+        if (PendingUpdateItems == null || PendingUpdateItems.Count == 0)
+        {
+            ClearPendingUpdates();
+            return;
+        }
+
+        CurrentReviewIndex = 0;
+        NotifyReviewProperties();
     }
 
     /// <summary>
-    /// After accept/skip, Collaborator removes the current key from PendingUpdates.
-    /// The next remaining item slides into the same index — do not increment, or we skip it.
+    /// After accept/skip, Collaborator removes the current key from the list.
+    /// The next item slides into the same index — do not increment (#115).
     /// </summary>
     private void AdvanceReview()
     {
-        if (PendingUpdates == null || PendingUpdates.Count == 0)
+        if (PendingUpdateItems == null || PendingUpdateItems.Count == 0)
         {
             IsInReviewMode = false;
             ClearPendingUpdates();
             return;
         }
 
-        // If index is past the end (accepted the last remaining item), finish.
-        if (CurrentReviewIndex >= PendingUpdates.Count)
+        if (CurrentReviewIndex >= PendingUpdateItems.Count)
         {
             IsInReviewMode = false;
-            ClearPendingUpdates();
+            if (PendingUpdateItems.Count == 0)
+                ClearPendingUpdates();
             return;
         }
 
-        // Still have an item at CurrentReviewIndex (the next after remove). Refresh UI only.
+        NotifyReviewProperties();
+    }
+
+    private void NotifyReviewProperties()
+    {
         OnPropertyChanged(nameof(CurrentReviewKey));
         OnPropertyChanged(nameof(CurrentReviewValue));
+        OnPropertyChanged(nameof(CurrentReviewExisting));
+        OnPropertyChanged(nameof(CurrentReviewCraft));
+        OnPropertyChanged(nameof(CurrentReviewHasCraft));
+        OnPropertyChanged(nameof(CurrentReviewCraftVisibility));
         OnPropertyChanged(nameof(ReviewProgress));
     }
 
     public void ClearPendingUpdates()
     {
-        PendingUpdates.Clear();
+        PendingUpdateItems.Clear();
         IsInReviewMode = false;
         UpdatesApplied = false;
         CurrentReviewIndex = 0;
-    }
-
-    /// <summary>
-    /// Receives pending updates from Collaborator after workflow execution.
-    /// </summary>
-    public void SetPendingUpdates(Dictionary<string, object> updates)
-    {
-        PendingUpdates = updates;
-        UpdatesApplied = false;
-        OnPropertyChanged(nameof(PendingUpdates));
         OnPropertyChanged(nameof(HasUpdates));
         OnPropertyChanged(nameof(HasPendingUpdates));
     }
 
     /// <summary>
-    /// Called by Collaborator after updates are applied (disables action buttons).
+    /// Receives classified pending updates from Collaborator after workflow execution (#116).
     /// </summary>
+    public void SetPendingUpdates(IReadOnlyList<PendingUpdateItem> items)
+    {
+        PendingUpdateItems.Clear();
+        if (items != null)
+        {
+            foreach (var item in items)
+                PendingUpdateItems.Add(item);
+        }
+
+        UpdatesApplied = false;
+        OnPropertyChanged(nameof(PendingUpdateItems));
+        OnPropertyChanged(nameof(HasUpdates));
+        OnPropertyChanged(nameof(HasPendingUpdates));
+        NotifyReviewProperties();
+    }
+
+    /// <summary>Called by Collaborator after all free updates are applied.</summary>
     public void MarkUpdatesApplied()
     {
         UpdatesApplied = true;
         IsInReviewMode = false;
+        PendingUpdateItems.Clear();
+        OnPropertyChanged(nameof(HasUpdates));
+        OnPropertyChanged(nameof(HasPendingUpdates));
     }
 
     #endregion

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
@@ -77,24 +77,22 @@
                         <!-- Header -->
                         <TextBlock Text="Property Updates" FontWeight="SemiBold" Margin="0,0,0,8" />
 
-                        <!-- Updates List -->
-                        <ListView ItemsSource="{x:Bind ViewModel.PendingUpdates, Mode=OneWay}"
+                        <!-- Updates List (#116: current vs proposed + protect/craft labels) -->
+                        <ListView ItemsSource="{x:Bind ViewModel.PendingUpdateItems, Mode=OneWay}"
                                   SelectionMode="None"
-                                  MaxHeight="200"
+                                  MaxHeight="220"
                                   AutomationProperties.AutomationId="WorkflowPendingUpdatesList">
                             <ListView.ItemTemplate>
                                 <DataTemplate>
-                                    <!-- Template root: no AutomationId (TemplateSafety forbids it). Item
-                                         identity binds to the property Key (the update's identity within
-                                         the list), not Value (its content) - convention's templated-Name
-                                         treatment, ImageGalleryControl precedent. Classic {Binding} matches
-                                         what the template already uses (no x:DataType here). -->
+                                    <!-- Template root: no AutomationId (TemplateSafety forbids it). -->
                                     <StackPanel Margin="0,4"
                                                 AutomationProperties.Name="{Binding Key, Mode=OneWay}">
                                         <TextBlock Text="{Binding Key}" FontWeight="SemiBold" FontSize="12" />
-                                        <TextBlock Text="{Binding Value}"
+                                        <TextBlock Text="{Binding SummaryLine}"
+                                                   FontSize="11"
+                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                        <TextBlock Text="{Binding ProposedDisplay}"
                                                    TextWrapping="Wrap"
-                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                                    FontSize="12"
                                                    MaxLines="3" />
                                     </StackPanel>
@@ -125,14 +123,29 @@
                                     Margin="0,8,0,0">
                             <TextBlock Text="Review Property Update" FontWeight="SemiBold" Margin="0,0,0,8" />
 
-                            <!-- Current property being reviewed -->
+                            <!-- Current property being reviewed (#116: yours vs proposed + craft) -->
                             <Border Background="{ThemeResource SystemAccentColorLight2}"
                                     CornerRadius="4" Padding="10" Margin="0,0,0,8">
                                 <StackPanel>
                                     <TextBlock Text="{x:Bind ViewModel.CurrentReviewKey, Mode=OneWay}"
                                                FontWeight="Bold" FontSize="13" />
+                                    <TextBlock Text="Yours"
+                                               FontSize="11"
+                                               Margin="0,8,0,0"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                    <TextBlock Text="{x:Bind ViewModel.CurrentReviewExisting, Mode=OneWay}"
+                                               TextWrapping="Wrap" Margin="0,2,0,0" />
+                                    <TextBlock Text="Proposed"
+                                               FontSize="11"
+                                               Margin="0,8,0,0"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                     <TextBlock Text="{x:Bind ViewModel.CurrentReviewValue, Mode=OneWay}"
-                                               TextWrapping="Wrap" Margin="0,4,0,0" />
+                                               TextWrapping="Wrap" Margin="0,2,0,0" />
+                                    <TextBlock Text="{x:Bind ViewModel.CurrentReviewCraft, Mode=OneWay}"
+                                               TextWrapping="Wrap"
+                                               Margin="0,8,0,0"
+                                               FontSize="12"
+                                               Visibility="{x:Bind ViewModel.CurrentReviewCraftVisibility, Mode=OneWay}" />
                                 </StackPanel>
                             </Border>
 
@@ -147,10 +160,11 @@
                                         Command="{x:Bind ViewModel.SkipCurrentCommand}"
                                         IsEnabled="{x:Bind ViewModel.IsInReviewMode, Mode=OneWay}"
                                         AutomationProperties.AutomationId="WorkflowSkipButton" />
-                                <Button Content="Accept Remaining"
+                                <Button Content="Accept Free Remaining"
                                         Command="{x:Bind ViewModel.AcceptRemainingCommand}"
                                         IsEnabled="{x:Bind ViewModel.IsInReviewMode, Mode=OneWay}"
-                                        AutomationProperties.AutomationId="WorkflowAcceptRemainingButton" />
+                                        AutomationProperties.AutomationId="WorkflowAcceptRemainingButton"
+                                        ToolTipService.ToolTip="Applies empty/session fields only; leaves fields that already have your text" />
                             </StackPanel>
 
                             <!-- Progress indicator -->

--- a/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
@@ -402,21 +402,32 @@ public class WorkflowViewModelTests
 
     #endregion
 
-    #region Review Each (issue #115)
+    #region Review Each (issue #115 / #116)
+
+    private static PendingUpdateItem Item(string key, string proposed = "v", bool isProtected = false) =>
+        new()
+        {
+            Key = key,
+            ProposedDisplay = proposed,
+            CurrentDisplay = isProtected ? "existing" : "",
+            KindLabel = isProtected ? "Has your text" : "New",
+            IsProtected = isProtected,
+            SummaryLine = isProtected ? "Has your text" : "New"
+        };
 
     /// <summary>
-    /// Simulates Collaborator: accept/skip removes the key then SetPendingUpdates.
+    /// Simulates Collaborator: accept/skip removes the key then SetPendingUpdates (#116 item list).
     /// </summary>
-    private void WireRemoveOnAcceptOrSkip(Dictionary<string, object> store)
+    private void WireRemoveOnAcceptOrSkip(List<PendingUpdateItem> store)
     {
         _viewModel.OnAcceptProperty = key =>
         {
-            store.Remove(key);
+            store.RemoveAll(i => i.Key == key);
             _viewModel.SetPendingUpdates(store);
         };
         _viewModel.OnSkipProperty = key =>
         {
-            store.Remove(key);
+            store.RemoveAll(i => i.Key == key);
             _viewModel.SetPendingUpdates(store);
         };
     }
@@ -425,11 +436,11 @@ public class WorkflowViewModelTests
     public void ReviewEach_AcceptCurrent_DoesNotSkipMiddleProperty()
     {
         // Arrange — three updates (Ideation: Description, Concept, Premise)
-        var store = new Dictionary<string, object>
+        var store = new List<PendingUpdateItem>
         {
-            ["Overview.Description"] = "idea",
-            ["Overview.Concept"] = "concept",
-            ["Overview.Premise"] = "premise"
+            Item("Overview.Description", "idea"),
+            Item("Overview.Concept", "concept"),
+            Item("Overview.Premise", "premise")
         };
         _viewModel.SetPendingUpdates(store);
         WireRemoveOnAcceptOrSkip(store);
@@ -457,11 +468,11 @@ public class WorkflowViewModelTests
     [TestMethod]
     public void ReviewEach_SkipCurrent_DoesNotDropRemaining()
     {
-        var store = new Dictionary<string, object>
+        var store = new List<PendingUpdateItem>
         {
-            ["Overview.Description"] = "idea",
-            ["Overview.Concept"] = "concept",
-            ["Overview.Premise"] = "premise"
+            Item("Overview.Description", "idea"),
+            Item("Overview.Concept", "concept"),
+            Item("Overview.Premise", "premise")
         };
         _viewModel.SetPendingUpdates(store);
         WireRemoveOnAcceptOrSkip(store);
@@ -484,10 +495,10 @@ public class WorkflowViewModelTests
     public void ReviewEach_AcceptLastOfTwo_DoesNotClearUnreviewed()
     {
         // Secondary bug: accept first of two remaining while index logic treated "done" early
-        var store = new Dictionary<string, object>
+        var store = new List<PendingUpdateItem>
         {
-            ["A"] = 1,
-            ["B"] = 2
+            Item("A", "1"),
+            Item("B", "2")
         };
         _viewModel.SetPendingUpdates(store);
         WireRemoveOnAcceptOrSkip(store);
@@ -496,7 +507,7 @@ public class WorkflowViewModelTests
         _viewModel.AcceptCurrentCommand.Execute(null);
         Assert.AreEqual("B", _viewModel.CurrentReviewKey);
         Assert.AreEqual(1, store.Count);
-        Assert.IsTrue(store.ContainsKey("B"));
+        Assert.IsTrue(store.Exists(i => i.Key == "B"));
 
         _viewModel.AcceptCurrentCommand.Execute(null);
         Assert.AreEqual(0, store.Count);


### PR DESCRIPTION
## Summary
- Classify scalar pending updates against the live outline and session-touch set: **Fill** / **Refresh** / **Protect** / **NoOp** (Collaborator issue #116).
- **Accept All** applies free rows only; protected fields stay for **Review Each** (current vs proposed + optional craft note).
- Session-only remember of fields Collaborator wrote; StoryCAD edits stay protected.
- InnerOuter still **proposes** ConflictType = Person vs. Self without silent force when the user already chose another list value (craft explanation on Protect).

## Test plan
- [ ] Unit: Collaborator `OverwritePolicyTests` (8) green against this CollaboratorLib
- [ ] Manual: Overview with Story Idea filled → Premise → Accept All leaves Description; fills empty Concept/Premise
- [ ] Manual: Review Each on protected field shows Yours / Proposed
- [ ] Manual: Accept protected once → re-run same session → Accept All may refresh that field
- [ ] Manual: Inner problem with non–Person vs. Self ConflictType → craft note; Accept All does not stomp

## Related
- Collaborator tests PR (same branch name): fix/116-overwrite-policy
- Issue: storybuilder-org/Collaborator#116