### PR TITLE
feat(#107): problem-character spine map in StoryContext

### DIFF
--- a/CollaboratorLib/Context/ContextResolver.cs
+++ b/CollaboratorLib/Context/ContextResolver.cs
@@ -8,40 +8,57 @@ namespace CollaboratorLib.Context;
 /// </summary>
 public class ContextResolver
 {
-    // Workflow labels that need full context
     private static readonly HashSet<string> FullContextWorkflows = new(StringComparer.OrdinalIgnoreCase)
     {
         "GMC",
         "Critique"
     };
 
-    // Workflow labels that only need story constraints
     private static readonly HashSet<string> MinimalContextWorkflows = new(StringComparer.OrdinalIgnoreCase)
     {
         "Premise"
     };
 
     /// <summary>
+    /// High-tier character craft: problem stakes (GMC) in StoryContext.
+    /// </summary>
+    private static readonly HashSet<string> CharacterHighDetailWorkflows = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Flaw",
+        "Backstory",
+        "RoleAndStoryRole"
+    };
+
+    /// <summary>
+    /// Medium-tier character craft: links (and GMC when useful).
+    /// </summary>
+    private static readonly HashSet<string> CharacterMediumDetailWorkflows = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "PsychologicalMakeup",
+        "Relationship"
+    };
+
+    /// <summary>
     /// Get the context specification for a workflow and element type combination.
     /// </summary>
-    /// <param name="workflowLabel">The workflow being executed (e.g., "GMC", "Premise")</param>
-    /// <param name="elementType">The type of element being processed</param>
-    /// <returns>ContextSpec indicating what context to gather</returns>
     public ContextSpec GetContextFor(string workflowLabel, StoryItemType elementType)
     {
-        // GMC workflow on Problem needs full context for temporal awareness
         if (FullContextWorkflows.Contains(workflowLabel) && elementType == StoryItemType.Problem)
         {
             return ContextSpec.Full;
         }
 
-        // Premise workflow only needs story constraints
+        // Premise: constraints only (omit cast map to keep ideation prompts light)
         if (MinimalContextWorkflows.Contains(workflowLabel))
         {
-            return ContextSpec.Default;
+            return new ContextSpec
+            {
+                IncludeStoryConstraints = true,
+                IncludeCastProblemMap = false,
+                CharacterProblemDetail = CharacterProblemDetail.None
+            };
         }
 
-        // Scene workflows need character and setting context
         if (elementType == StoryItemType.Scene)
         {
             return new ContextSpec
@@ -50,23 +67,33 @@ public class ContextResolver
                 IncludeBeatHierarchy = false,
                 IncludeCharacterContext = true,
                 IncludePrecedingEvents = true,
-                MaxPrecedingBeats = 2
+                MaxPrecedingBeats = 2,
+                IncludeCastProblemMap = true,
+                CharacterProblemDetail = CharacterProblemDetail.None
             };
         }
 
-        // Character workflows need relationship context (future enhancement)
         if (elementType == StoryItemType.Character)
         {
+            var detail = CharacterProblemDetail.LinksOnly;
+            if (CharacterHighDetailWorkflows.Contains(workflowLabel))
+                detail = CharacterProblemDetail.LinksAndGmc;
+            else if (CharacterMediumDetailWorkflows.Contains(workflowLabel))
+                detail = CharacterProblemDetail.LinksAndGmc;
+            // PhysicalAppearance, SocialFactors, InnerOuterTraits stay LinksOnly
+
             return new ContextSpec
             {
                 IncludeStoryConstraints = true,
                 IncludeBeatHierarchy = false,
-                IncludeCharacterContext = false, // Don't include self
-                IncludePrecedingEvents = false
+                IncludeCharacterContext = false,
+                IncludePrecedingEvents = false,
+                IncludeCastProblemMap = true,
+                CharacterProblemDetail = detail
             };
         }
 
-        // Default: story constraints only
+        // Default: constraints + spine map (problem/setting and other targets)
         return ContextSpec.Default;
     }
 
@@ -75,7 +102,6 @@ public class ContextResolver
     /// </summary>
     public bool ShouldEnrichContext(string workflowLabel)
     {
-        // All workflows get at least story constraints
         return true;
     }
 }

--- a/CollaboratorLib/Context/ContextSpec.cs
+++ b/CollaboratorLib/Context/ContextSpec.cs
@@ -1,6 +1,21 @@
 namespace CollaboratorLib.Context;
 
 /// <summary>
+/// How much problem detail to include for a character-target context slice (issue #107).
+/// </summary>
+public enum CharacterProblemDetail
+{
+    /// <summary>No per-character problem section.</summary>
+    None = 0,
+
+    /// <summary>Problem names and roles only.</summary>
+    LinksOnly = 1,
+
+    /// <summary>Links plus GMC fields and opposing force name when available.</summary>
+    LinksAndGmc = 2
+}
+
+/// <summary>
 /// Specifies what context to gather for a workflow invocation.
 /// Determined by ContextResolver based on workflow and element type.
 /// </summary>
@@ -17,7 +32,7 @@ public record ContextSpec
     public bool IncludeBeatHierarchy { get; init; }
 
     /// <summary>
-    /// Include character details for Protagonist/Antagonist references.
+    /// Include character details for Protagonist/Antagonist references (problem-target runs).
     /// </summary>
     public bool IncludeCharacterContext { get; init; }
 
