### PR TITLE
feat(#107): RelatedProblems collection and required-field gap GUIDs

### DIFF
--- a/CollaboratorLib/Context/ContextResolver.cs
+++ b/CollaboratorLib/Context/ContextResolver.cs
@@ -20,23 +20,21 @@ public class ContextResolver
     };
 
     /// <summary>
-    /// High-tier character craft: problem stakes (GMC) in StoryContext.
+    /// Character craft workflows that receive the RelatedProblems collection (issue #107).
+    /// Relationship is deferred (not problem-based).
     /// </summary>
-    private static readonly HashSet<string> CharacterHighDetailWorkflows = new(StringComparer.OrdinalIgnoreCase)
+    public static readonly HashSet<string> RelatedProblemsWorkflows = new(StringComparer.OrdinalIgnoreCase)
     {
+        "PhysicalAppearance",
+        "SocialFactors",
+        "PsychologicalMakeup",
+        "InnerOuterTraits",
         "Flaw",
         "Backstory",
         "RoleAndStoryRole"
     };
 
-    /// <summary>
-    /// Medium-tier character craft: links (and GMC when useful).
-    /// </summary>
-    private static readonly HashSet<string> CharacterMediumDetailWorkflows = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "PsychologicalMakeup",
-        "Relationship"
-    };
+    public const string RelatedProblemsRequestName = "RelatedProblems";
 
     /// <summary>
     /// Get the context specification for a workflow and element type combination.
@@ -48,14 +46,13 @@ public class ContextResolver
             return ContextSpec.Full;
         }
 
-        // Premise: constraints only (omit cast map to keep ideation prompts light)
+        // Premise: constraints + gaps (gap pass is outline-wide for every run)
         if (MinimalContextWorkflows.Contains(workflowLabel))
         {
             return new ContextSpec
             {
                 IncludeStoryConstraints = true,
-                IncludeCastProblemMap = false,
-                CharacterProblemDetail = CharacterProblemDetail.None
+                IncludeGaps = true
             };
         }
 
@@ -68,32 +65,22 @@ public class ContextResolver
                 IncludeCharacterContext = true,
                 IncludePrecedingEvents = true,
                 MaxPrecedingBeats = 2,
-                IncludeCastProblemMap = true,
-                CharacterProblemDetail = CharacterProblemDetail.None
+                IncludeGaps = true
             };
         }
 
         if (elementType == StoryItemType.Character)
         {
-            var detail = CharacterProblemDetail.LinksOnly;
-            if (CharacterHighDetailWorkflows.Contains(workflowLabel))
-                detail = CharacterProblemDetail.LinksAndGmc;
-            else if (CharacterMediumDetailWorkflows.Contains(workflowLabel))
-                detail = CharacterProblemDetail.LinksAndGmc;
-            // PhysicalAppearance, SocialFactors, InnerOuterTraits stay LinksOnly
-
             return new ContextSpec
             {
                 IncludeStoryConstraints = true,
                 IncludeBeatHierarchy = false,
                 IncludeCharacterContext = false,
                 IncludePrecedingEvents = false,
-                IncludeCastProblemMap = true,
-                CharacterProblemDetail = detail
+                IncludeGaps = true
             };
         }
 
-        // Default: constraints + spine map (problem/setting and other targets)
         return ContextSpec.Default;
     }
 

--- a/CollaboratorLib/Context/ContextSpec.cs
+++ b/CollaboratorLib/Context/ContextSpec.cs
@@ -1,21 +1,6 @@
 namespace CollaboratorLib.Context;
 
 /// <summary>
-/// How much problem detail to include for a character-target context slice (issue #107).
-/// </summary>
-public enum CharacterProblemDetail
-{
-    /// <summary>No per-character problem section.</summary>
-    None = 0,
-
-    /// <summary>Problem names and roles only.</summary>
-    LinksOnly = 1,
-
-    /// <summary>Links plus GMC fields and opposing force name when available.</summary>
-    LinksAndGmc = 2
-}
-
-/// <summary>
 /// Specifies what context to gather for a workflow invocation.
 /// Determined by ContextResolver based on workflow and element type.
 /// </summary>
@@ -47,18 +32,13 @@ public record ContextSpec
     public int MaxPrecedingBeats { get; init; } = 3;
 
     /// <summary>
