### PR TITLE
chore(#1497): Uno.Sdk 6.6.42 and remove Tmds.DBus.Protocol pin

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Microsoft.SemanticKernel.Planners.OpenAI" Version="1.16.0-preview" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Elmah.Io.Client" Version="5.3.131" />
-    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageVersion Include="dotenv.net" Version="4.0.1" />
     <PackageVersion Include="Elmah.Io.NLog" Version="5.4.80" />
     <PackageVersion Include="MySql.Data" Version="9.6.0" />
@@ -24,11 +24,6 @@
     <PackageVersion Include="Octokit" Version="14.0.0" />
     <PackageVersion Include="SkiaSharp" Version="3.119.2" />
     <PackageVersion Include="Uno.Fonts.Fluent" Version="2.7.1" />
-    <!-- Pinned to override Uno 6.5's vulnerable transitive (GHSA-xrw6-gwf8-vvr9, high severity).
-         Uno PR #22998 bumped Tmds.DBus.Protocol to 0.92.0 on master but did NOT backport to the 6.5 line.
-         Remove this pin (and the direct PackageReference lines in StoryCAD.csproj / StoryCADTests.csproj)
-         when global.json Uno.Sdk bumps to 6.6+. Tracked by issue #1383. -->
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.3" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.1.0" />
     <PackageVersion Include="MSTest.TestFramework" Version="4.1.0" />
     <PackageVersion Include="Microsoft.TestPlatform.TestHost" Version="18.3.0" />

--- a/StoryCAD/StoryCAD.csproj
+++ b/StoryCAD/StoryCAD.csproj
@@ -101,9 +101,6 @@
 
     <ItemGroup>
         <PackageReference Include="Uno.Fonts.Fluent" />
-        <!-- Transitive CVE override (GHSA-xrw6-gwf8-vvr9). Version pinned in Directory.Packages.props.
-             Remove when Uno.Sdk in global.json bumps to 6.6+. Tracked by issue #1383. -->
-        <PackageReference Include="Tmds.DBus.Protocol" />
     </ItemGroup>
 
     <ItemGroup>

--- a/StoryCADTests/StoryCADTests.csproj
+++ b/StoryCADTests/StoryCADTests.csproj
@@ -109,9 +109,6 @@
             <ExcludeAssets>build</ExcludeAssets>
         </PackageReference>
         <PackageReference Include="CommunityToolkit.Mvvm" />
-        <!-- Transitive CVE override (GHSA-xrw6-gwf8-vvr9). Version pinned in Directory.Packages.props.
-             Remove when Uno.Sdk in global.json bumps to 6.6+. Tracked by issue #1383. -->
-        <PackageReference Include="Tmds.DBus.Protocol" />
     </ItemGroup>
 
     <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.31"
+    "Uno.Sdk": "6.6.42"
   },
   "sdk": {
     "version": "10.0.100",


### PR DESCRIPTION
## Summary
- `global.json`: **Uno.Sdk 6.6.42**
- **Same commit:** remove `Tmds.DBus.Protocol` 0.21.3 CPM pin + PackageReferences in StoryCAD / StoryCADTests (**#1383**) — restore fails with NU1109 if pin remains on 6.6
- `CommunityToolkit.Mvvm` → **8.4.2** (Uno.UI.HotDesign)

## Verification
- [x] Restore without NU1109
- [x] StoryCAD.sln Debug/x64 build
- [x] `Tmds.DBus.Protocol` **0.92.0** transitive
- [x] `dotnet list package --vulnerable --include-transitive` clean for StoryCAD projects
- [x] StoryCADTests 1255 passed / 14 skipped

## Related
- Closes work tracked by #1497 (StoryCAD side)
- Completes #1383 pin removal (close when this merges)
- Companion PRs: Collaborator + StoryCADAPI