@@ -32,7 +47,18 @@ public record ContextSpec
     public int MaxPrecedingBeats { get; init; } = 3;
 
     /// <summary>
-    /// Default spec with minimal context (story constraints only).
+    /// Include outline-level cast–problem map and spine gap lines (issue #107).
+    /// Default on so most runs see plot-spine honesty; Premise turns this off.
+    /// </summary>
+    public bool IncludeCastProblemMap { get; init; } = true;
+
+    /// <summary>
+    /// Per-character problem slice when the target element is a Character.
+    /// </summary>
+    public CharacterProblemDetail CharacterProblemDetail { get; init; } = CharacterProblemDetail.None;
+
+    /// <summary>
+    /// Default spec with story constraints and cast–problem map (no beats / character GMC slice).
     /// </summary>
     public static ContextSpec Default => new();
 
@@ -45,6 +71,8 @@ public record ContextSpec
         IncludeBeatHierarchy = true,
         IncludeCharacterContext = true,
         IncludePrecedingEvents = true,
-        MaxPrecedingBeats = 3
+        MaxPrecedingBeats = 3,
+        IncludeCastProblemMap = true,
+        CharacterProblemDetail = CharacterProblemDetail.None
     };
 }

--- a/CollaboratorLib/Context/ProblemCharacterIndex.cs
+++ b/CollaboratorLib/Context/ProblemCharacterIndex.cs
@@ -4,7 +4,7 @@ using StoryCADLib.Services.Collaborator.Contracts;
 namespace CollaboratorLib.Context;
 
 /// <summary>
-/// Role of a character on a problem (Problem.Protagonist / Antagonist links).
+/// Role of a character slot on a problem (Problem.Protagonist / Antagonist).
 /// </summary>
 public enum ProblemCharacterRole
 {
@@ -13,7 +13,23 @@ public enum ProblemCharacterRole
 }
 
 /// <summary>
-/// One resolvable Problem → Character cast link.
+/// Resolution of one problem cast slot.
+/// </summary>
+public enum ProblemCharacterLinkStatus
+{
+    /// <summary>GUID set and resolves to a Character.</summary>
+    Linked,
+
+    /// <summary>GUID is Empty; slot not assigned.</summary>
+    Unassigned,
+
+    /// <summary>GUID set but does not resolve to a Character.</summary>
+    Unresolved
+}
+
+/// <summary>
+/// One problem cast slot (always two per problem: protagonist and antagonist).
+/// Unassigned and unresolved slots are first-class; they are not omitted from the index.
 /// </summary>
 public sealed record ProblemCharacterEdge(
     Guid ProblemGuid,
@@ -21,11 +37,13 @@ public sealed record ProblemCharacterEdge(
     ProblemCharacterRole Role,
     Guid CharacterGuid,
     string CharacterName,
-    bool IsStoryProblem);
+    bool IsStoryProblem,
+    ProblemCharacterLinkStatus Status,
+    bool ProblemHasGmcText);
 
 /// <summary>
-/// Reverse index of problem prot/antag links for StoryContext (issue #107 spine map).
-/// Built once per context assembly from existing Problem GUID fields.
+/// Slot-complete index of problem prot/antag links for StoryContext (issue #107 spine map).
+/// Built once per context assembly. Every problem contributes two slots.
 /// </summary>
 public sealed class ProblemCharacterIndex
 {
@@ -37,9 +55,7 @@ public sealed class ProblemCharacterIndex
     private readonly HashSet<Guid> _majorCast;
     private readonly Guid _storyProblemGuid;
 
-    private ProblemCharacterIndex(
-        List<ProblemCharacterEdge> edges,
-        Guid storyProblemGuid)
+    private ProblemCharacterIndex(List<ProblemCharacterEdge> edges, Guid storyProblemGuid)
     {
         _edges = edges;
         _storyProblemGuid = storyProblemGuid;
@@ -49,13 +65,6 @@ public sealed class ProblemCharacterIndex
 
         foreach (var edge in edges)
         {
-            if (!_byCharacter.TryGetValue(edge.CharacterGuid, out var charList))
-            {
-                charList = new List<ProblemCharacterEdge>();
-                _byCharacter[edge.CharacterGuid] = charList;
-            }
-            charList.Add(edge);
-
             if (!_byProblem.TryGetValue(edge.ProblemGuid, out var probList))
             {
                 probList = new List<ProblemCharacterEdge>();
@@ -63,19 +72,36 @@ public sealed class ProblemCharacterIndex
             }
             probList.Add(edge);
 
+            if (edge.Status != ProblemCharacterLinkStatus.Linked)
+                continue;
+            if (edge.CharacterGuid == Guid.Empty)
+                continue;
+
+            if (!_byCharacter.TryGetValue(edge.CharacterGuid, out var charList))
+            {
+                charList = new List<ProblemCharacterEdge>();
+                _byCharacter[edge.CharacterGuid] = charList;
+            }
+            charList.Add(edge);
             _majorCast.Add(edge.CharacterGuid);
         }
     }
 
+    /// <summary>All slots (Linked, Unassigned, Unresolved), two per problem.</summary>
     public IReadOnlyList<ProblemCharacterEdge> Edges => _edges;
+
+    /// <summary>Slots that resolve to a character only.</summary>
+    public IEnumerable<ProblemCharacterEdge> LinkedEdges =>
+        _edges.Where(e => e.Status == ProblemCharacterLinkStatus.Linked);
 
     public Guid StoryProblemGuid => _storyProblemGuid;
 
+    /// <summary>Characters with at least one Linked slot.</summary>
     public IReadOnlyCollection<Guid> MajorCastGuids => _majorCast;
 
     /// <summary>
-    /// Build the index from all problems in the open outline.
-    /// Empty prot/antag GUIDs and unresolvable GUIDs produce no edge.
+    /// Build the index from all problems. Each problem yields two slots
+    /// (protagonist and antagonist), including Unassigned and Unresolved.
     /// </summary>
     public static ProblemCharacterIndex Build(IStoryCADAPI api, StoryModel model)
     {
@@ -102,37 +128,55 @@ public sealed class ProblemCharacterIndex
                 continue;
 
             bool isStoryProblem = storyProblemGuid != Guid.Empty && problem.Uuid == storyProblemGuid;
-            TryAddEdge(api, edges, problem, problem.Protagonist, ProblemCharacterRole.Protagonist, isStoryProblem);
-            TryAddEdge(api, edges, problem, problem.Antagonist, ProblemCharacterRole.Antagonist, isStoryProblem);
+            bool hasGmc = ProblemHasGmcText(problem);
+            edges.Add(CreateSlot(api, problem, problem.Protagonist, ProblemCharacterRole.Protagonist, isStoryProblem, hasGmc));
+            edges.Add(CreateSlot(api, problem, problem.Antagonist, ProblemCharacterRole.Antagonist, isStoryProblem, hasGmc));
         }
 
         return new ProblemCharacterIndex(edges, storyProblemGuid);
     }
 