-    /// Include outline-level cast–problem map and spine gap lines (issue #107).
-    /// Default on so most runs see plot-spine honesty; Premise turns this off.
+    /// Include outline-wide required-field gap GUIDs (issue #107).
+    /// Default on for all runs; turn off only for explicit minimal prompts.
     /// </summary>
-    public bool IncludeCastProblemMap { get; init; } = true;
+    public bool IncludeGaps { get; init; } = true;
 
     /// <summary>
-    /// Per-character problem slice when the target element is a Character.
-    /// </summary>
-    public CharacterProblemDetail CharacterProblemDetail { get; init; } = CharacterProblemDetail.None;
-
-    /// <summary>
-    /// Default spec with story constraints and cast–problem map (no beats / character GMC slice).
+    /// Default: story constraints + gap GUID list.
     /// </summary>
     public static ContextSpec Default => new();
 
@@ -72,7 +52,6 @@ public record ContextSpec
         IncludeCharacterContext = true,
         IncludePrecedingEvents = true,
         MaxPrecedingBeats = 3,
-        IncludeCastProblemMap = true,
-        CharacterProblemDetail = CharacterProblemDetail.None
+        IncludeGaps = true
     };
 }

--- a/CollaboratorLib/Context/ProblemCharacterIndex.cs
+++ b/CollaboratorLib/Context/ProblemCharacterIndex.cs
@@ -47,8 +47,6 @@ public sealed record ProblemCharacterEdge(
 /// </summary>
 public sealed class ProblemCharacterIndex
 {
-    public const int DefaultMaxDetailedProblems = 2;
-
     private readonly List<ProblemCharacterEdge> _edges;
     private readonly Dictionary<Guid, List<ProblemCharacterEdge>> _byCharacter;
     private readonly Dictionary<Guid, List<ProblemCharacterEdge>> _byProblem;
@@ -197,36 +195,14 @@ public sealed class ProblemCharacterIndex
     }
 
     /// <summary>
-    /// Linked slots for the character, prefer Story Problem, then Protagonist role; cap problems.
+    /// Distinct problem GUIDs where this character is Protagonist and/or Antagonist (linked).
+    /// Same character on both slots yields one GUID. No cap — all related problems.
     /// </summary>
-    public IReadOnlyList<ProblemCharacterEdge> SelectDetailedEdgesForCharacter(
-        Guid characterGuid,
-        int maxProblems = DefaultMaxDetailedProblems)
+    public IReadOnlyList<Guid> RelatedProblemGuids(Guid characterGuid)
     {
-        var edges = EdgesForCharacter(characterGuid);
-        if (edges.Count == 0)
-            return edges;
-
-        var ordered = edges
-            .OrderByDescending(e => e.IsStoryProblem)
-            .ThenBy(e => e.Role == ProblemCharacterRole.Protagonist ? 0 : 1)
-            .ThenBy(e => e.ProblemName, StringComparer.OrdinalIgnoreCase)
+        return EdgesForCharacter(characterGuid)
+            .Select(e => e.ProblemGuid)
+            .Distinct()
             .ToList();
-
-        var selectedProblems = new List<Guid>();
-        var result = new List<ProblemCharacterEdge>();
-        foreach (var edge in ordered)
-        {
-            if (!selectedProblems.Contains(edge.ProblemGuid))
-            {
-                if (selectedProblems.Count >= maxProblems)
-                    continue;
-                selectedProblems.Add(edge.ProblemGuid);
-            }
-            if (selectedProblems.Contains(edge.ProblemGuid))
-                result.Add(edge);
-        }
-
-        return result;
     }
 }