-    private static void TryAddEdge(
+    private static ProblemCharacterEdge CreateSlot(
         IStoryCADAPI api,
-        List<ProblemCharacterEdge> edges,
         ProblemModel problem,
         Guid characterGuid,
         ProblemCharacterRole role,
-        bool isStoryProblem)
+        bool isStoryProblem,
+        bool hasGmc)
     {
+        var name = problem.Name ?? string.Empty;
+
         if (characterGuid == Guid.Empty)
-            return;
+        {
+            return new ProblemCharacterEdge(
+                problem.Uuid, name, role, Guid.Empty, string.Empty,
+                isStoryProblem, ProblemCharacterLinkStatus.Unassigned, hasGmc);
+        }
 
         var result = api.GetStoryElement(characterGuid);
-        if (!result.IsSuccess || result.Payload is not CharacterModel character)
-            return;
+        if (result.IsSuccess && result.Payload is CharacterModel character)
+        {
+            return new ProblemCharacterEdge(
+                problem.Uuid, name, role, character.Uuid, character.Name ?? string.Empty,
+                isStoryProblem, ProblemCharacterLinkStatus.Linked, hasGmc);
+        }
 
-        edges.Add(new ProblemCharacterEdge(
-            problem.Uuid,
-            problem.Name ?? string.Empty,
-            role,
-            character.Uuid,
-            character.Name ?? string.Empty,
-            isStoryProblem));
+        return new ProblemCharacterEdge(
+            problem.Uuid, name, role, characterGuid, string.Empty,
+            isStoryProblem, ProblemCharacterLinkStatus.Unresolved, hasGmc);
     }
 
+    public static bool ProblemHasGmcText(ProblemModel problem)
+    {
+        return !string.IsNullOrWhiteSpace(problem.ProtGoal)
+               || !string.IsNullOrWhiteSpace(problem.ProtMotive)
+               || !string.IsNullOrWhiteSpace(problem.ProtConflict)
+               || !string.IsNullOrWhiteSpace(problem.AntagGoal)
+               || !string.IsNullOrWhiteSpace(problem.AntagMotive)
+               || !string.IsNullOrWhiteSpace(problem.AntagConflict);
+    }
+
+    /// <summary>Linked slots only for this character.</summary>
     public IReadOnlyList<ProblemCharacterEdge> EdgesForCharacter(Guid characterGuid)
     {
         if (characterGuid == Guid.Empty)
@@ -142,6 +186,7 @@ public sealed class ProblemCharacterIndex
             : Array.Empty<ProblemCharacterEdge>();
     }
 
+    /// <summary>All slots for this problem (typically two).</summary>
     public IReadOnlyList<ProblemCharacterEdge> EdgesForProblem(Guid problemGuid)
     {
         if (problemGuid == Guid.Empty)
@@ -152,7 +197,7 @@ public sealed class ProblemCharacterIndex
     }
 
     /// <summary>
-    /// Prefer Story Problem edges, then Protagonist, then Antagonist; cap count.
+    /// Linked slots for the character, prefer Story Problem, then Protagonist role; cap problems.
     /// </summary>
     public IReadOnlyList<ProblemCharacterEdge> SelectDetailedEdgesForCharacter(
         Guid characterGuid,
@@ -162,7 +207,6 @@ public sealed class ProblemCharacterIndex
         if (edges.Count == 0)
             return edges;
 
-        // Distinct problems in priority order, keep both roles if same problem
         var ordered = edges
             .OrderByDescending(e => e.IsStoryProblem)
             .ThenBy(e => e.Role == ProblemCharacterRole.Protagonist ? 0 : 1)

--- a/CollaboratorLib/Context/ProblemCharacterIndex.cs
+++ b/CollaboratorLib/Context/ProblemCharacterIndex.cs
@@ -1,0 +1,188 @@
+using StoryCADLib.Models;
+using StoryCADLib.Services.Collaborator.Contracts;
+
+namespace CollaboratorLib.Context;
+
+/// <summary>
+/// Role of a character on a problem (Problem.Protagonist / Antagonist links).
+/// </summary>
+public enum ProblemCharacterRole
+{
+    Protagonist,
+    Antagonist
+}
+
+/// <summary>
+/// One resolvable Problem → Character cast link.
+/// </summary>
+public sealed record ProblemCharacterEdge(
+    Guid ProblemGuid,
+    string ProblemName,
+    ProblemCharacterRole Role,
+    Guid CharacterGuid,
+    string CharacterName,
+    bool IsStoryProblem);
+
+/// <summary>
+/// Reverse index of problem prot/antag links for StoryContext (issue #107 spine map).
+/// Built once per context assembly from existing Problem GUID fields.
+/// </summary>
+public sealed class ProblemCharacterIndex
+{
+    public const int DefaultMaxDetailedProblems = 2;
+
+    private readonly List<ProblemCharacterEdge> _edges;
+    private readonly Dictionary<Guid, List<ProblemCharacterEdge>> _byCharacter;
+    private readonly Dictionary<Guid, List<ProblemCharacterEdge>> _byProblem;
+    private readonly HashSet<Guid> _majorCast;
+    private readonly Guid _storyProblemGuid;
+
+    private ProblemCharacterIndex(
+        List<ProblemCharacterEdge> edges,
+        Guid storyProblemGuid)
+    {
+        _edges = edges;
+        _storyProblemGuid = storyProblemGuid;
+        _byCharacter = new Dictionary<Guid, List<ProblemCharacterEdge>>();
+        _byProblem = new Dictionary<Guid, List<ProblemCharacterEdge>>();
+        _majorCast = new HashSet<Guid>();
+
+        foreach (var edge in edges)
+        {
+            if (!_byCharacter.TryGetValue(edge.CharacterGuid, out var charList))
+            {
+                charList = new List<ProblemCharacterEdge>();
+                _byCharacter[edge.CharacterGuid] = charList;
+            }
+            charList.Add(edge);
+
+            if (!_byProblem.TryGetValue(edge.ProblemGuid, out var probList))
+            {
+                probList = new List<ProblemCharacterEdge>();
+                _byProblem[edge.ProblemGuid] = probList;
+            }
+            probList.Add(edge);
+
+            _majorCast.Add(edge.CharacterGuid);
+        }
+    }
+
+    public IReadOnlyList<ProblemCharacterEdge> Edges => _edges;
+
+    public Guid StoryProblemGuid => _storyProblemGuid;
+
+    public IReadOnlyCollection<Guid> MajorCastGuids => _majorCast;
+
+    /// <summary>
+    /// Build the index from all problems in the open outline.
+    /// Empty prot/antag GUIDs and unresolvable GUIDs produce no edge.
+    /// </summary>
+    public static ProblemCharacterIndex Build(IStoryCADAPI api, StoryModel model)
+    {
+        if (api == null) throw new ArgumentNullException(nameof(api));
+        if (model == null) throw new ArgumentNullException(nameof(model));
+
+        var storyProblemGuid = Guid.Empty;
+        var overviewResult = api.GetElementsByType(StoryItemType.StoryOverview);
+        if (overviewResult.IsSuccess)
+        {
+            var overview = overviewResult.Payload?.OfType<OverviewModel>().FirstOrDefault();
+            if (overview != null)
+                storyProblemGuid = overview.StoryProblem;
+        }
+
+        var edges = new List<ProblemCharacterEdge>();
+        var problemsResult = api.GetElementsByType(StoryItemType.Problem);
+        if (!problemsResult.IsSuccess || problemsResult.Payload == null)
+            return new ProblemCharacterIndex(edges, storyProblemGuid);
+
+        foreach (var element in problemsResult.Payload)
+        {
+            if (element is not ProblemModel problem)
+                continue;
+
+            bool isStoryProblem = storyProblemGuid != Guid.Empty && problem.Uuid == storyProblemGuid;
+            TryAddEdge(api, edges, problem, problem.Protagonist, ProblemCharacterRole.Protagonist, isStoryProblem);
+            TryAddEdge(api, edges, problem, problem.Antagonist, ProblemCharacterRole.Antagonist, isStoryProblem);
+        }
+
+        return new ProblemCharacterIndex(edges, storyProblemGuid);
+    }
+
+    private static void TryAddEdge(
+        IStoryCADAPI api,
+        List<ProblemCharacterEdge> edges,
+        ProblemModel problem,
+        Guid characterGuid,
+        ProblemCharacterRole role,
+        bool isStoryProblem)
+    {
+        if (characterGuid == Guid.Empty)
+            return;
+
+        var result = api.GetStoryElement(characterGuid);
+        if (!result.IsSuccess || result.Payload is not CharacterModel character)
+            return;
+
+        edges.Add(new ProblemCharacterEdge(
+            problem.Uuid,
+            problem.Name ?? string.Empty,
+            role,
+            character.Uuid,
+            character.Name ?? string.Empty,
+            isStoryProblem));
+    }
+
+    public IReadOnlyList<ProblemCharacterEdge> EdgesForCharacter(Guid characterGuid)
+    {
+        if (characterGuid == Guid.Empty)
+            return Array.Empty<ProblemCharacterEdge>();
+        return _byCharacter.TryGetValue(characterGuid, out var list)
+            ? list
+            : Array.Empty<ProblemCharacterEdge>();
+    }
+
+    public IReadOnlyList<ProblemCharacterEdge> EdgesForProblem(Guid problemGuid)
+    {
+        if (problemGuid == Guid.Empty)
+            return Array.Empty<ProblemCharacterEdge>();
+        return _byProblem.TryGetValue(problemGuid, out var list)
+            ? list
+            : Array.Empty<ProblemCharacterEdge>();
+    }
+
+    /// <summary>
+    /// Prefer Story Problem edges, then Protagonist, then Antagonist; cap count.
+    /// </summary>
+    public IReadOnlyList<ProblemCharacterEdge> SelectDetailedEdgesForCharacter(
+        Guid characterGuid,
+        int maxProblems = DefaultMaxDetailedProblems)
+    {
+        var edges = EdgesForCharacter(characterGuid);
+        if (edges.Count == 0)
+            return edges;
+
+        // Distinct problems in priority order, keep both roles if same problem
+        var ordered = edges
+            .OrderByDescending(e => e.IsStoryProblem)
+            .ThenBy(e => e.Role == ProblemCharacterRole.Protagonist ? 0 : 1)
+            .ThenBy(e => e.ProblemName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var selectedProblems = new List<Guid>();
+        var result = new List<ProblemCharacterEdge>();
+        foreach (var edge in ordered)
+        {
+            if (!selectedProblems.Contains(edge.ProblemGuid))
+            {
+                if (selectedProblems.Count >= maxProblems)
+                    continue;
+                selectedProblems.Add(edge.ProblemGuid);
+            }
+            if (selectedProblems.Contains(edge.ProblemGuid))
+                result.Add(edge);
+        }
+
+        return result;
+    }
+}

--- a/CollaboratorLib/Context/StoryContextBuilder.cs
+++ b/CollaboratorLib/Context/StoryContextBuilder.cs
@@ -36,8 +36,29 @@ public class StoryContextBuilder
         var phase = DetectDevelopmentPhase(model);
         AppendPhaseContext(sb, phase);
 
+        // Issue #107: problem–character spine map (once per context build)
+        ProblemCharacterIndex? index = null;
+        if (spec.IncludeCastProblemMap ||
+            spec.CharacterProblemDetail != CharacterProblemDetail.None)
+        {
+            index = ProblemCharacterIndex.Build(_api, model);
+        }
+
+        if (spec.IncludeCastProblemMap && index != null)
+        {
+            AppendCastProblemMap(sb, index);
+            AppendSpineGaps(sb, index, model);
+        }
+
         if (spec.IncludeStoryConstraints)
             AppendStoryConstraints(sb, model);
+
+        if (spec.CharacterProblemDetail != CharacterProblemDetail.None &&
+            targetElement is CharacterModel character &&
+            index != null)
+        {
+            AppendCharacterProblemSlice(sb, character, index, model, spec.CharacterProblemDetail);
+        }
 
         if (spec.IncludeBeatHierarchy && targetElement is ProblemModel problem)
             AppendBeatHierarchy(sb, problem, model);
@@ -341,6 +362,192 @@ public class StoryContextBuilder
         }
 
         sb.AppendLine();
+    }
+
+    #endregion
+
+    #region Cast–problem map and character slice (issue #107)
+
+    private void AppendCastProblemMap(StringBuilder sb, ProblemCharacterIndex index)
+    {
+        sb.AppendLine("## Cast-problem map");
+
+        if (index.Edges.Count == 0)
+        {
+            sb.AppendLine("No problems with protagonist/antagonist links yet.");
+            sb.AppendLine();
+            return;
+        }
+
+        var majorNames = index.Edges
+            .GroupBy(e => e.CharacterGuid)
+            .Select(g => g.First().CharacterName)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (majorNames.Count > 0)
+            sb.AppendLine($"Major cast (prot/antag on ≥1 problem): {string.Join(", ", majorNames)}");
+
+        // Group edges by problem for readable lines
+        foreach (var group in index.Edges
+                     .GroupBy(e => e.ProblemGuid)
+                     .OrderByDescending(g => g.Any(e => e.IsStoryProblem))
+                     .ThenBy(g => g.First().ProblemName, StringComparer.OrdinalIgnoreCase))
+        {
+            var first = group.First();
+            var label = first.IsStoryProblem ? "Story Problem" : "Problem";
+            var roles = group
+                .OrderBy(e => e.Role == ProblemCharacterRole.Protagonist ? 0 : 1)
+                .Select(e => $"{e.CharacterName} ({e.Role})")
+                .ToList();
+            sb.AppendLine($"{label} \"{first.ProblemName}\": {string.Join(", ", roles)}");
+        }
+
+        sb.AppendLine();
+    }
+
+    private void AppendSpineGaps(StringBuilder sb, ProblemCharacterIndex index, StoryModel model)
+    {
+        var gaps = new List<string>();
+
+        if (index.StoryProblemGuid != Guid.Empty)
+        {
+            var storyProblem = ResolveElement(index.StoryProblemGuid, model) as ProblemModel;
+            if (storyProblem != null)
+            {
+                var storyEdges = index.EdgesForProblem(storyProblem.Uuid);
+                bool hasProt = storyEdges.Any(e => e.Role == ProblemCharacterRole.Protagonist);
+                bool hasAntag = storyEdges.Any(e => e.Role == ProblemCharacterRole.Antagonist);
+                if (!hasProt && !hasAntag)
+                    gaps.Add($"Story Problem \"{storyProblem.Name}\" has no protagonist/antagonist assigned.");
+                else if (!hasProt)
+                    gaps.Add($"Story Problem \"{storyProblem.Name}\" has no protagonist assigned.");
+                else if (!hasAntag)
+                    gaps.Add($"Story Problem \"{storyProblem.Name}\" has no antagonist assigned.");
+            }
+        }
+
+        var problemsResult = _api.GetElementsByType(StoryItemType.Problem);
+        if (problemsResult.IsSuccess && problemsResult.Payload != null)
+        {
+            foreach (var element in problemsResult.Payload)
+            {
+                if (element is not ProblemModel problem)
+                    continue;
+                if (index.EdgesForProblem(problem.Uuid).Count > 0)
+                    continue;
+                if (!ProblemHasGmcText(problem))
+                    continue;
+                gaps.Add($"Problem \"{problem.Name}\" has goal/conflict text but no cast links.");
+            }
+        }
+
+        if (gaps.Count == 0)
+            return;
+
+        sb.AppendLine("## Spine gaps");
+        foreach (var gap in gaps)
+            sb.AppendLine(gap);
+        sb.AppendLine();
+    }
+
+    private static bool ProblemHasGmcText(ProblemModel problem)
+    {
+        return !string.IsNullOrWhiteSpace(problem.ProtGoal)
+               || !string.IsNullOrWhiteSpace(problem.ProtMotive)
+               || !string.IsNullOrWhiteSpace(problem.ProtConflict)
+               || !string.IsNullOrWhiteSpace(problem.AntagGoal)
+               || !string.IsNullOrWhiteSpace(problem.AntagMotive)
+               || !string.IsNullOrWhiteSpace(problem.AntagConflict);
+    }
+
+    private void AppendCharacterProblemSlice(
+        StringBuilder sb,
+        CharacterModel character,
+        ProblemCharacterIndex index,
+        StoryModel model,
+        CharacterProblemDetail detail)
+    {
+        sb.AppendLine("## This character's problems");
+
+        var edges = index.SelectDetailedEdgesForCharacter(character.Uuid);
+        if (edges.Count == 0)
+        {
+            sb.AppendLine("Not protagonist or antagonist on any problem (off the problem spine).");
+            sb.AppendLine();
+            return;
+        }
+
+        foreach (var problemGroup in edges.GroupBy(e => e.ProblemGuid))
+        {
+            var sample = problemGroup.First();
+            var tag = sample.IsStoryProblem ? "Story Problem" : "Problem";
+            var roles = string.Join(", ", problemGroup
+                .OrderBy(e => e.Role == ProblemCharacterRole.Protagonist ? 0 : 1)
+                .Select(e => e.Role.ToString()));
+            sb.AppendLine($"- [{tag}] \"{sample.ProblemName}\" — {roles}");
+
+            if (detail != CharacterProblemDetail.LinksAndGmc)
+                continue;
+
+            var problem = ResolveElement(sample.ProblemGuid, model) as ProblemModel;
+            if (problem == null)
+                continue;
+
+            // This character's GMC side(s)
+            foreach (var edge in problemGroup.OrderBy(e => e.Role == ProblemCharacterRole.Protagonist ? 0 : 1))
+            {
+                if (edge.Role == ProblemCharacterRole.Protagonist)
+                {
+                    AppendGmcLine(sb, "  ProtGoal", problem.ProtGoal);
+                    AppendGmcLine(sb, "  ProtMotive", problem.ProtMotive);
+                    AppendGmcLine(sb, "  ProtConflict", problem.ProtConflict);
+                }
+                else
+                {
+                    AppendGmcLine(sb, "  AntagGoal", problem.AntagGoal);
+                    AppendGmcLine(sb, "  AntagMotive", problem.AntagMotive);
+                    AppendGmcLine(sb, "  AntagConflict", problem.AntagConflict);
+                }
+            }
+
+            // Opposing force when this character is only one side
+            var isProt = problemGroup.Any(e => e.Role == ProblemCharacterRole.Protagonist);
+            var isAntag = problemGroup.Any(e => e.Role == ProblemCharacterRole.Antagonist);
+            if (isProt && !isAntag && problem.Antagonist != Guid.Empty)
+            {
+                var antag = ResolveElement(problem.Antagonist, model) as CharacterModel;
+                if (antag != null)
+                {
+                    sb.AppendLine($"  Opposing (Antagonist): {antag.Name}");
+                    AppendGmcLine(sb, "  AntagGoal", problem.AntagGoal);
+                    AppendGmcLine(sb, "  AntagMotive", problem.AntagMotive);
+                    AppendGmcLine(sb, "  AntagConflict", problem.AntagConflict);
+                }
+            }
+            else if (isAntag && !isProt && problem.Protagonist != Guid.Empty)
+            {
+                var prot = ResolveElement(problem.Protagonist, model) as CharacterModel;
+                if (prot != null)
+                {
+                    sb.AppendLine($"  Opposing (Protagonist): {prot.Name}");
+                    AppendGmcLine(sb, "  ProtGoal", problem.ProtGoal);
+                    AppendGmcLine(sb, "  ProtMotive", problem.ProtMotive);
+                    AppendGmcLine(sb, "  ProtConflict", problem.ProtConflict);
+                }
+            }
+        }
+
+        sb.AppendLine();
+    }
+
+    private static void AppendGmcLine(StringBuilder sb, string label, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return;
+        sb.AppendLine($"{label}: {value.Trim()}");
     }
 
     #endregion