--- a/CollaboratorLib/Context/RequiredFieldGapScanner.cs
+++ b/CollaboratorLib/Context/RequiredFieldGapScanner.cs
@@ -1,0 +1,107 @@
+using StoryCADLib.Models;
+using StoryCADLib.Services.Collaborator.Contracts;
+
+namespace CollaboratorLib.Context;
+
+/// <summary>
+/// Outline-wide required-field gaps (issue #107). One GUID per element missing any required property.
+/// </summary>
+public static class RequiredFieldGapScanner
+{
+    /// <summary>
+    /// Returns distinct element GUIDs that fail at least one required-field check for their type.
+    /// Scans Overview, Problem, Character, Setting, and Scene only.
+    /// </summary>
+    public static IReadOnlyList<Guid> FindGapGuids(IStoryCADAPI api, StoryModel model)
+    {
+        if (api == null) throw new ArgumentNullException(nameof(api));
+        if (model == null) throw new ArgumentNullException(nameof(model));
+
+        var gaps = new List<Guid>();
+        foreach (var element in model.StoryElements)
+        {
+            if (element == null) continue;
+            if (HasGap(api, element))
+                gaps.Add(element.Uuid);
+        }
+
+        return gaps;
+    }
+
+    public static bool HasGap(IStoryCADAPI api, StoryElement element)
+    {
+        if (IsBlank(element.Name) || IsBlank(element.Description))
+            return true;
+
+        return element switch
+        {
+            OverviewModel overview => OverviewHasGap(api, overview),
+            ProblemModel problem => ProblemHasGap(api, problem),
+            CharacterModel character => CharacterHasGap(character),
+            SettingModel => false, // Name + Description only
+            SceneModel scene => SceneHasGap(api, scene),
+            _ => false
+        };
+    }
+
+    private static bool OverviewHasGap(IStoryCADAPI api, OverviewModel overview)
+    {
+        return IsBlank(overview.Author)
+            || IsBlank(overview.Concept)
+            || IsBlank(overview.Premise)
+            || IsBlank(overview.StoryType)
+            || IsBlank(overview.StoryGenre)
+            || !IsResolvable(api, overview.StoryProblem, StoryItemType.Problem);
+    }
+
+    private static bool ProblemHasGap(IStoryCADAPI api, ProblemModel problem)
+    {
+        return IsBlank(problem.ProblemCategory)
+            || IsBlank(problem.Premise)
+            || IsBlank(problem.ProtGoal)
+            || IsBlank(problem.ProtMotive)
+            || IsBlank(problem.ProtConflict)
+            || IsBlank(problem.AntagGoal)
+            || IsBlank(problem.AntagMotive)
+            || IsBlank(problem.AntagConflict)
+            || IsBlank(problem.Outcome)
+            || !IsResolvable(api, problem.Protagonist, StoryItemType.Character)
+            || !IsResolvable(api, problem.Antagonist, StoryItemType.Character);
+    }
+
+    private static bool CharacterHasGap(CharacterModel character)
+    {
+        return IsBlank(character.Role) || IsBlank(character.StoryRole);
+    }
+
+    private static bool SceneHasGap(IStoryCADAPI api, SceneModel scene)
+    {
+        if (!IsResolvable(api, scene.Setting, StoryItemType.Setting))
+            return true;
+
+        if (scene.CastMembers == null || scene.CastMembers.Count == 0)
+            return true;
+
+        foreach (var member in scene.CastMembers)
+        {
+            if (!IsResolvable(api, member, StoryItemType.Character))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsBlank(string? value) => string.IsNullOrWhiteSpace(value);
+
+    private static bool IsResolvable(IStoryCADAPI api, Guid guid, StoryItemType expectedType)
+    {
+        if (guid == Guid.Empty)
+            return false;
+
+        var result = api.GetStoryElement(guid);
+        if (!result.IsSuccess || result.Payload == null)
+            return false;
+
+        return result.Payload.ElementType == expectedType;
+    }
+}

--- a/CollaboratorLib/Context/StoryContextBuilder.cs
+++ b/CollaboratorLib/Context/StoryContextBuilder.cs
@@ -36,29 +36,12 @@ public class StoryContextBuilder
         var phase = DetectDevelopmentPhase(model);
         AppendPhaseContext(sb, phase);
 
-        // Issue #107: problem–character spine map (once per context build)
-        ProblemCharacterIndex? index = null;
-        if (spec.IncludeCastProblemMap ||
-            spec.CharacterProblemDetail != CharacterProblemDetail.None)
-        {
-            index = ProblemCharacterIndex.Build(_api, model);
-        }
-
-        if (spec.IncludeCastProblemMap && index != null)
-        {
-            AppendCastProblemMap(sb, index);
-            AppendSpineGaps(sb, index, model);
-        }
+        // Issue #107: required-field gap GUIDs (outline-wide; no problem craft paste)
+        if (spec.IncludeGaps)
+            AppendGaps(sb, model);
 
         if (spec.IncludeStoryConstraints)
             AppendStoryConstraints(sb, model);
-
-        if (spec.CharacterProblemDetail != CharacterProblemDetail.None &&
-            targetElement is CharacterModel character &&
-            index != null)
-        {
-            AppendCharacterProblemSlice(sb, character, index, model, spec.CharacterProblemDetail);
-        }
 
         if (spec.IncludeBeatHierarchy && targetElement is ProblemModel problem)
             AppendBeatHierarchy(sb, problem, model);
@@ -366,204 +349,21 @@ public class StoryContextBuilder
 
     #endregion
 
-    #region Cast–problem map and character slice (issue #107)
-
-    private void AppendCastProblemMap(StringBuilder sb, ProblemCharacterIndex index)
-    {
-        sb.AppendLine("## Cast-problem map");
-
-        if (index.Edges.Count == 0)
-        {
-            sb.AppendLine("No problems in the outline yet.");
-            sb.AppendLine();
-            return;
-        }
-
-        var majorNames = index.LinkedEdges
-            .Select(e => e.CharacterName)
-            .Where(n => !string.IsNullOrWhiteSpace(n))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        if (majorNames.Count > 0)
-            sb.AppendLine($"Major cast (linked prot/antag on a problem): {string.Join(", ", majorNames)}");
-        else
-            sb.AppendLine("Major cast: none (no linked protagonist/antagonist slots).");
-
-        foreach (var group in index.Edges
-                     .GroupBy(e => e.ProblemGuid)
-                     .OrderByDescending(g => g.Any(e => e.IsStoryProblem))
-                     .ThenBy(g => g.First().ProblemName, StringComparer.OrdinalIgnoreCase))
-        {
-            var first = group.First();
-            var label = first.IsStoryProblem ? "Story Problem" : "Problem";
-            var roles = group
-                .OrderBy(e => e.Role == ProblemCharacterRole.Protagonist ? 0 : 1)
-                .Select(FormatSlotForMap)
-                .ToList();
-            sb.AppendLine($"{label} \"{first.ProblemName}\": {string.Join(", ", roles)}");
-        }
-
-        sb.AppendLine();
-    }
-
-    private static string FormatSlotForMap(ProblemCharacterEdge edge)
-    {
-        return edge.Status switch
-        {
-            ProblemCharacterLinkStatus.Linked =>
-                $"{edge.CharacterName} ({edge.Role})",
-            ProblemCharacterLinkStatus.Unassigned =>
-                $"({edge.Role} unassigned)",
-            ProblemCharacterLinkStatus.Unresolved =>
-                $"({edge.Role} unresolved GUID)",
-            _ => $"({edge.Role} unknown)"
-        };
-    }
+    #region Required-field gaps (issue #107)
 
     /// <summary>
-    /// Spine gaps derived only from the index (slot status + ProblemHasGmcText on edges).
+    /// Outline-wide gaps: one GUID per element missing any required property.
     /// </summary>
-    private void AppendSpineGaps(StringBuilder sb, ProblemCharacterIndex index, StoryModel model)
+    private void AppendGaps(StringBuilder sb, StoryModel model)
     {
-        _ = model; // index is authoritative for slots; model kept for call-site symmetry
-        var gaps = new List<string>();
-
-        // One row per problem from either slot
-        foreach (var group in index.Edges.GroupBy(e => e.ProblemGuid))
-        {
-            var first = group.First();
-            var prot = group.FirstOrDefault(e => e.Role == ProblemCharacterRole.Protagonist);
-            var antag = group.FirstOrDefault(e => e.Role == ProblemCharacterRole.Antagonist);
-            var problemLabel = first.IsStoryProblem ? "Story Problem" : "Problem";
-            var problemName = first.ProblemName;
-
-            bool bothUnassigned =
-                prot is { Status: ProblemCharacterLinkStatus.Unassigned } &&
-                antag is { Status: ProblemCharacterLinkStatus.Unassigned };
-
-            if (bothUnassigned)
-            {
-                // One line: empty cast is a spine hole; prefer GMC orphan wording when text exists
-                if (first.ProblemHasGmcText)
-                    gaps.Add($"{problemLabel} \"{problemName}\" has goal/conflict text but no cast links.");
-                else
-                    gaps.Add($"{problemLabel} \"{problemName}\" has no protagonist/antagonist assigned.");
-            }
-            else
-            {
-                if (prot is { Status: ProblemCharacterLinkStatus.Unassigned })
-                    gaps.Add($"{problemLabel} \"{problemName}\" has no protagonist assigned.");
-                if (antag is { Status: ProblemCharacterLinkStatus.Unassigned })
-                    gaps.Add($"{problemLabel} \"{problemName}\" has no antagonist assigned.");
-            }
-
-            if (prot is { Status: ProblemCharacterLinkStatus.Unresolved })
-                gaps.Add($"{problemLabel} \"{problemName}\" protagonist link does not resolve to a character.");
-            if (antag is { Status: ProblemCharacterLinkStatus.Unresolved })
-                gaps.Add($"{problemLabel} \"{problemName}\" antagonist link does not resolve to a character.");
-        }
-
-        if (gaps.Count == 0)
+        var gapGuids = RequiredFieldGapScanner.FindGapGuids(_api, model);
+        if (gapGuids.Count == 0)
             return;
 
-        sb.AppendLine("## Spine gaps");
-        foreach (var gap in gaps)
-            sb.AppendLine(gap);
+        sb.AppendLine("## Gaps");
+        foreach (var guid in gapGuids)
+            sb.AppendLine(guid.ToString("D"));
         sb.AppendLine();
-    }
-
-    private void AppendCharacterProblemSlice(
-        StringBuilder sb,
-        CharacterModel character,
-        ProblemCharacterIndex index,
-        StoryModel model,
-        CharacterProblemDetail detail)
-    {
-        sb.AppendLine("## This character's problems");
-
-        var edges = index.SelectDetailedEdgesForCharacter(character.Uuid);
-        if (edges.Count == 0)
-        {
-            sb.AppendLine("Not protagonist or antagonist on any problem (off the problem spine).");
-            sb.AppendLine();
-            return;
-        }
-
-        foreach (var problemGroup in edges.GroupBy(e => e.ProblemGuid))
-        {
-            var sample = problemGroup.First();
-            var tag = sample.IsStoryProblem ? "Story Problem" : "Problem";
-            var roles = string.Join(", ", problemGroup
-                .OrderBy(e => e.Role == ProblemCharacterRole.Protagonist ? 0 : 1)
-                .Select(e => e.Role.ToString()));
-            sb.AppendLine($"- [{tag}] \"{sample.ProblemName}\" — {roles}");
-
-            if (detail != CharacterProblemDetail.LinksAndGmc)
-                continue;
-
-            var problem = ResolveElement(sample.ProblemGuid, model) as ProblemModel;
-            if (problem == null)
-                continue;
-
-            // This character's GMC side(s)
-            foreach (var edge in problemGroup.OrderBy(e => e.Role == ProblemCharacterRole.Protagonist ? 0 : 1))
-            {
-                if (edge.Role == ProblemCharacterRole.Protagonist)
-                {
-                    AppendGmcLine(sb, "  ProtGoal", problem.ProtGoal);
-                    AppendGmcLine(sb, "  ProtMotive", problem.ProtMotive);
-                    AppendGmcLine(sb, "  ProtConflict", problem.ProtConflict);
-                }
-                else
-                {
-                    AppendGmcLine(sb, "  AntagGoal", problem.AntagGoal);
-                    AppendGmcLine(sb, "  AntagMotive", problem.AntagMotive);
-                    AppendGmcLine(sb, "  AntagConflict", problem.AntagConflict);
-                }
-            }
-
-            // Opposing force from index slots (not a second Problem GUID walk)
-            var isProt = problemGroup.Any(e => e.Role == ProblemCharacterRole.Protagonist);
-            var isAntag = problemGroup.Any(e => e.Role == ProblemCharacterRole.Antagonist);
-            var problemSlots = index.EdgesForProblem(sample.ProblemGuid);
-            if (isProt && !isAntag)
-            {
-                var antagSlot = problemSlots.FirstOrDefault(e =>
-                    e.Role == ProblemCharacterRole.Antagonist &&
-                    e.Status == ProblemCharacterLinkStatus.Linked);
-                if (antagSlot != null)
-                {
-                    sb.AppendLine($"  Opposing (Antagonist): {antagSlot.CharacterName}");
-                    AppendGmcLine(sb, "  AntagGoal", problem.AntagGoal);
-                    AppendGmcLine(sb, "  AntagMotive", problem.AntagMotive);
-                    AppendGmcLine(sb, "  AntagConflict", problem.AntagConflict);
-                }
-            }
-            else if (isAntag && !isProt)
-            {
-                var protSlot = problemSlots.FirstOrDefault(e =>
-                    e.Role == ProblemCharacterRole.Protagonist &&
-                    e.Status == ProblemCharacterLinkStatus.Linked);
-                if (protSlot != null)
-                {
-                    sb.AppendLine($"  Opposing (Protagonist): {protSlot.CharacterName}");
-                    AppendGmcLine(sb, "  ProtGoal", problem.ProtGoal);
-                    AppendGmcLine(sb, "  ProtMotive", problem.ProtMotive);
-                    AppendGmcLine(sb, "  ProtConflict", problem.ProtConflict);
-                }
-            }
-        }
-
-        sb.AppendLine();
-    }
-
-    private static void AppendGmcLine(StringBuilder sb, string label, string? value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            return;
-        sb.AppendLine($"{label}: {value.Trim()}");
     }
 
     #endregion

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -213,6 +213,7 @@ namespace StoryCollaborator
         /// Builds the #106 request body: full gathered elements (RTF stripped on outbound copy only)
         /// plus pass-through args and declared collection lists. Does not flatten Label_Property keys
         /// and does not invent lists from WriteVia.
+        /// Issue #107: character craft workflows also get RelatedProblems (full Problem models).
         /// </summary>
         internal WorkflowProxyBody BuildWorkflowRequestBody(Dictionary<string, StoryElement> gatheredElements)
         {
@@ -236,7 +237,38 @@ namespace StoryCollaborator
                 body.Args[collection.RequestName] = JsonSerializer.Serialize(projected, serOpts);
             }
 
+            AttachRelatedProblemsCollection(body, gatheredElements, serOpts);
+
             return body;
+        }
+
+        /// <summary>
+        /// Index → all problems where Character is prot and/or antag → full models in args.
+        /// Empty array when no links or no Character. Relationship deferred.
+        /// </summary>
+        private void AttachRelatedProblemsCollection(
+            WorkflowProxyBody body,
+            Dictionary<string, StoryElement> gatheredElements,
+            JsonSerializerOptions serOpts)
+        {
+            _ = serOpts;
+            if (!ContextResolver.RelatedProblemsWorkflows.Contains(workflowModel.Label))
+                return;
+
+            var array = new JsonArray();
+            if (gatheredElements.TryGetValue("Character", out var characterElement) &&
+                characterElement is CharacterModel character)
+            {
+                var index = ProblemCharacterIndex.Build(_storyApi, storyModel);
+                foreach (var problemGuid in index.RelatedProblemGuids(character.Uuid))
+                {
+                    var result = _storyApi.GetStoryElement(problemGuid);
+                    if (result.IsSuccess && result.Payload is ProblemModel problem)
+                        array.Add(SerializeElementOutbound(problem));
+                }
+            }
+
+            body.Args[ContextResolver.RelatedProblemsRequestName] = array.ToJsonString();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Attach **all** problems where the target character is prot and/or antag as full models on `args.RelatedProblems` (character craft workflows; not Relationship).
- Replace StoryContext cast-problem map / spine prose / character problem paste with outline-wide **## Gaps** (required-field GUID list via `RequiredFieldGapScanner`).
- Part of Collaborator #107 phases 5 / 5b. **Issue stays open** (phase 6 gap workflow next).

## Test plan
- [x] Collaborator.sln Debug/x64 build (uses this CollaboratorLib)
- [x] CollaboratorTests: 228 passed, 23 skipped
- [ ] Manual: Role on a Story Problem protagonist with RelatedProblems on wire (proxy already deployed)

## Related
- Collaborator companion PR (tests, proxy templates, design phases 5–6)
- Proxy dev already deployed with Role/Flaw/Backstory consuming RelatedProblems