--- a/CollaboratorLib/Context/StoryContextBuilder.cs
+++ b/CollaboratorLib/Context/StoryContextBuilder.cs
@@ -374,23 +374,23 @@ public class StoryContextBuilder
 
         if (index.Edges.Count == 0)
         {
-            sb.AppendLine("No problems with protagonist/antagonist links yet.");
+            sb.AppendLine("No problems in the outline yet.");
             sb.AppendLine();
             return;
         }
 
-        var majorNames = index.Edges
-            .GroupBy(e => e.CharacterGuid)
-            .Select(g => g.First().CharacterName)
+        var majorNames = index.LinkedEdges
+            .Select(e => e.CharacterName)
             .Where(n => !string.IsNullOrWhiteSpace(n))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         if (majorNames.Count > 0)
-            sb.AppendLine($"Major cast (prot/antag on ≥1 problem): {string.Join(", ", majorNames)}");
+            sb.AppendLine($"Major cast (linked prot/antag on a problem): {string.Join(", ", majorNames)}");
+        else
+            sb.AppendLine("Major cast: none (no linked protagonist/antagonist slots).");
 
-        // Group edges by problem for readable lines
         foreach (var group in index.Edges
                      .GroupBy(e => e.ProblemGuid)
                      .OrderByDescending(g => g.Any(e => e.IsStoryProblem))
@@ -400,7 +400,7 @@ public class StoryContextBuilder
             var label = first.IsStoryProblem ? "Story Problem" : "Problem";
             var roles = group
                 .OrderBy(e => e.Role == ProblemCharacterRole.Protagonist ? 0 : 1)
-                .Select(e => $"{e.CharacterName} ({e.Role})")
+                .Select(FormatSlotForMap)
                 .ToList();
             sb.AppendLine($"{label} \"{first.ProblemName}\": {string.Join(", ", roles)}");
         }
@@ -408,40 +408,61 @@ public class StoryContextBuilder
         sb.AppendLine();
     }
 
+    private static string FormatSlotForMap(ProblemCharacterEdge edge)
+    {
+        return edge.Status switch
+        {
+            ProblemCharacterLinkStatus.Linked =>
+                $"{edge.CharacterName} ({edge.Role})",
+            ProblemCharacterLinkStatus.Unassigned =>
+                $"({edge.Role} unassigned)",
+            ProblemCharacterLinkStatus.Unresolved =>
+                $"({edge.Role} unresolved GUID)",
+            _ => $"({edge.Role} unknown)"
+        };
+    }
+
+    /// <summary>
+    /// Spine gaps derived only from the index (slot status + ProblemHasGmcText on edges).
+    /// </summary>
     private void AppendSpineGaps(StringBuilder sb, ProblemCharacterIndex index, StoryModel model)
     {
+        _ = model; // index is authoritative for slots; model kept for call-site symmetry
         var gaps = new List<string>();
 
-        if (index.StoryProblemGuid != Guid.Empty)
+        // One row per problem from either slot
+        foreach (var group in index.Edges.GroupBy(e => e.ProblemGuid))
         {
-            var storyProblem = ResolveElement(index.StoryProblemGuid, model) as ProblemModel;
-            if (storyProblem != null)
-            {
-                var storyEdges = index.EdgesForProblem(storyProblem.Uuid);
-                bool hasProt = storyEdges.Any(e => e.Role == ProblemCharacterRole.Protagonist);
-                bool hasAntag = storyEdges.Any(e => e.Role == ProblemCharacterRole.Antagonist);
-                if (!hasProt && !hasAntag)
-                    gaps.Add($"Story Problem \"{storyProblem.Name}\" has no protagonist/antagonist assigned.");
-                else if (!hasProt)
-                    gaps.Add($"Story Problem \"{storyProblem.Name}\" has no protagonist assigned.");
-                else if (!hasAntag)
-                    gaps.Add($"Story Problem \"{storyProblem.Name}\" has no antagonist assigned.");
-            }
-        }
+            var first = group.First();
+            var prot = group.FirstOrDefault(e => e.Role == ProblemCharacterRole.Protagonist);
+            var antag = group.FirstOrDefault(e => e.Role == ProblemCharacterRole.Antagonist);
+            var problemLabel = first.IsStoryProblem ? "Story Problem" : "Problem";
+            var problemName = first.ProblemName;
 
-        var problemsResult = _api.GetElementsByType(StoryItemType.Problem);
-        if (problemsResult.IsSuccess && problemsResult.Payload != null)
-        {
-            foreach (var element in problemsResult.Payload)
+            bool bothUnassigned =
+                prot is { Status: ProblemCharacterLinkStatus.Unassigned } &&
+                antag is { Status: ProblemCharacterLinkStatus.Unassigned };
+
+            if (bothUnassigned)
             {
-                if (element is not ProblemModel problem)
-                    continue;
-                if (index.EdgesForProblem(problem.Uuid).Count > 0)
-                    continue;
-                if (!ProblemHasGmcText(problem))
-                    continue;
-                gaps.Add($"Problem \"{problem.Name}\" has goal/conflict text but no cast links.");
+                // One line: empty cast is a spine hole; prefer GMC orphan wording when text exists
+                if (first.ProblemHasGmcText)
+                    gaps.Add($"{problemLabel} \"{problemName}\" has goal/conflict text but no cast links.");
+                else
+                    gaps.Add($"{problemLabel} \"{problemName}\" has no protagonist/antagonist assigned.");
             }
+            else
+            {
+                if (prot is { Status: ProblemCharacterLinkStatus.Unassigned })
+                    gaps.Add($"{problemLabel} \"{problemName}\" has no protagonist assigned.");
+                if (antag is { Status: ProblemCharacterLinkStatus.Unassigned })
+                    gaps.Add($"{problemLabel} \"{problemName}\" has no antagonist assigned.");
+            }
+
+            if (prot is { Status: ProblemCharacterLinkStatus.Unresolved })
+                gaps.Add($"{problemLabel} \"{problemName}\" protagonist link does not resolve to a character.");
+            if (antag is { Status: ProblemCharacterLinkStatus.Unresolved })
+                gaps.Add($"{problemLabel} \"{problemName}\" antagonist link does not resolve to a character.");
         }
 
         if (gaps.Count == 0)
@@ -451,16 +472,6 @@ public class StoryContextBuilder
         foreach (var gap in gaps)
             sb.AppendLine(gap);
         sb.AppendLine();
-    }
-
-    private static bool ProblemHasGmcText(ProblemModel problem)
-    {
-        return !string.IsNullOrWhiteSpace(problem.ProtGoal)
-               || !string.IsNullOrWhiteSpace(problem.ProtMotive)
-               || !string.IsNullOrWhiteSpace(problem.ProtConflict)
-               || !string.IsNullOrWhiteSpace(problem.AntagGoal)
-               || !string.IsNullOrWhiteSpace(problem.AntagMotive)
-               || !string.IsNullOrWhiteSpace(problem.AntagConflict);
     }
 
     private void AppendCharacterProblemSlice(
@@ -513,26 +524,31 @@ public class StoryContextBuilder
                 }
             }
 
-            // Opposing force when this character is only one side
+            // Opposing force from index slots (not a second Problem GUID walk)
             var isProt = problemGroup.Any(e => e.Role == ProblemCharacterRole.Protagonist);
             var isAntag = problemGroup.Any(e => e.Role == ProblemCharacterRole.Antagonist);
-            if (isProt && !isAntag && problem.Antagonist != Guid.Empty)
+            var problemSlots = index.EdgesForProblem(sample.ProblemGuid);
+            if (isProt && !isAntag)
             {
-                var antag = ResolveElement(problem.Antagonist, model) as CharacterModel;
-                if (antag != null)
+                var antagSlot = problemSlots.FirstOrDefault(e =>
+                    e.Role == ProblemCharacterRole.Antagonist &&
+                    e.Status == ProblemCharacterLinkStatus.Linked);
+                if (antagSlot != null)
                 {
-                    sb.AppendLine($"  Opposing (Antagonist): {antag.Name}");
+                    sb.AppendLine($"  Opposing (Antagonist): {antagSlot.CharacterName}");
                     AppendGmcLine(sb, "  AntagGoal", problem.AntagGoal);
                     AppendGmcLine(sb, "  AntagMotive", problem.AntagMotive);
                     AppendGmcLine(sb, "  AntagConflict", problem.AntagConflict);
                 }
             }
-            else if (isAntag && !isProt && problem.Protagonist != Guid.Empty)
+            else if (isAntag && !isProt)
             {
-                var prot = ResolveElement(problem.Protagonist, model) as CharacterModel;
-                if (prot != null)
+                var protSlot = problemSlots.FirstOrDefault(e =>
+                    e.Role == ProblemCharacterRole.Protagonist &&
+                    e.Status == ProblemCharacterLinkStatus.Linked);
+                if (protSlot != null)
                 {
-                    sb.AppendLine($"  Opposing (Protagonist): {prot.Name}");
+                    sb.AppendLine($"  Opposing (Protagonist): {protSlot.CharacterName}");
                     AppendGmcLine(sb, "  ProtGoal", problem.ProtGoal);
                     AppendGmcLine(sb, "  ProtMotive", problem.ProtMotive);
                     AppendGmcLine(sb, "  ProtConflict", problem.ProtConflict);


### PR DESCRIPTION
## Summary
- `ProblemCharacterIndex`: every problem contributes two cast slots (Linked / Unassigned / Unresolved)
- StoryContext: Cast-problem map, spine gaps (from index only), per-character problem slice with GMC when tiered
- ContextResolver tiers: Flaw/Backstory/RoleAndStoryRole = LinksAndGmc; Physical/Social/Traits = LinksOnly; Premise omits map

## Paired work
- Collaborator PR: design, ContextTests, Worker templates (dev Worker already deployed with step-4 prompts)
- Issue: storybuilder-org/Collaborator#107

## Test plan
- [x] Collaborator ContextTests green against this lib
- [ ] Manual: run Flaw on linked protagonist vs walk-on; confirm map/gaps/slice in context
- [ ] Jake testing welcome; file issues for findings