### PR TITLE
Update UI

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -349,10 +349,10 @@ public class Collaborator : ICollaborator
         ArgumentNullException.ThrowIfNull(workflow);
 
         viewModel.Title = workflow.Title;
+        // Brief purpose only; long registry Explanation is not shown (topical strip instead).
         viewModel.Description = workflow.Description;
-        viewModel.Explanation = workflow.Explanation;
 
-        // Build summary of selected elements
+        // Selected elements live in topical Explanation (#129), not a separate card.
         if (gatheredElements != null && gatheredElements.Count > 0)
         {
             var lines = gatheredElements
@@ -360,6 +360,12 @@ public class Collaborator : ICollaborator
                 .ToList();
             viewModel.SelectedElementsSummary = string.Join("\n", lines);
         }
+        else
+        {
+            viewModel.SelectedElementsSummary = string.Empty;
+        }
+
+        viewModel.RefreshTopicalExplanation();
     }
 
     /// <summary>

--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -42,6 +42,7 @@ public class Collaborator : ICollaborator
     private ElementResolver? _elementResolver;
     private string? _filePath;
     private Window? _hostWindow;
+    private WorkflowShellViewModel? _shellViewModel;
     private bool _disposed;
     private StoryCADLib.Services.Logging.ILogService? _auditLogger;
 
@@ -129,6 +130,7 @@ public class Collaborator : ICollaborator
             var viewModel = shell.DataContext as StoryCADLib.Collaborator.ViewModels.WorkflowShellViewModel;
             if (viewModel != null)
             {
+                _shellViewModel = viewModel;
                 viewModel.MenuItems.Clear();
                 foreach (var workflow in WorkflowRegistry.All)
                 {
@@ -169,6 +171,10 @@ public class Collaborator : ICollaborator
                 {
                     if (viewModel.ContentFrame != null && workflowTag is Workflow workflow)
                     {
+                        // Short name on top bar (Label, not long Title path).
+                        viewModel.ActiveWorkflowName = FormatWorkflowShortName(workflow.Label);
+                        viewModel.HasPendingUpdates = false;
+
                         // Clear shell status; gather cancel has no chat page (#123).
                         viewModel.StatusText = string.Empty;
 
@@ -193,6 +199,7 @@ public class Collaborator : ICollaborator
                         {
                             PopulateWorkflowViewModel(page.ViewModel, workflow, gatherResult.Elements);
                             WireUpChatCallback(page.ViewModel, workflow, gatherResult.Elements);
+                            WireShellWorkflowActions(page.ViewModel);
 
                             // Add status messages from gathering phase
                             foreach (var message in gatherResult.StatusMessages)
@@ -618,6 +625,7 @@ public class Collaborator : ICollaborator
                             if (protect.Count == 0)
                             {
                                 viewModel.MarkUpdatesApplied();
+                                SyncShellPending(viewModel);
                             }
                             else
                             {
@@ -769,7 +777,10 @@ public class Collaborator : ICollaborator
                                     : "All done.")));
 
                             if (result.PendingUpdates.Count == 0)
+                            {
                                 viewModel.MarkUpdatesApplied();
+                                SyncShellPending(viewModel);
+                            }
                             else
                                 PushPendingToViewModel(viewModel, result);
 
@@ -817,14 +828,41 @@ public class Collaborator : ICollaborator
     }
 
     /// <summary>
-    /// Pushes classified pending updates into the workflow panel (issue #116).
+    /// Pushes classified pending updates into the workflow panel (issue #116)
+    /// and enables shell Accept All / Review Each / Try Again.
     /// </summary>
-    private static void PushPendingToViewModel(
+    private void PushPendingToViewModel(
         StoryCADLib.Collaborator.ViewModels.WorkflowViewModel viewModel,
         WorkflowResult result)
     {
         var items = result.PendingUpdates.Select(ToPendingUpdateItem).ToList();
         viewModel.SetPendingUpdates(items);
+        SyncShellPending(viewModel);
+    }
+
+    /// <summary>
+    /// Routes top-bar Accept All / Review Each / Try Again to the active page VM.
+    /// </summary>
+    private void WireShellWorkflowActions(WorkflowViewModel pageVm)
+    {
+        if (_shellViewModel == null) return;
+
+        _shellViewModel.OnAcceptAll = () => pageVm.AcceptAllCommand.Execute(null);
+        _shellViewModel.OnReviewEach = () => pageVm.ReviewEachCommand.Execute(null);
+        _shellViewModel.OnTryAgain = async () =>
+        {
+            if (pageVm.OnTryAgain != null)
+                await pageVm.OnTryAgain();
+            else
+                pageVm.TryAgainCommand.Execute(null);
+        };
+        SyncShellPending(pageVm);
+    }
+
+    private void SyncShellPending(WorkflowViewModel pageVm)
+    {
+        if (_shellViewModel != null)
+            _shellViewModel.HasPendingUpdates = pageVm.HasPendingUpdates;
     }
 
     private static PendingUpdateItem ToPendingUpdateItem(PendingUpdate u)
@@ -900,6 +938,30 @@ public class Collaborator : ICollaborator
         public Dictionary<string, StoryElement> Elements { get; set; } = new();
         public List<string> StatusMessages { get; set; } = new();
         public bool Cancelled { get; set; }
+    }
+
+    /// <summary>
+    /// Short chrome label from registry Label (e.g. StoryProblem → "Story Problem").
+    /// Not the long Title path used in the nav list.
+    /// </summary>
+    private static string FormatWorkflowShortName(string? label)
+    {
+        if (string.IsNullOrWhiteSpace(label))
+            return string.Empty;
+
+        // Insert spaces before capitals in PascalCase / camelCase identifiers.
+        var sb = new System.Text.StringBuilder(label.Length + 8);
+        for (var i = 0; i < label.Length; i++)
+        {
+            var c = label[i];
+            if (i > 0 && char.IsUpper(c) && !char.IsUpper(label[i - 1]))
+                sb.Append(' ');
+            else if (i > 0 && char.IsUpper(c) && i + 1 < label.Length && char.IsLower(label[i + 1])
+                     && char.IsUpper(label[i - 1]))
+                sb.Append(' ');
+            sb.Append(c);
+        }
+        return sb.ToString();
     }
 
     /// <summary>

--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -11,8 +11,10 @@ using StoryCADLib.Services.Store;
 using StoryCollaborator.Services;
 using StoryCollaborator.Models;
 using StoryCollaborator.Workflows;
+using CollaboratorLib.Context;
 using StoryCADLib.Collaborator.ViewModels;
 using StoryCADLib.Collaborator.Models;
+using StoryCADLib.Collaborator.Views;
 
 namespace StoryCollaborator;
 
@@ -131,31 +133,9 @@ public class Collaborator : ICollaborator
             if (viewModel != null)
             {
                 _shellViewModel = viewModel;
-                // Workflows grouped by story element type; group headers expand/collapse only (#129).
-                viewModel.MenuItems.Clear();
-                Microsoft.UI.Xaml.Controls.NavigationViewItem? group = null;
-                StoryItemType? groupType = null;
-                foreach (var workflow in WorkflowRegistry.All)
-                {
-                    if (group == null || workflow.PrimaryElementType != groupType)
-                    {
-                        groupType = workflow.PrimaryElementType;
-                        group = new Microsoft.UI.Xaml.Controls.NavigationViewItem
-                        {
-                            Content = GroupTitle(groupType.Value),
-                            SelectsOnInvoked = false,
-                            IsExpanded = true
-                        };
-                        viewModel.MenuItems.Add(group);
-                    }
-
-                    group.MenuItems.Add(new Microsoft.UI.Xaml.Controls.NavigationViewItem
-                    {
-                        Content = workflow.Title,
-                        Tag = workflow
-                    });
-                }
-                _logger.LogInformation("Populated {Count} workflow groups in menu", viewModel.MenuItems.Count);
+                // Outline gaps (if any) then #129 groups by element type.
+                RebuildWorkflowMenu(viewModel);
+                _logger.LogInformation("Populated {Count} menu items", viewModel.MenuItems.Count);
 
                 // Set up settings - pass current settings and wire up change callback
                 viewModel.CurrentSettings = _settings;
@@ -184,7 +164,18 @@ public class Collaborator : ICollaborator
                 // Set up navigation callback - when user selects a workflow, navigate to WorkflowPage
                 viewModel.OnWorkflowSelected = async (workflowTag) =>
                 {
-                    if (viewModel.ContentFrame != null && workflowTag is Workflow workflow)
+                    if (viewModel.ContentFrame == null)
+                        return;
+
+                    // Issue #107 phase 6: Outline gaps (navigate only; no LLM)
+                    if (workflowTag is string tag &&
+                        string.Equals(tag, GapWorkflowOwnership.OutlineGapsTag, StringComparison.Ordinal))
+                    {
+                        await OpenOutlineGapsPageAsync(viewModel);
+                        return;
+                    }
+
+                    if (workflowTag is Workflow workflow)
                     {
                         // Short name on top bar (Label, not long Title path).
                         viewModel.ActiveWorkflowName = FormatWorkflowShortName(workflow.Label);
@@ -224,6 +215,9 @@ public class Collaborator : ICollaborator
 
                             // Auto-execute the workflow and show progress
                             await ExecuteWorkflowWithFeedback(page.ViewModel, workflow, gatherResult.Elements);
+
+                            // Gaps may have closed after Accept — refresh nav
+                            RebuildWorkflowMenu(viewModel);
                         }
 
                         _logger.LogInformation("Navigated to workflow: {Workflow} with {Count} input elements",
@@ -270,6 +264,131 @@ public class Collaborator : ICollaborator
 
         Dispose();
         return result;
+    }
+
+    /// <summary>
+    /// Rebuild nav: Outline gaps first (when any), then workflows grouped by element type (#129).
+    /// </summary>
+    private void RebuildWorkflowMenu(WorkflowShellViewModel viewModel)
+    {
+        viewModel.MenuItems.Clear();
+
+        if (_storyApi != null && _storyModel != null)
+        {
+            var gapDetails = RequiredFieldGapScanner.FindGapDetails(_storyApi, _storyModel);
+            if (gapDetails.Count > 0)
+            {
+                viewModel.MenuItems.Add(new Microsoft.UI.Xaml.Controls.NavigationViewItem
+                {
+                    Content = $"{GapWorkflowOwnership.OutlineGapsNavTitle} ({gapDetails.Count})",
+                    Tag = GapWorkflowOwnership.OutlineGapsTag
+                });
+            }
+        }
+
+        // Workflows grouped by story element type; group headers expand/collapse only (#129).
+        Microsoft.UI.Xaml.Controls.NavigationViewItem? group = null;
+        StoryItemType? groupType = null;
+        foreach (var workflow in WorkflowRegistry.All)
+        {
+            if (group == null || workflow.PrimaryElementType != groupType)
+            {
+                groupType = workflow.PrimaryElementType;
+                group = new Microsoft.UI.Xaml.Controls.NavigationViewItem
+                {
+                    Content = GroupTitle(groupType.Value),
+                    SelectsOnInvoked = false,
+                    IsExpanded = true
+                };
+                viewModel.MenuItems.Add(group);
+            }
+
+            group.MenuItems.Add(new Microsoft.UI.Xaml.Controls.NavigationViewItem
+            {
+                Content = workflow.Title,
+                Tag = workflow
+            });
+        }
+    }
+
+    /// <summary>
+    /// Opens the Outline gaps page (no gather, no LLM).
+    /// </summary>
+    private Task OpenOutlineGapsPageAsync(WorkflowShellViewModel shellViewModel)
+    {
+        shellViewModel.StatusText = string.Empty;
+        if (_storyApi == null || _storyModel == null || shellViewModel.ContentFrame == null)
+            return Task.CompletedTask;
+
+        var details = RequiredFieldGapScanner.FindGapDetails(_storyApi, _storyModel);
+        var groups = details.Select(d =>
+        {
+            // Option 2: each missing field is a link (workflow if mapped, else host element)
+            var fields = new List<GapFieldLink>();
+            for (var i = 0; i < d.MissingProperties.Count; i++)
+            {
+                var prop = d.MissingProperties[i];
+                var display = i < d.MissingPropertyLabels.Count
+                    ? d.MissingPropertyLabels[i]
+                    : prop;
+                var helpers = GapWorkflowOwnership.WorkflowsFor(d.ElementType, prop);
+                var workflowLabel = helpers.Count > 0 ? helpers[0] : string.Empty;
+                var wf = string.IsNullOrEmpty(workflowLabel)
+                    ? null
+                    : WorkflowRegistry.Get(workflowLabel);
+
+                fields.Add(new GapFieldLink
+                {
+                    DisplayLabel = display,
+                    PropertyName = prop,
+                    ElementGuid = d.ElementGuid,
+                    WorkflowLabel = workflowLabel,
+                    WorkflowTitle = wf?.Title ?? workflowLabel
+                });
+            }
+
+            return new GapElementGroup
+            {
+                ElementGuid = d.ElementGuid,
+                ElementName = d.ElementName,
+                ElementTypeLabel = d.ElementType.ToString(),
+                MissingFields = fields
+            };
+        }).ToList();
+
+        shellViewModel.ContentFrame.Navigate(typeof(GapWorkflowPage));
+        if (shellViewModel.ContentFrame.Content is GapWorkflowPage page && page.ViewModel != null)
+        {
+            page.ViewModel.Load(new GapWorkflowPayload { Groups = groups });
+            page.ViewModel.OnOpenElement = guid =>
+            {
+                var result = _storyApi.SelectStoryElement(guid);
+                if (!result.IsSuccess)
+                    shellViewModel.StatusText = result.ErrorMessage ?? "Could not open element in StoryCAD.";
+                else
+                    shellViewModel.StatusText = string.Empty;
+            };
+            page.ViewModel.OnOpenWorkflow = async label =>
+            {
+                var workflow = WorkflowRegistry.Get(label);
+                if (workflow == null)
+                {
+                    shellViewModel.StatusText = $"Unknown workflow: {label}";
+                    return;
+                }
+
+                // Select matching nav item if present (workflows are nested under type groups, #129)
+                var navItem = FindWorkflowNavItem(shellViewModel, label);
+                if (navItem != null)
+                    shellViewModel.CurrentItem = navItem;
+
+                if (shellViewModel.OnWorkflowSelected != null)
+                    await shellViewModel.OnWorkflowSelected(workflow);
+            };
+        }
+
+        _logger?.LogInformation("Opened Outline gaps page with {Count} gappy elements", groups.Count);
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -982,6 +1101,27 @@ public class Collaborator : ICollaborator
     /// Short chrome label from registry Label (e.g. StoryProblem → "Story Problem").
     /// Not the long Title path used in the nav list.
     /// </summary>
+    private static Microsoft.UI.Xaml.Controls.NavigationViewItem? FindWorkflowNavItem(
+        WorkflowShellViewModel shellViewModel,
+        string workflowLabel)
+    {
+        foreach (var top in shellViewModel.MenuItems)
+        {
+            if (top.Tag is Workflow w &&
+                string.Equals(w.Label, workflowLabel, StringComparison.OrdinalIgnoreCase))
+                return top;
+
+            foreach (var child in top.MenuItems.OfType<Microsoft.UI.Xaml.Controls.NavigationViewItem>())
+            {
+                if (child.Tag is Workflow cw &&
+                    string.Equals(cw.Label, workflowLabel, StringComparison.OrdinalIgnoreCase))
+                    return child;
+            }
+        }
+
+        return null;
+    }
+
     private static string FormatWorkflowShortName(string? label) =>
         ValueDisplay.SplitPascalCase(label);
 

--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -131,16 +131,31 @@ public class Collaborator : ICollaborator
             if (viewModel != null)
             {
                 _shellViewModel = viewModel;
+                // Workflows grouped by story element type; group headers expand/collapse only (#129).
                 viewModel.MenuItems.Clear();
+                Microsoft.UI.Xaml.Controls.NavigationViewItem? group = null;
+                StoryItemType? groupType = null;
                 foreach (var workflow in WorkflowRegistry.All)
                 {
-                    viewModel.MenuItems.Add(new Microsoft.UI.Xaml.Controls.NavigationViewItem
+                    if (group == null || workflow.PrimaryElementType != groupType)
+                    {
+                        groupType = workflow.PrimaryElementType;
+                        group = new Microsoft.UI.Xaml.Controls.NavigationViewItem
+                        {
+                            Content = GroupTitle(groupType.Value),
+                            SelectsOnInvoked = false,
+                            IsExpanded = true
+                        };
+                        viewModel.MenuItems.Add(group);
+                    }
+
+                    group.MenuItems.Add(new Microsoft.UI.Xaml.Controls.NavigationViewItem
                     {
                         Content = workflow.Title,
                         Tag = workflow
                     });
                 }
-                _logger.LogInformation("Populated {Count} workflows in menu", viewModel.MenuItems.Count);
+                _logger.LogInformation("Populated {Count} workflow groups in menu", viewModel.MenuItems.Count);
 
                 // Set up settings - pass current settings and wire up change callback
                 viewModel.CurrentSettings = _settings;
@@ -201,10 +216,10 @@ public class Collaborator : ICollaborator
                             WireUpChatCallback(page.ViewModel, workflow, gatherResult.Elements);
                             WireShellWorkflowActions(page.ViewModel);
 
-                            // Add status messages from gathering phase
+                            // Add status messages from gathering phase (rolled up, #129)
                             foreach (var message in gatherResult.StatusMessages)
                             {
-                                page.ViewModel.ConversationList.Add(ChatMessage.FromCollaborator(message));
+                                page.ViewModel.AddStatusMessage(message);
                             }
 
                             // Auto-execute the workflow and show progress
@@ -389,7 +404,12 @@ public class Collaborator : ICollaborator
             $"{workflow.Description}\n\n" +
             $"## Current Story Context\n{elementContext}\n\n" +
             "Provide helpful, constructive feedback to help the writer develop their story. " +
-            "Reference the story elements above when giving advice.");
+            "Reference the story elements above when giving advice.\n\n" +
+            // The chat pane renders replies in a plain TextBlock; any markup arrives verbatim.
+            "Respond in plain text only. Never use Markdown, HTML, RTF, or any other markup: " +
+            "no headings, asterisks for bold or italics, backticks, tables, or links. " +
+            "The display cannot render formatting, so markup characters would appear literally. " +
+            "For lists, use simple lines starting with a hyphen. Separate ideas with blank lines.");
 
         // Wire up the callback
         viewModel.OnSendMessage = async (userMessage) =>
@@ -516,7 +536,7 @@ public class Collaborator : ICollaborator
         try
         {
             // Show progress
-            viewModel.ConversationList.Add(ChatMessage.FromCollaborator($"Running {workflow.Title}..."));
+            viewModel.AddStatusMessage($"Running {workflow.Title}...");
             viewModel.ProgressVisibility = Microsoft.UI.Xaml.Visibility.Visible;
 
             // Execute via WorkflowRunner
@@ -535,16 +555,15 @@ public class Collaborator : ICollaborator
 
             if (result.Success)
             {
-                // Show status messages (omit noisy per-field classify lines from chat)
-                viewModel.ConversationList.Add(ChatMessage.FromCollaborator($"Workflow completed successfully."));
-
+                // Show status messages rolled up (omit noisy per-field classify lines)
                 foreach (var msg in result.StatusMessages)
                 {
                     if (msg.StartsWith("Classified ", StringComparison.Ordinal)
                         || msg.StartsWith("No-op ", StringComparison.Ordinal))
                         continue;
-                    viewModel.ConversationList.Add(ChatMessage.FromCollaborator($"  {msg}"));
+                    viewModel.AddStatusMessage(msg);
                 }
+                viewModel.AddStatusMessage("Workflow completed successfully.");
 
                 // Add AI explanation if available in raw response
                 if (!string.IsNullOrEmpty(result.RawResponse))
@@ -598,7 +617,7 @@ public class Collaborator : ICollaborator
                                 sb.AppendLine();
                                 foreach (var u in free)
                                 {
-                                    var valuePreview = TruncateForChat(u.Value?.ToString());
+                                    var valuePreview = TruncateForChat(FormatValueForDisplay(u.Value));
                                     sb.AppendLine($"**{u.Key}**: {valuePreview}");
                                     sb.AppendLine();
                                 }
@@ -659,7 +678,7 @@ public class Collaborator : ICollaborator
                         try
                         {
                             viewModel.ClearPendingUpdates();
-                            viewModel.ConversationList.Add(ChatMessage.FromCollaborator("Re-running workflow..."));
+                            viewModel.AddStatusMessage("Re-running workflow...");
                             await ExecuteWorkflowWithFeedback(viewModel, workflow, gatheredElements);
                         }
                         catch (Exception ex)
@@ -694,7 +713,7 @@ public class Collaborator : ICollaborator
                             if (applied > 0)
                             {
                                 _sessionTouchedFields.Add(pending.SessionTouchKey);
-                                viewModel.ConversationList.Add(ChatMessage.FromCollaborator($"Applied {propertyKey}"));
+                                viewModel.AddStatusMessage($"Applied {propertyKey}");
                                 _logger?.LogInformation("AcceptProperty: Applied {Key}", propertyKey);
                                 _auditLogger?.Log(StoryCADLib.Services.Logging.LogLevel.Info,
                                     $"Applied update: {propertyKey}");
@@ -735,7 +754,7 @@ public class Collaborator : ICollaborator
                             result.UpdatedProperties.Remove(propertyKey);
                             if (removed > 0)
                             {
-                                viewModel.ConversationList.Add(ChatMessage.FromCollaborator($"Skipped {propertyKey}"));
+                                viewModel.AddStatusMessage($"Skipped {propertyKey}");
                                 _logger?.LogInformation("SkipProperty: Skipped {Key}", propertyKey);
                                 PushPendingToViewModel(viewModel, result);
                             }
@@ -818,7 +837,7 @@ public class Collaborator : ICollaborator
                 viewModel.ConversationList.Add(ChatMessage.Error(result.ErrorMessage ?? "Unknown error"));
                 foreach (var msg in result.StatusMessages)
                 {
-                    viewModel.ConversationList.Add(ChatMessage.FromCollaborator($"  {msg}"));
+                    viewModel.AddStatusMessage(msg);
                 }
             }
 
@@ -871,9 +890,9 @@ public class Collaborator : ICollaborator
             _shellViewModel.HasPendingUpdates = pageVm.HasPendingUpdates;
     }
 
-    private static PendingUpdateItem ToPendingUpdateItem(PendingUpdate u)
+    private PendingUpdateItem ToPendingUpdateItem(PendingUpdate u)
     {
-        var proposed = TruncateForChat(u.Value?.ToString() ?? string.Empty, 300);
+        var proposed = TruncateForChat(FormatValueForDisplay(u.Value), 300);
         var current = TruncateForChat(u.CurrentDisplay ?? string.Empty, 300);
         var kindLabel = u.Kind switch
         {
@@ -892,6 +911,8 @@ public class Collaborator : ICollaborator
         return new PendingUpdateItem
         {
             Key = u.Key,
+            ElementName = ValueDisplay.SplitPascalCase(u.ElementLabel),
+            PropertyDisplayName = ValueDisplay.SplitPascalCase(u.Spec.Property),
             ProposedDisplay = string.IsNullOrEmpty(proposed) ? "(empty)" : proposed,
             CurrentDisplay = current,
             KindLabel = kindLabel,
@@ -900,6 +921,17 @@ public class Collaborator : ICollaborator
             SummaryLine = summary
         };
     }
+
+    /// <summary>
+    /// Readable text for a typed pending-update value; lists render per entry and
+    /// element GUIDs resolve to outline names (#129).
+    /// </summary>
+    private string FormatValueForDisplay(object? value) =>
+        ValueDisplay.Format(value, guid =>
+            _storyModel?.StoryElements?.StoryElementGuids != null
+            && _storyModel.StoryElements.StoryElementGuids.TryGetValue(guid, out var element)
+                ? element?.Name
+                : null);
 
     private static string TruncateForChat(string? text, int max = 200)
     {
@@ -950,25 +982,16 @@ public class Collaborator : ICollaborator
     /// Short chrome label from registry Label (e.g. StoryProblem → "Story Problem").
     /// Not the long Title path used in the nav list.
     /// </summary>
-    private static string FormatWorkflowShortName(string? label)
-    {
-        if (string.IsNullOrWhiteSpace(label))
-            return string.Empty;
+    private static string FormatWorkflowShortName(string? label) =>
+        ValueDisplay.SplitPascalCase(label);
 
-        // Insert spaces before capitals in PascalCase / camelCase identifiers.
-        var sb = new System.Text.StringBuilder(label.Length + 8);
-        for (var i = 0; i < label.Length; i++)
-        {
-            var c = label[i];
-            if (i > 0 && char.IsUpper(c) && !char.IsUpper(label[i - 1]))
-                sb.Append(' ');
-            else if (i > 0 && char.IsUpper(c) && i + 1 < label.Length && char.IsLower(label[i + 1])
-                     && char.IsUpper(label[i - 1]))
-                sb.Append(' ');
-            sb.Append(c);
-        }
-        return sb.ToString();
-    }
+    /// <summary>Nav group header for a workflow's primary element type (#129).</summary>
+    private static string GroupTitle(StoryItemType type) => type switch
+    {
+        StoryItemType.StoryOverview => "Overview",
+        StoryItemType.Unknown => "Other",
+        _ => ValueDisplay.SplitPascalCase(type.ToString())
+    };
 
     /// <summary>
     /// One-line shell status from gather messages (skip section headers). #123

--- a/CollaboratorLib/Context/GapDetail.cs
+++ b/CollaboratorLib/Context/GapDetail.cs
@@ -1,0 +1,25 @@
+using StoryCADLib.Models;
+
+namespace CollaboratorLib.Context;
+
+/// <summary>
+/// One outline element with at least one required-field gap (issue #107 phase 6).
+/// </summary>
+public sealed class GapDetail
+{
+    public required Guid ElementGuid { get; init; }
+    public required string ElementName { get; init; }
+    public required StoryItemType ElementType { get; init; }
+
+    /// <summary>Missing required property names (model names, e.g. ProtGoal).</summary>
+    public required IReadOnlyList<string> MissingProperties { get; init; }
+
+    /// <summary>Display labels for missing properties (e.g. Character Sketch).</summary>
+    public required IReadOnlyList<string> MissingPropertyLabels { get; init; }
+
+    /// <summary>
+    /// Distinct Collaborator workflow labels that help fill these properties
+    /// (e.g. GMC, RoleAndStoryRole). Empty if only host-element edit applies.
+    /// </summary>
+    public required IReadOnlyList<string> HelperWorkflowLabels { get; init; }
+}

--- a/CollaboratorLib/Context/GapWorkflowOwnership.cs
+++ b/CollaboratorLib/Context/GapWorkflowOwnership.cs
@@ -1,0 +1,79 @@
+using StoryCADLib.Models;
+
+namespace CollaboratorLib.Context;
+
+/// <summary>
+/// Maps required-field property names to Collaborator workflow labels (issue #107 phase 6).
+/// Empty workflow list means host-element edit only.
+/// </summary>
+public static class GapWorkflowOwnership
+{
+    public const string OutlineGapsNavTitle = "Outline gaps";
+    public const string OutlineGapsTag = "OutlineGaps";
+
+    /// <summary>
+    /// Returns helper workflow labels for a missing property on an element type.
+    /// </summary>
+    public static IReadOnlyList<string> WorkflowsFor(StoryItemType elementType, string propertyName)
+    {
+        return (elementType, propertyName) switch
+        {
+            (StoryItemType.StoryOverview, "StoryType") => new[] { "StoryForm" },
+            (StoryItemType.StoryOverview, "StoryGenre") => new[] { "StoryForm" },
+            (StoryItemType.StoryOverview, "Concept") => new[] { "Premise" },
+            (StoryItemType.StoryOverview, "Premise") => new[] { "Premise" },
+            (StoryItemType.StoryOverview, "Description") => new[] { "Premise" },
+            (StoryItemType.StoryOverview, "StoryProblem") => new[] { "StoryProblem" },
+            (StoryItemType.StoryOverview, "Author") => Array.Empty<string>(),
+
+            (StoryItemType.Problem, "ProtGoal") => new[] { "GMC" },
+            (StoryItemType.Problem, "ProtMotive") => new[] { "GMC" },
+            (StoryItemType.Problem, "ProtConflict") => new[] { "GMC" },
+            (StoryItemType.Problem, "AntagGoal") => new[] { "GMC" },
+            (StoryItemType.Problem, "AntagMotive") => new[] { "GMC" },
+            (StoryItemType.Problem, "AntagConflict") => new[] { "GMC" },
+            (StoryItemType.Problem, "Outcome") => new[] { "GMC" },
+            (StoryItemType.Problem, "Protagonist") => new[] { "StoryProblem", "GMC" },
+            (StoryItemType.Problem, "Antagonist") => new[] { "StoryProblem", "GMC" },
+            (StoryItemType.Problem, "ProblemCategory") => new[] { "StoryProblem" },
+            (StoryItemType.Problem, "Premise") => new[] { "StoryProblem" },
+            (StoryItemType.Problem, "Description") => new[] { "StoryProblem" },
+
+            (StoryItemType.Character, "Role") => new[] { "RoleAndStoryRole" },
+            (StoryItemType.Character, "StoryRole") => new[] { "RoleAndStoryRole" },
+            (StoryItemType.Character, "Description") => Array.Empty<string>(),
+            (StoryItemType.Character, "Name") => Array.Empty<string>(),
+
+            (StoryItemType.Setting, "Description") => new[] { "SettingTimeSpace" },
+            (StoryItemType.Setting, "Name") => Array.Empty<string>(),
+
+            (StoryItemType.Scene, "Description") => new[] { "SceneSummary" },
+            (StoryItemType.Scene, "CastMembers") => new[] { "CastSceneRoles" },
+            (StoryItemType.Scene, "Setting") => new[] { "SceneSummary", "CastSceneRoles" },
+            (StoryItemType.Scene, "Name") => Array.Empty<string>(),
+
+            (_, "Name") => Array.Empty<string>(),
+            (_, "Description") => Array.Empty<string>(),
+            _ => Array.Empty<string>()
+        };
+    }
+
+    public static string DisplayLabel(StoryItemType elementType, string propertyName)
+    {
+        return (elementType, propertyName) switch
+        {
+            (StoryItemType.StoryOverview, "Description") => "Story Idea",
+            (StoryItemType.Problem, "Description") => "Story Question",
+            (StoryItemType.Character, "Description") => "Character Sketch",
+            (StoryItemType.Setting, "Description") => "Setting Summary",
+            (StoryItemType.Scene, "Description") => "Scene Sketch",
+            (StoryItemType.StoryOverview, "StoryType") => "Type",
+            (StoryItemType.StoryOverview, "StoryGenre") => "Genre",
+            (StoryItemType.StoryOverview, "StoryProblem") => "Story Problem",
+            (StoryItemType.Character, "StoryRole") => "Story Role",
+            (StoryItemType.Problem, "ProblemCategory") => "Problem Category",
+            (StoryItemType.Scene, "CastMembers") => "Cast",
+            _ => propertyName
+        };
+    }
+}

--- a/CollaboratorLib/Context/RequiredFieldGapScanner.cs
+++ b/CollaboratorLib/Context/RequiredFieldGapScanner.cs
@@ -4,92 +4,147 @@ using StoryCADLib.Services.Collaborator.Contracts;
 namespace CollaboratorLib.Context;
 
 /// <summary>
-/// Outline-wide required-field gaps (issue #107). One GUID per element missing any required property.
+/// Outline-wide required-field gaps (issue #107). GUIDs for StoryContext; details for gap workflow.
 /// </summary>
 public static class RequiredFieldGapScanner
 {
     /// <summary>
     /// Returns distinct element GUIDs that fail at least one required-field check for their type.
-    /// Scans Overview, Problem, Character, Setting, and Scene only.
     /// </summary>
     public static IReadOnlyList<Guid> FindGapGuids(IStoryCADAPI api, StoryModel model)
+    {
+        return FindGapDetails(api, model).Select(g => g.ElementGuid).ToList();
+    }
+
+    /// <summary>
+    /// Full gap report for the Outline gaps workflow (phase 6).
+    /// </summary>
+    public static IReadOnlyList<GapDetail> FindGapDetails(IStoryCADAPI api, StoryModel model)
     {
         if (api == null) throw new ArgumentNullException(nameof(api));
         if (model == null) throw new ArgumentNullException(nameof(model));
 
-        var gaps = new List<Guid>();
+        var details = new List<GapDetail>();
         foreach (var element in model.StoryElements)
         {
             if (element == null) continue;
-            if (HasGap(api, element))
-                gaps.Add(element.Uuid);
+            if (element is not (OverviewModel or ProblemModel or CharacterModel or SettingModel or SceneModel))
+                continue;
+
+            var missing = GetMissingProperties(api, element);
+            if (missing.Count == 0)
+                continue;
+
+            var labels = missing
+                .Select(p => GapWorkflowOwnership.DisplayLabel(element.ElementType, p))
+                .ToList();
+
+            var helpers = missing
+                .SelectMany(p => GapWorkflowOwnership.WorkflowsFor(element.ElementType, p))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            details.Add(new GapDetail
+            {
+                ElementGuid = element.Uuid,
+                ElementName = string.IsNullOrWhiteSpace(element.Name) ? "(unnamed)" : element.Name.Trim(),
+                ElementType = element.ElementType,
+                MissingProperties = missing,
+                MissingPropertyLabels = labels,
+                HelperWorkflowLabels = helpers
+            });
         }
 
-        return gaps;
+        // Spine order: Overview, Problem, Character, Setting, Scene
+        return details
+            .OrderBy(d => TypeOrder(d.ElementType))
+            .ThenBy(d => d.ElementName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 
     public static bool HasGap(IStoryCADAPI api, StoryElement element)
     {
-        if (IsBlank(element.Name) || IsBlank(element.Description))
-            return true;
+        return GetMissingProperties(api, element).Count > 0;
+    }
 
-        return element switch
+    public static IReadOnlyList<string> GetMissingProperties(IStoryCADAPI api, StoryElement element)
+    {
+        if (element is not (OverviewModel or ProblemModel or CharacterModel or SettingModel or SceneModel))
+            return Array.Empty<string>();
+
+        var missing = new List<string>();
+        if (IsBlank(element.Name))
+            missing.Add("Name");
+        if (IsBlank(element.Description))
+            missing.Add("Description");
+
+        switch (element)
         {
-            OverviewModel overview => OverviewHasGap(api, overview),
-            ProblemModel problem => ProblemHasGap(api, problem),
-            CharacterModel character => CharacterHasGap(character),
-            SettingModel => false, // Name + Description only
-            SceneModel scene => SceneHasGap(api, scene),
-            _ => false
-        };
-    }
+            case OverviewModel overview:
+                if (IsBlank(overview.Author)) missing.Add("Author");
+                if (IsBlank(overview.Concept)) missing.Add("Concept");
+                if (IsBlank(overview.Premise)) missing.Add("Premise");
+                if (IsBlank(overview.StoryType)) missing.Add("StoryType");
+                if (IsBlank(overview.StoryGenre)) missing.Add("StoryGenre");
+                if (!IsResolvable(api, overview.StoryProblem, StoryItemType.Problem))
+                    missing.Add("StoryProblem");
+                break;
 
-    private static bool OverviewHasGap(IStoryCADAPI api, OverviewModel overview)
-    {
-        return IsBlank(overview.Author)
-            || IsBlank(overview.Concept)
-            || IsBlank(overview.Premise)
-            || IsBlank(overview.StoryType)
-            || IsBlank(overview.StoryGenre)
-            || !IsResolvable(api, overview.StoryProblem, StoryItemType.Problem);
-    }
+            case ProblemModel problem:
+                if (IsBlank(problem.ProblemCategory)) missing.Add("ProblemCategory");
+                if (IsBlank(problem.Premise)) missing.Add("Premise");
+                if (IsBlank(problem.ProtGoal)) missing.Add("ProtGoal");
+                if (IsBlank(problem.ProtMotive)) missing.Add("ProtMotive");
+                if (IsBlank(problem.ProtConflict)) missing.Add("ProtConflict");
+                if (IsBlank(problem.AntagGoal)) missing.Add("AntagGoal");
+                if (IsBlank(problem.AntagMotive)) missing.Add("AntagMotive");
+                if (IsBlank(problem.AntagConflict)) missing.Add("AntagConflict");
+                if (IsBlank(problem.Outcome)) missing.Add("Outcome");
+                if (!IsResolvable(api, problem.Protagonist, StoryItemType.Character))
+                    missing.Add("Protagonist");
+                if (!IsResolvable(api, problem.Antagonist, StoryItemType.Character))
+                    missing.Add("Antagonist");
+                break;
 
-    private static bool ProblemHasGap(IStoryCADAPI api, ProblemModel problem)
-    {
-        return IsBlank(problem.ProblemCategory)
-            || IsBlank(problem.Premise)
-            || IsBlank(problem.ProtGoal)
-            || IsBlank(problem.ProtMotive)
-            || IsBlank(problem.ProtConflict)
-            || IsBlank(problem.AntagGoal)
-            || IsBlank(problem.AntagMotive)
-            || IsBlank(problem.AntagConflict)
-            || IsBlank(problem.Outcome)
-            || !IsResolvable(api, problem.Protagonist, StoryItemType.Character)
-            || !IsResolvable(api, problem.Antagonist, StoryItemType.Character);
-    }
+            case CharacterModel character:
+                if (IsBlank(character.Role)) missing.Add("Role");
+                if (IsBlank(character.StoryRole)) missing.Add("StoryRole");
+                break;
 
-    private static bool CharacterHasGap(CharacterModel character)
-    {
-        return IsBlank(character.Role) || IsBlank(character.StoryRole);
-    }
+            case SettingModel:
+                break;
 
-    private static bool SceneHasGap(IStoryCADAPI api, SceneModel scene)
-    {
-        if (!IsResolvable(api, scene.Setting, StoryItemType.Setting))
-            return true;
-
-        if (scene.CastMembers == null || scene.CastMembers.Count == 0)
-            return true;
-
-        foreach (var member in scene.CastMembers)
-        {
-            if (!IsResolvable(api, member, StoryItemType.Character))
-                return true;
+            case SceneModel scene:
+                if (!IsResolvable(api, scene.Setting, StoryItemType.Setting))
+                    missing.Add("Setting");
+                if (scene.CastMembers == null || scene.CastMembers.Count == 0)
+                    missing.Add("CastMembers");
+                else
+                {
+                    foreach (var member in scene.CastMembers)
+                    {
+                        if (!IsResolvable(api, member, StoryItemType.Character))
+                        {
+                            missing.Add("CastMembers");
+                            break;
+                        }
+                    }
+                }
+                break;
         }
 
-        return false;
+        return missing;
     }
+
+    private static int TypeOrder(StoryItemType type) => type switch
+    {
+        StoryItemType.StoryOverview => 0,
+        StoryItemType.Problem => 1,
+        StoryItemType.Character => 2,
+        StoryItemType.Setting => 3,
+        StoryItemType.Scene => 4,
+        _ => 9
+    };
 
     private static bool IsBlank(string? value) => string.IsNullOrWhiteSpace(value);
 

--- a/CollaboratorLib/Models/ValueDisplay.cs
+++ b/CollaboratorLib/Models/ValueDisplay.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+
+namespace StoryCollaborator.Models;
+
+/// <summary>
+/// Human-readable display text for pending-update values and identifiers (#129).
+/// Values reach the UI typed per WriteVia (see <see cref="PendingUpdate"/>); rendering
+/// them with ToString leaks CLR type names like "System.Collections.Generic.List`1[...]".
+/// </summary>
+internal static class ValueDisplay
+{
+    /// <summary>
+    /// Inserts spaces into a PascalCase identifier (StructureTitle → "Structure Title").
+    /// Consecutive capitals stay together (GMCNotes → "GMC Notes").
+    /// </summary>
+    internal static string SplitPascalCase(string? identifier)
+    {
+        if (string.IsNullOrWhiteSpace(identifier))
+            return string.Empty;
+
+        var sb = new StringBuilder(identifier.Length + 8);
+        for (var i = 0; i < identifier.Length; i++)
+        {
+            var c = identifier[i];
+            if (i > 0 && char.IsUpper(c) && !char.IsUpper(identifier[i - 1]))
+                sb.Append(' ');
+            else if (i > 0 && char.IsUpper(c) && i + 1 < identifier.Length && char.IsLower(identifier[i + 1])
+                     && char.IsUpper(identifier[i - 1]))
+                sb.Append(' ');
+            sb.Append(c);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Formats a pending-update value for display. Lists render one entry per line;
+    /// element GUIDs resolve to names through <paramref name="resolveElementName"/>.
+    /// </summary>
+    internal static string Format(object? value, Func<Guid, string?>? resolveElementName = null)
+    {
+        switch (value)
+        {
+            case null:
+                return string.Empty;
+
+            case string s:
+                return s;
+
+            case List<string> entries:
+                return Bullets(entries);
+
+            case List<BeatInfo> beats:
+                return string.Join("\n", beats.Select((beat, i) =>
+                    string.IsNullOrWhiteSpace(beat.Description)
+                        ? $"{i + 1}. {beat.Title}"
+                        : $"{i + 1}. {beat.Title} — {beat.Description}"));
+
+            case List<Guid> guids:
+                return Bullets(guids.Select(g => ResolveName(g, resolveElementName)));
+
+            case List<RelationshipInfo> relationships:
+                return Bullets(relationships.Select(rel =>
+                {
+                    var name = ResolveName(rel.RecipientGuid, resolveElementName);
+                    return string.IsNullOrWhiteSpace(rel.Description) ? name : $"{name} — {rel.Description}";
+                }));
+
+            case List<JsonElement> jsonEntries:
+                return Bullets(jsonEntries.Select(FormatJson));
+
+            case IEnumerable enumerable:
+                return Bullets(enumerable.Cast<object?>().Select(item => item?.ToString() ?? string.Empty));
+
+            default:
+                return value.ToString() ?? string.Empty;
+        }
+    }
+
+    private static string Bullets(IEnumerable<string> entries) =>
+        string.Join("\n", entries.Select(e => $"• {e}"));
+
+    private static string ResolveName(Guid guid, Func<Guid, string?>? resolve)
+    {
+        var name = resolve?.Invoke(guid);
+        return string.IsNullOrWhiteSpace(name) ? guid.ToString("D") : name;
+    }
+
+    private static string FormatJson(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            return string.Join("; ", element.EnumerateObject()
+                .Select(prop => $"{SplitPascalCase(prop.Name)}: {prop.Value}"));
+        }
+        return element.ToString();
+    }
+}

--- a/CollaboratorLib/Workflows/Workflow.cs
+++ b/CollaboratorLib/Workflows/Workflow.cs
@@ -19,6 +19,12 @@ namespace StoryCollaborator.Workflows
         public string Explanation { get; set; } = string.Empty;
         public string PluginsFolder => Plugins;
 
+        /// <summary>
+        /// The story element type this workflow develops; groups the nav menu (#129).
+        /// The simple constructor sets it; full-WorkflowIO registry entries set it explicitly.
+        /// </summary>
+        public StoryItemType PrimaryElementType { get; set; } = StoryItemType.Unknown;
+
         // Additional properties
         public StoryModel? Model { get; set; }
         public string Plugins { get; set; } = string.Empty;
@@ -57,6 +63,7 @@ namespace StoryCollaborator.Workflows
             Description = description;
             Explanation = explanation ?? string.Empty;
             Plugins = label;
+            PrimaryElementType = primaryElementType;
 
             _workflowIO = CreateSimpleWorkflowIO(primaryElementType, outputProperties, exampleLists);
         }

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -88,7 +88,7 @@ namespace StoryCollaborator.Workflows
         
                             }
                         }
-                    }),
+                    }) { PrimaryElementType = StoryItemType.StoryOverview },
 
                 // Story Problem workflow - full WorkflowIO
                 new Workflow(
@@ -197,7 +197,7 @@ namespace StoryCollaborator.Workflows
         
                             }
                         }
-                    }),
+                    }) { PrimaryElementType = StoryItemType.StoryOverview },
 
                 // Story Form - simple workflow
                 new Workflow(
@@ -281,7 +281,7 @@ namespace StoryCollaborator.Workflows
                             }
                         },
                         ExampleLists = new List<string> { "ConflictType", "Motive" }
-                    }),
+                    }) { PrimaryElementType = StoryItemType.Problem },
 
                 new Workflow(
                     "ConflictBuilder", "Conflict Builder",
@@ -368,7 +368,7 @@ namespace StoryCollaborator.Workflows
                                 }
                             }
                         }
-                    }),
+                    }) { PrimaryElementType = StoryItemType.Problem },
                 new Workflow(
                     "Structure", "Problem Structure",
                     "Define the structural beats and turning points of a story problem by selecting and applying " +
@@ -529,7 +529,7 @@ namespace StoryCollaborator.Workflows
                                 Projection = ElementProjection.IdAndName
                             }
                         }
-                    }),
+                    }) { PrimaryElementType = StoryItemType.Character },
 
                 // === Setting Workflows (scene-specific) ===
                 new Workflow(
@@ -657,7 +657,7 @@ namespace StoryCollaborator.Workflows
                                 }
                             }
                         }
-                    }),
+                    }) { PrimaryElementType = StoryItemType.Scene },
                 new Workflow(
                     "Sequel", "Sequel (Reaction)",
                     "Develop the character's emotional reaction, reflection, and decision-making after a " +

--- a/StoryCAD/StoryCAD.csproj
+++ b/StoryCAD/StoryCAD.csproj
@@ -70,6 +70,22 @@
               DestinationFolder="$(PublishDir)/StoryCAD.app/Contents/MacOS/" />
     </Target>
 
+    <!-- Same shim, dev loop: publish is the only thing that builds an .app, so the target above
+         never runs for `dotnet build` / `dotnet run -f net10.0-desktop`. Without the dylib in the
+         output the interop's probe fails, BootStrapper falls back to NullStoreService, and every
+         dev run reports "Collaborator requires the Microsoft Store or Mac App Store edition".
+         $(OutDir) is the resolver's beside-the-executable probe, so a plain build behaves like the
+         bundle. Unsigned and unbundled, so StoreKit itself still has no App Store context; this
+         makes the store path reachable, not transacting. -->
+    <Target Name="_BuildAndCopyStoreKitShimToOutput" AfterTargets="Build"
+            Condition="$([MSBuild]::IsOSPlatform('OSX'))"
+            Inputs="$(MSBuildProjectDirectory)/../src/macos/StoreKitShim/StoreKitShim.swift;$(MSBuildProjectDirectory)/../src/macos/StoreKitShim/build.sh"
+            Outputs="$(OutDir)libStoryCADStoreKit.dylib">
+        <Exec Command="bash &quot;$(MSBuildProjectDirectory)/../src/macos/StoreKitShim/build.sh&quot;" />
+        <Copy SourceFiles="$(MSBuildProjectDirectory)/../src/macos/StoreKitShim/out/libStoryCADStoreKit.dylib"
+              DestinationFolder="$(OutDir)" />
+    </Target>
+
     <PropertyGroup>
         <!-- MSIX Configuration for Windows -->
         <UseWinUI Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">true</UseWinUI>

--- a/StoryCAD/Views/Shell.xaml
+++ b/StoryCAD/Views/Shell.xaml
@@ -653,12 +653,11 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <!-- ComboBox -->
-                <ColumnDefinition Width="Auto" />
-                <!-- Status Text -->
+                <ColumnDefinition Width="*" />
+                <!-- Status Text: takes the slack so long messages stay readable, and trims with an
+                     ellipsis rather than pushing the buttons past the window edge -->
                 <ColumnDefinition Width="Auto" />
                 <!-- Save Button -->
-                <ColumnDefinition Width="*" />
-                <!-- Filler -->
                 <ColumnDefinition Width="Auto" />
                 <!-- Autosave Button -->
                 <ColumnDefinition Width="Auto" />
@@ -674,7 +673,8 @@
 
             <TextBlock Grid.Column="1" Text="{x:Bind ShellVm.StatusMessage, Mode=OneWay}"
                        Foreground="{x:Bind ShellVm.StatusColor, Mode=OneWay}"
-                       Width="350" FontSize="14" Margin="10" FontFamily="Segoe UI" Padding="0,5" />
+                       TextTrimming="CharacterEllipsis"
+                       FontSize="14" Margin="10" FontFamily="Segoe UI" Padding="0,5" />
 
             <Button Grid.Column="2" Background="Transparent" Command="{x:Bind ShellVm.SaveFileCommand}"
                     AutomationProperties.AutomationId="SaveStatusButton"
@@ -690,9 +690,7 @@
                 </Button.Content>
             </Button>
 
-            <!-- Spacer in Column 3 -->
-
-            <Button Grid.Column="4" Background="Transparent" BorderBrush="Transparent" HorizontalAlignment="Right"
+            <Button Grid.Column="3" Background="Transparent" BorderBrush="Transparent" HorizontalAlignment="Right"
                     AutomationProperties.AutomationId="AutosaveStatusButton"
                     AutomationProperties.Name="Autosave">
                 <Button.Content>
@@ -705,7 +703,7 @@
                 </Button.Content>
             </Button>
 
-            <Button Grid.Column="5" Background="Transparent" Command="{x:Bind ShellVm.CreateBackupCommand}"
+            <Button Grid.Column="4" Background="Transparent" Command="{x:Bind ShellVm.CreateBackupCommand}"
                     AutomationProperties.AutomationId="BackupStatusButton"
                     AutomationProperties.Name="Backup"
                     BorderBrush="Transparent" HorizontalAlignment="Right">

--- a/StoryCADLib/Collaborator/Models/ChatMessage.cs
+++ b/StoryCADLib/Collaborator/Models/ChatMessage.cs
@@ -1,3 +1,5 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.UI;
 using Microsoft.UI.Xaml.Media;
 using Windows.UI;
@@ -6,11 +8,14 @@ namespace StoryCADLib.Collaborator.Models;
 
 /// <summary>
 /// Represents a message in the workflow chat conversation.
+/// A message is either a chat bubble (user or Collaborator) or a rolled-up
+/// status group — consecutive workflow progress lines shown as one collapsed
+/// expander row instead of a bubble each (#129 chat cleanup).
 /// </summary>
-public class ChatMessage
+public partial class ChatMessage : ObservableObject
 {
     /// <summary>
-    /// The message text content.
+    /// The message text content (bubbles only; status groups use <see cref="Steps"/>).
     /// </summary>
     public string Text { get; set; } = string.Empty;
 
@@ -20,9 +25,60 @@ public class ChatMessage
     public bool IsUser { get; set; }
 
     /// <summary>
+    /// True for a rolled-up run of workflow status lines.
+    /// </summary>
+    public bool IsStatusGroup { get; init; }
+
+    /// <summary>
+    /// Status lines in this group (status groups only).
+    /// </summary>
+    public ObservableCollection<string> Steps { get; } = new();
+
+    /// <summary>
+    /// Collapsed header for a status group: latest step plus count.
+    /// </summary>
+    public string StatusHeader => Steps.Count switch
+    {
+        0 => string.Empty,
+        1 => Steps[0],
+        _ => $"{Steps[^1]}  ·  {Steps.Count} steps"
+    };
+
+    /// <summary>
+    /// Appends a status line and refreshes the collapsed header.
+    /// </summary>
+    public void AddStep(string step)
+    {
+        Steps.Add(step);
+        OnPropertyChanged(nameof(StatusHeader));
+    }
+
+    /// <summary>
     /// Display label for the message sender.
     /// </summary>
     public string Sender => IsUser ? "You" : "Collaborator";
+
+    private bool _showSender = true;
+    /// <summary>
+    /// False when the previous message came from the same sender — the label is
+    /// shown once per run of consecutive messages. Set by WorkflowViewModel.
+    /// </summary>
+    public bool ShowSender
+    {
+        get => _showSender;
+        set
+        {
+            if (SetProperty(ref _showSender, value))
+                OnPropertyChanged(nameof(SenderVisibility));
+        }
+    }
+
+    /// <summary>
+    /// Sender label visibility (classic Binding needs Visibility, not bool).
+    /// </summary>
+    public Microsoft.UI.Xaml.Visibility SenderVisibility => ShowSender
+        ? Microsoft.UI.Xaml.Visibility.Visible
+        : Microsoft.UI.Xaml.Visibility.Collapsed;
 
     /// <summary>
     /// Background brush for the message bubble.
@@ -59,4 +115,9 @@ public class ChatMessage
     /// Creates an error message (displayed as Collaborator).
     /// </summary>
     public static ChatMessage Error(string text) => new() { Text = $"Error: {text}", IsUser = false };
+
+    /// <summary>
+    /// Creates an empty status group; append lines with <see cref="AddStep"/>.
+    /// </summary>
+    public static ChatMessage StatusGroup() => new() { IsStatusGroup = true, IsUser = false };
 }

--- a/StoryCADLib/Collaborator/Models/ChatMessage.cs
+++ b/StoryCADLib/Collaborator/Models/ChatMessage.cs
@@ -27,7 +27,8 @@ public partial class ChatMessage : ObservableObject
     /// <summary>
     /// True for a rolled-up run of workflow status lines.
     /// </summary>
-    public bool IsStatusGroup { get; init; }
+    // get/set (not init): WinUI XamlTypeInfo assigns after construction on net10.0-windows
+    public bool IsStatusGroup { get; set; }
 
     /// <summary>
     /// Status lines in this group (status groups only).

--- a/StoryCADLib/Collaborator/Models/GapWorkflowModels.cs
+++ b/StoryCADLib/Collaborator/Models/GapWorkflowModels.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+
+namespace StoryCADLib.Collaborator.Models;
+
+/// <summary>
+/// Payload passed to the Outline gaps page (issue #107 phase 6).
+/// Built in CollaboratorLib; displayed in StoryCADLib UI.
+/// </summary>
+public sealed class GapWorkflowPayload
+{
+    public IReadOnlyList<GapElementGroup> Groups { get; set; } = Array.Empty<GapElementGroup>();
+}
+
+public sealed class GapElementGroup
+{
+    public Guid ElementGuid { get; set; }
+    public string ElementName { get; set; } = string.Empty;
+    public string ElementTypeLabel { get; set; } = string.Empty;
+
+    /// <summary>One link per missing required field (option 2: field → workflow or element).</summary>
+    public IReadOnlyList<GapFieldLink> MissingFields { get; set; } = Array.Empty<GapFieldLink>();
+}
+
+/// <summary>
+/// A single empty required field. Click opens its helper workflow, or the host element if none.
+/// </summary>
+public sealed class GapFieldLink
+{
+    public string DisplayLabel { get; set; } = string.Empty;
+    public string PropertyName { get; set; } = string.Empty;
+    public Guid ElementGuid { get; set; }
+
+    /// <summary>Collaborator workflow label, or empty when only StoryCAD edit applies.</summary>
+    public string WorkflowLabel { get; set; } = string.Empty;
+
+    /// <summary>Workflow display title when <see cref="WorkflowLabel"/> is set.</summary>
+    public string WorkflowTitle { get; set; } = string.Empty;
+
+    public bool OpensElementOnly => string.IsNullOrEmpty(WorkflowLabel);
+
+    /// <summary>Shown under the field name: "via GMC" or "edit in StoryCAD".</summary>
+    public string ActionHint
+    {
+        get
+        {
+            if (OpensElementOnly)
+                return "edit in StoryCAD";
+            return string.IsNullOrEmpty(WorkflowTitle) ? WorkflowLabel : $"via {WorkflowTitle}";
+        }
+    }
+}

--- a/StoryCADLib/Collaborator/Models/PendingUpdateItem.cs
+++ b/StoryCADLib/Collaborator/Models/PendingUpdateItem.cs
@@ -6,8 +6,21 @@ namespace StoryCADLib.Collaborator.Models;
 /// </summary>
 public sealed class PendingUpdateItem
 {
-    /// <summary>ElementLabel.PropertyName</summary>
+    /// <summary>ElementLabel.PropertyName (raw key used by accept/skip callbacks).</summary>
     public string Key { get; set; } = string.Empty;
+
+    /// <summary>Element display name with spaces (e.g. "Outer Problem").</summary>
+    public string ElementName { get; set; } = string.Empty;
+
+    /// <summary>Property name with spaces (e.g. "Structure Title").</summary>
+    public string PropertyDisplayName { get; set; } = string.Empty;
+
+    /// <summary>Row title; falls back to the raw key when display fields are unset.</summary>
+    public string DisplayName => string.IsNullOrEmpty(PropertyDisplayName) ? Key : PropertyDisplayName;
+
+    /// <summary>Right-column caption: element plus kind (e.g. "Problem · New").</summary>
+    public string ElementAndKind =>
+        string.IsNullOrEmpty(ElementName) ? SummaryLine : $"{ElementName} · {SummaryLine}";
 
     /// <summary>Proposed value (truncated for display).</summary>
     public string ProposedDisplay { get; set; } = string.Empty;

--- a/StoryCADLib/Collaborator/ViewModels/GapWorkflowViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/GapWorkflowViewModel.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using StoryCADLib.Collaborator.Models;
+
+namespace StoryCADLib.Collaborator.ViewModels;
+
+/// <summary>
+/// Outline gaps page — navigate only (issue #107 phase 6).
+/// Each missing field links to its helper workflow or the host element.
+/// </summary>
+[Microsoft.UI.Xaml.Data.Bindable]
+public partial class GapWorkflowViewModel : ObservableRecipient
+{
+    public GapWorkflowViewModel()
+    {
+        Groups = new ObservableCollection<GapElementGroup>();
+        OpenElementCommand = new RelayCommand<Guid>(guid => OnOpenElement?.Invoke(guid));
+        OpenFieldCommand = new AsyncRelayCommand<GapFieldLink>(OpenFieldAsync);
+    }
+
+    public string Title { get; set; } = "Outline gaps";
+
+    public string Description { get; set; } =
+        "Required fields that are empty or broken. Click a field to open its helper workflow, or the element name to open it in StoryCAD.";
+
+    public ObservableCollection<GapElementGroup> Groups { get; }
+
+    public bool HasGroups => Groups.Count > 0;
+
+    public string EmptyMessage { get; set; } = "No required-field gaps.";
+
+    /// <summary>Select/focus element in host StoryCAD.</summary>
+    public Action<Guid> OnOpenElement { get; set; }
+
+    /// <summary>Start a Collaborator workflow by registry label.</summary>
+    public Func<string, Task> OnOpenWorkflow { get; set; }
+
+    public RelayCommand<Guid> OpenElementCommand { get; }
+    public IAsyncRelayCommand<GapFieldLink> OpenFieldCommand { get; }
+
+    public void Load(GapWorkflowPayload payload)
+    {
+        Groups.Clear();
+        if (payload?.Groups != null)
+        {
+            foreach (var g in payload.Groups)
+                Groups.Add(g);
+        }
+        OnPropertyChanged(nameof(HasGroups));
+    }
+
+    private async Task OpenFieldAsync(GapFieldLink field)
+    {
+        if (field == null)
+            return;
+
+        if (field.OpensElementOnly)
+        {
+            OnOpenElement?.Invoke(field.ElementGuid);
+            return;
+        }
+
+        if (OnOpenWorkflow != null)
+            await OnOpenWorkflow(field.WorkflowLabel);
+    }
+}

--- a/StoryCADLib/Collaborator/ViewModels/WorkflowShellViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WorkflowShellViewModel.cs
@@ -19,6 +19,7 @@ public partial class WorkflowShellViewModel : ObservableRecipient
         MenuItems = new ObservableCollection<NavigationViewItem>();
         SaveCommand = new RelayCommand(SaveOutline);
         ExitCommand = new RelayCommand(ExitCollaborator);
+        TogglePaneCommand = new RelayCommand(TogglePane);
         AcceptAllCommand = new RelayCommand(() => OnAcceptAll?.Invoke());
         ReviewEachCommand = new RelayCommand(() => OnReviewEach?.Invoke());
         TryAgainCommand = new RelayCommand(async () =>
@@ -97,6 +98,17 @@ public partial class WorkflowShellViewModel : ObservableRecipient
         set => SetProperty(ref _hasPendingUpdates, value);
     }
 
+    /// <summary>
+    /// Workflow list pane open (bound to NavigationView.IsPaneOpen).
+    /// Toggled by the top-bar hamburger; built-in NavView toggle is hidden.
+    /// </summary>
+    private bool _isPaneOpen = true;
+    public bool IsPaneOpen
+    {
+        get => _isPaneOpen;
+        set => SetProperty(ref _isPaneOpen, value);
+    }
+
     /// <summary>Wired by Collaborator to the active WorkflowViewModel actions.</summary>
     public Action OnAcceptAll { get; set; }
     public Action OnReviewEach { get; set; }
@@ -148,11 +160,18 @@ public partial class WorkflowShellViewModel : ObservableRecipient
 
     public RelayCommand ExitCommand { get; }
 
+    public RelayCommand TogglePaneCommand { get; }
+
     public RelayCommand AcceptAllCommand { get; }
 
     public RelayCommand ReviewEachCommand { get; }
 
     public RelayCommand TryAgainCommand { get; }
+
+    private void TogglePane()
+    {
+        IsPaneOpen = !IsPaneOpen;
+    }
 
     private void SaveOutline()
     {

--- a/StoryCADLib/Collaborator/ViewModels/WorkflowShellViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WorkflowShellViewModel.cs
@@ -19,6 +19,13 @@ public partial class WorkflowShellViewModel : ObservableRecipient
         MenuItems = new ObservableCollection<NavigationViewItem>();
         SaveCommand = new RelayCommand(SaveOutline);
         ExitCommand = new RelayCommand(ExitCollaborator);
+        AcceptAllCommand = new RelayCommand(() => OnAcceptAll?.Invoke());
+        ReviewEachCommand = new RelayCommand(() => OnReviewEach?.Invoke());
+        TryAgainCommand = new RelayCommand(async () =>
+        {
+            if (OnTryAgain != null)
+                await OnTryAgain();
+        });
     }
 
     #region Properties
@@ -69,7 +76,34 @@ public partial class WorkflowShellViewModel : ObservableRecipient
     public string Title { get; set; } = "Story Collaborator";
 
     /// <summary>
-    /// Shell-level status (CommandBar InfoBar). Visible when the content frame
+    /// Short workflow name on the top bar (left). Uses the registry label
+    /// (e.g. Premise), not the long ideation path title. Empty until a workflow is selected.
+    /// </summary>
+    private string _activeWorkflowName = string.Empty;
+    public string ActiveWorkflowName
+    {
+        get => _activeWorkflowName;
+        set => SetProperty(ref _activeWorkflowName, value ?? string.Empty);
+    }
+
+    /// <summary>
+    /// True when the current workflow page has pending property updates.
+    /// Enables Accept All / Review Each / Try Again on the top bar.
+    /// </summary>
+    private bool _hasPendingUpdates;
+    public bool HasPendingUpdates
+    {
+        get => _hasPendingUpdates;
+        set => SetProperty(ref _hasPendingUpdates, value);
+    }
+
+    /// <summary>Wired by Collaborator to the active WorkflowViewModel actions.</summary>
+    public Action OnAcceptAll { get; set; }
+    public Action OnReviewEach { get; set; }
+    public Func<Task> OnTryAgain { get; set; }
+
+    /// <summary>
+    /// Shell-level status (bottom status bar InfoBar). Visible when the content frame
     /// is empty — e.g. after gather cancel when chat is not available (#123).
     /// </summary>
     private string _statusText = string.Empty;
@@ -114,6 +148,12 @@ public partial class WorkflowShellViewModel : ObservableRecipient
 
     public RelayCommand ExitCommand { get; }
 
+    public RelayCommand AcceptAllCommand { get; }
+
+    public RelayCommand ReviewEachCommand { get; }
+
+    public RelayCommand TryAgainCommand { get; }
+
     private void SaveOutline()
     {
         OnSave?.Invoke();
@@ -127,6 +167,11 @@ public partial class WorkflowShellViewModel : ObservableRecipient
             NavView.SelectionChanged -= NavView_SelectionChanged;
         }
         MenuItems.Clear();
+        HasPendingUpdates = false;
+        ActiveWorkflowName = string.Empty;
+        OnAcceptAll = null;
+        OnReviewEach = null;
+        OnTryAgain = null;
     }
 
     #endregion

--- a/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
@@ -21,6 +21,7 @@ public partial class WorkflowViewModel : ObservableRecipient
     public WorkflowViewModel()
     {
         ConversationList = new ObservableCollection<ChatMessage>();
+        ConversationList.CollectionChanged += OnConversationChanged;
         PendingUpdateItems = new ObservableCollection<PendingUpdateItem>();
 
         // Existing commands
@@ -36,6 +37,49 @@ public partial class WorkflowViewModel : ObservableRecipient
         AcceptCurrentCommand = new RelayCommand(ExecuteAcceptCurrent);
         SkipCurrentCommand = new RelayCommand(ExecuteSkipCurrent);
         AcceptRemainingCommand = new RelayCommand(ExecuteAcceptRemaining);
+    }
+
+    /// <summary>
+    /// Shows the sender label once per run of consecutive same-sender bubbles;
+    /// status groups never carry a label (#129 chat cleanup).
+    /// </summary>
+    private void OnConversationChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action != System.Collections.Specialized.NotifyCollectionChangedAction.Add || e.NewItems == null)
+            return;
+
+        foreach (ChatMessage added in e.NewItems)
+        {
+            var index = ConversationList.IndexOf(added);
+            var previous = index > 0 ? ConversationList[index - 1] : null;
+            added.ShowSender = !added.IsStatusGroup
+                && (previous == null || previous.IsUser != added.IsUser);
+        }
+    }
+
+    /// <summary>
+    /// Adds a workflow progress line, rolling consecutive lines into one
+    /// collapsed status group instead of a bubble each (#129 chat cleanup).
+    /// </summary>
+    public void AddStatusMessage(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return;
+
+        var line = message.Trim().Trim('-').Trim();
+        if (line.Length == 0)
+            return;
+
+        if (ConversationList.Count > 0
+            && ConversationList[^1] is { IsStatusGroup: true } group)
+        {
+            group.AddStep(line);
+            return;
+        }
+
+        var newGroup = ChatMessage.StatusGroup();
+        newGroup.AddStep(line);
+        ConversationList.Add(newGroup);
     }
 
     public async Task InitializeAsync(object workflow)
@@ -124,7 +168,7 @@ public partial class WorkflowViewModel : ObservableRecipient
         if (IsInReviewMode && PendingUpdateItems != null && PendingUpdateItems.Count > 0)
         {
             parts.Add(
-                $"Reviewing {CurrentReviewIndex + 1} of {PendingUpdateItems.Count}: {CurrentReviewKey}. " +
+                $"Reviewing {CurrentReviewIndex + 1} of {PendingUpdateItems.Count}: {CurrentReviewDisplayName}. " +
                 "Accept to apply, Skip to keep yours.");
         }
         else if (HasPendingUpdates && PendingUpdateItems != null)
@@ -205,6 +249,26 @@ public partial class WorkflowViewModel : ObservableRecipient
         IsInReviewMode && PendingUpdateItems?.Count > CurrentReviewIndex
             ? PendingUpdateItems[CurrentReviewIndex].Key
             : string.Empty;
+
+    /// <summary>
+    /// Friendly title for the row under review, e.g. "Structure Title (Problem)".
+    /// Falls back to the raw key when display fields are unset (#129).
+    /// </summary>
+    public string CurrentReviewDisplayName
+    {
+        get
+        {
+            if (!IsInReviewMode || PendingUpdateItems == null || PendingUpdateItems.Count <= CurrentReviewIndex)
+                return string.Empty;
+
+            var item = PendingUpdateItems[CurrentReviewIndex];
+            if (string.IsNullOrEmpty(item.PropertyDisplayName))
+                return item.Key;
+            return string.IsNullOrEmpty(item.ElementName)
+                ? item.PropertyDisplayName
+                : $"{item.PropertyDisplayName} ({item.ElementName})";
+        }
+    }
 
     /// <summary>Proposed value for the row under review.</summary>
     public string CurrentReviewValue =>
@@ -368,6 +432,25 @@ public partial class WorkflowViewModel : ObservableRecipient
             await OnTryAgain();
     }
 
+    /// <summary>
+    /// Accepts a single row from its inline tick (#129); works outside review mode.
+    /// Collaborator's handler applies the update, removes the key, and re-syncs the list.
+    /// </summary>
+    public void AcceptItem(string key)
+    {
+        if (string.IsNullOrEmpty(key) || !HasPendingUpdates) return;
+        OnAcceptProperty?.Invoke(key);
+    }
+
+    /// <summary>
+    /// Skips (discards) a single row from its inline dismiss button (#129).
+    /// </summary>
+    public void SkipItem(string key)
+    {
+        if (string.IsNullOrEmpty(key) || !HasPendingUpdates) return;
+        OnSkipProperty?.Invoke(key);
+    }
+
     private void ExecuteAcceptCurrent()
     {
         if (!IsInReviewMode || !HasPendingUpdates) return;
@@ -441,6 +524,7 @@ public partial class WorkflowViewModel : ObservableRecipient
     private void NotifyReviewProperties()
     {
         OnPropertyChanged(nameof(CurrentReviewKey));
+        OnPropertyChanged(nameof(CurrentReviewDisplayName));
         OnPropertyChanged(nameof(CurrentReviewValue));
         OnPropertyChanged(nameof(CurrentReviewExisting));
         OnPropertyChanged(nameof(CurrentReviewCraft));
@@ -475,6 +559,17 @@ public partial class WorkflowViewModel : ObservableRecipient
         }
 
         UpdatesApplied = false;
+
+        // Inline ticks can shrink the list while Review Each is walking it (#129):
+        // exit review when it empties, clamp the index when it points past the end.
+        if (IsInReviewMode)
+        {
+            if (PendingUpdateItems.Count == 0)
+                IsInReviewMode = false;
+            else if (CurrentReviewIndex >= PendingUpdateItems.Count)
+                CurrentReviewIndex = PendingUpdateItems.Count - 1;
+        }
+
         OnPropertyChanged(nameof(PendingUpdateItems));
         OnPropertyChanged(nameof(HasUpdates));
         OnPropertyChanged(nameof(HasPendingUpdates));

--- a/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
@@ -107,6 +107,23 @@ public partial class WorkflowViewModel : ObservableRecipient
     /// <summary>True if updates exist and haven't been fully applied yet.</summary>
     public bool HasPendingUpdates => HasUpdates && !UpdatesApplied;
 
+    /// <summary>
+    /// Panel header with counts (#129): free vs need-review (Protect).
+    /// </summary>
+    public string PendingUpdatesHeader
+    {
+        get
+        {
+            if (PendingUpdateItems == null || PendingUpdateItems.Count == 0)
+                return "Property Updates";
+
+            var total = PendingUpdateItems.Count;
+            var needReview = PendingUpdateItems.Count(i => i.IsProtected);
+            var free = total - needReview;
+            return $"Property Updates ({total}: {free} free, {needReview} need review)";
+        }
+    }
+
     public Microsoft.UI.Xaml.Visibility ReviewModeVisibility =>
         IsInReviewMode ? Microsoft.UI.Xaml.Visibility.Visible : Microsoft.UI.Xaml.Visibility.Collapsed;
 
@@ -388,6 +405,7 @@ public partial class WorkflowViewModel : ObservableRecipient
         CurrentReviewIndex = 0;
         OnPropertyChanged(nameof(HasUpdates));
         OnPropertyChanged(nameof(HasPendingUpdates));
+        OnPropertyChanged(nameof(PendingUpdatesHeader));
     }
 
     /// <summary>
@@ -406,6 +424,7 @@ public partial class WorkflowViewModel : ObservableRecipient
         OnPropertyChanged(nameof(PendingUpdateItems));
         OnPropertyChanged(nameof(HasUpdates));
         OnPropertyChanged(nameof(HasPendingUpdates));
+        OnPropertyChanged(nameof(PendingUpdatesHeader));
         NotifyReviewProperties();
     }
 
@@ -417,6 +436,7 @@ public partial class WorkflowViewModel : ObservableRecipient
         PendingUpdateItems.Clear();
         OnPropertyChanged(nameof(HasUpdates));
         OnPropertyChanged(nameof(HasPendingUpdates));
+        OnPropertyChanged(nameof(PendingUpdatesHeader));
     }
 
     #endregion

--- a/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
@@ -55,9 +55,24 @@ public partial class WorkflowViewModel : ObservableRecipient
 
     public string Title { get; set; }
 
-    public string Description { get; set; }
+    private string _description = string.Empty;
+    /// <summary>Brief workflow purpose (registry description).</summary>
+    public string Description
+    {
+        get => _description;
+        set => SetProperty(ref _description, value ?? string.Empty);
+    }
 
-    public string Explanation { get; set; }
+    private string _explanation = string.Empty;
+    /// <summary>
+    /// Topical work-column context (#129): selected elements and what to do next
+    /// (pending accept/review). Not the long static registry essay.
+    /// </summary>
+    public string Explanation
+    {
+        get => _explanation;
+        set => SetProperty(ref _explanation, value ?? string.Empty);
+    }
 
     public ObservableCollection<ChatMessage> ConversationList { get; set; }
 
@@ -82,14 +97,51 @@ public partial class WorkflowViewModel : ObservableRecipient
         set => SetProperty(ref _promptOutput, value);
     }
 
-    private string _selectedElementsSummary;
+    private string _selectedElementsSummary = string.Empty;
     /// <summary>
-    /// Summary of elements selected for this workflow (e.g., "Problem: Herold wants Greta")
+    /// Gathered elements for this run (e.g. "Overview: Schrodinger's Computer").
+    /// Surfaced via <see cref="Explanation"/>, not a separate card.
     /// </summary>
     public string SelectedElementsSummary
     {
         get => _selectedElementsSummary;
-        set => SetProperty(ref _selectedElementsSummary, value);
+        set => SetProperty(ref _selectedElementsSummary, value ?? string.Empty);
+    }
+
+    /// <summary>
+    /// Rebuilds topical Explanation from selected elements + pending/review state.
+    /// </summary>
+    public void RefreshTopicalExplanation()
+    {
+        var parts = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(SelectedElementsSummary))
+        {
+            var oneLine = SelectedElementsSummary.Replace("\r\n", "; ").Replace("\n", "; ");
+            parts.Add($"Selected: {oneLine}");
+        }
+
+        if (IsInReviewMode && PendingUpdateItems != null && PendingUpdateItems.Count > 0)
+        {
+            parts.Add(
+                $"Reviewing {CurrentReviewIndex + 1} of {PendingUpdateItems.Count}: {CurrentReviewKey}. " +
+                "Accept to apply, Skip to keep yours.");
+        }
+        else if (HasPendingUpdates && PendingUpdateItems != null)
+        {
+            var total = PendingUpdateItems.Count;
+            var needReview = PendingUpdateItems.Count(i => i.IsProtected);
+            var free = total - needReview;
+            parts.Add(
+                $"{total} property update(s) ({free} free, {needReview} need review). " +
+                "Use Accept All, Review Each, or Try Again.");
+        }
+        else if (UpdatesApplied)
+        {
+            parts.Add("Updates applied. Ask in chat or choose another workflow.");
+        }
+
+        Explanation = parts.Count == 0 ? string.Empty : string.Join("\n", parts);
     }
 
     #endregion
@@ -395,6 +447,7 @@ public partial class WorkflowViewModel : ObservableRecipient
         OnPropertyChanged(nameof(CurrentReviewHasCraft));
         OnPropertyChanged(nameof(CurrentReviewCraftVisibility));
         OnPropertyChanged(nameof(ReviewProgress));
+        RefreshTopicalExplanation();
     }
 
     public void ClearPendingUpdates()
@@ -406,6 +459,7 @@ public partial class WorkflowViewModel : ObservableRecipient
         OnPropertyChanged(nameof(HasUpdates));
         OnPropertyChanged(nameof(HasPendingUpdates));
         OnPropertyChanged(nameof(PendingUpdatesHeader));
+        RefreshTopicalExplanation();
     }
 
     /// <summary>
@@ -426,6 +480,7 @@ public partial class WorkflowViewModel : ObservableRecipient
         OnPropertyChanged(nameof(HasPendingUpdates));
         OnPropertyChanged(nameof(PendingUpdatesHeader));
         NotifyReviewProperties();
+        RefreshTopicalExplanation();
     }
 
     /// <summary>Called by Collaborator after all free updates are applied.</summary>
@@ -437,6 +492,7 @@ public partial class WorkflowViewModel : ObservableRecipient
         OnPropertyChanged(nameof(HasUpdates));
         OnPropertyChanged(nameof(HasPendingUpdates));
         OnPropertyChanged(nameof(PendingUpdatesHeader));
+        RefreshTopicalExplanation();
     }
 
     #endregion

--- a/StoryCADLib/Collaborator/Views/ChatMessageTemplateSelector.cs
+++ b/StoryCADLib/Collaborator/Views/ChatMessageTemplateSelector.cs
@@ -1,0 +1,23 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using StoryCADLib.Collaborator.Models;
+
+namespace StoryCADLib.Collaborator.Views;
+
+/// <summary>
+/// Picks the chat bubble or the rolled-up status template for a conversation row
+/// (#129 chat cleanup).
+/// </summary>
+[Microsoft.UI.Xaml.Data.Bindable]
+public sealed partial class ChatMessageTemplateSelector : DataTemplateSelector
+{
+    public DataTemplate Bubble { get; set; }
+
+    public DataTemplate Status { get; set; }
+
+    protected override DataTemplate SelectTemplateCore(object item) =>
+        item is ChatMessage { IsStatusGroup: true } ? Status : Bubble;
+
+    protected override DataTemplate SelectTemplateCore(object item, DependencyObject container) =>
+        SelectTemplateCore(item);
+}

--- a/StoryCADLib/Collaborator/Views/GapWorkflowPage.xaml
+++ b/StoryCADLib/Collaborator/Views/GapWorkflowPage.xaml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="StoryCADLib.Collaborator.Views.GapWorkflowPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:StoryCADLib.Collaborator.Models"
+    mc:Ignorable="d">
+    <ScrollViewer Padding="12">
+        <StackPanel Spacing="12">
+            <TextBlock Text="{x:Bind ViewModel.Title, Mode=OneWay}"
+                       FontWeight="Bold" FontSize="16" TextWrapping="Wrap" />
+            <TextBlock Text="{x:Bind ViewModel.Description, Mode=OneWay}"
+                       TextWrapping="Wrap" Opacity="0.9" />
+
+            <TextBlock x:Name="EmptyMessageText"
+                       Text="{x:Bind ViewModel.EmptyMessage, Mode=OneWay}"
+                       FontStyle="Italic" />
+
+            <ItemsControl x:Name="GroupsList"
+                          ItemsSource="{x:Bind ViewModel.Groups, Mode=OneWay}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="models:GapElementGroup">
+                        <!-- Template root: no AutomationId (TemplateSafety). -->
+                        <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                BorderThickness="1" CornerRadius="4" Padding="12" Margin="0,0,0,8">
+                            <StackPanel Spacing="8">
+                                <HyperlinkButton Content="{x:Bind ElementName}"
+                                                 Click="ElementLink_Click"
+                                                 Tag="{x:Bind ElementGuid}"
+                                                 Padding="0"
+                                                 FontWeight="SemiBold"
+                                                 FontSize="15" />
+                                <TextBlock Text="{x:Bind ElementTypeLabel}"
+                                           Opacity="0.7" FontSize="12" />
+
+                                <TextBlock Text="Missing required fields"
+                                           FontWeight="SemiBold" FontSize="12"
+                                           Margin="0,4,0,0" />
+                                <ItemsControl ItemsSource="{x:Bind MissingFields}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="models:GapFieldLink">
+                                            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,2,0,2">
+                                                <HyperlinkButton Content="{x:Bind DisplayLabel}"
+                                                                 Click="FieldLink_Click"
+                                                                 Tag="{x:Bind}"
+                                                                 Padding="0"
+                                                                 VerticalAlignment="Center" />
+                                                <TextBlock Text="{x:Bind ActionHint}"
+                                                           Opacity="0.65" FontSize="12"
+                                                           VerticalAlignment="Center" />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/StoryCADLib/Collaborator/Views/GapWorkflowPage.xaml.cs
+++ b/StoryCADLib/Collaborator/Views/GapWorkflowPage.xaml.cs
@@ -1,0 +1,45 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using StoryCADLib.Collaborator.Models;
+using StoryCADLib.Collaborator.ViewModels;
+
+namespace StoryCADLib.Collaborator.Views;
+
+/// <summary>
+/// Outline gaps page — each missing field links to its helper workflow or host element (#107 phase 6).
+/// </summary>
+public sealed partial class GapWorkflowPage : Page
+{
+    public GapWorkflowPage()
+    {
+        InitializeComponent();
+        DataContext = new GapWorkflowViewModel();
+        ViewModel.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName is nameof(GapWorkflowViewModel.HasGroups) or nameof(GapWorkflowViewModel.Groups))
+                UpdateEmptyVisibility();
+        };
+        UpdateEmptyVisibility();
+    }
+
+    public GapWorkflowViewModel ViewModel => DataContext as GapWorkflowViewModel;
+
+    private void UpdateEmptyVisibility()
+    {
+        if (ViewModel == null) return;
+        EmptyMessageText.Visibility = ViewModel.HasGroups ? Visibility.Collapsed : Visibility.Visible;
+        GroupsList.Visibility = ViewModel.HasGroups ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void ElementLink_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is HyperlinkButton { Tag: Guid guid })
+            ViewModel?.OpenElementCommand.Execute(guid);
+    }
+
+    private void FieldLink_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is HyperlinkButton { Tag: GapFieldLink field } && ViewModel != null)
+            _ = ViewModel.OpenFieldCommand.ExecuteAsync(field);
+    }
+}

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
@@ -169,11 +169,11 @@
                       (VerticalScrollMode does not override it). Visible keeps the built-in bar
                       on screen whenever the list overflows: the scroll affordance #129 asks for.
                     -->
+                    <!-- ScrollViewer: no AutomationId (not in convention suffix table). List content is not a ListView. -->
                     <ScrollViewer Grid.Row="2"
                                   VerticalAlignment="Stretch"
                                   VerticalScrollBarVisibility="Visible"
-                                  HorizontalScrollBarVisibility="Disabled"
-                                  AutomationProperties.AutomationId="WorkflowPendingUpdatesList">
+                                  HorizontalScrollBarVisibility="Disabled">
                         <ItemsControl ItemsSource="{x:Bind ViewModel.PendingUpdateItems, Mode=OneWay}">
                             <ItemsControl.ItemTemplate>
                                     <DataTemplate>
@@ -331,7 +331,7 @@
                             HorizontalAlignment="Stretch"
                             Text="{x:Bind ViewModel.InputText, Mode=TwoWay}"
                             QuerySubmitted="InputTextBox_QuerySubmitted"
-                            AutomationProperties.AutomationId="InputTextBox"
+                            AutomationProperties.AutomationId="InputSearchBox"
                             AutomationProperties.Name="Message">
                 <AutoSuggestBox.QueryIcon>
                     <SymbolIcon Symbol="Send" />

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
@@ -28,18 +28,79 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:views="using:StoryCADLib.Collaborator.Views"
     mc:Ignorable="d"
     VerticalAlignment="Stretch"
     HorizontalAlignment="Stretch">
+    <Page.Resources>
+        <!-- Chat bubble: sender label shows once per run of same-sender messages (#129).
+             Bubbles stretch to the full chat column width rather than sitting at a fixed
+             420px cap. The speaker is still cued by the bubble colour and by the sender
+             label, which keeps its left/right alignment. -->
+        <DataTemplate x:Key="ChatBubbleTemplate">
+            <!-- Template root: no AutomationId (TemplateSafety forbids it). -->
+            <StackPanel Margin="0,4,0,4"
+                        HorizontalAlignment="Stretch"
+                        AutomationProperties.Name="{Binding Text, Mode=OneWay}">
+                <TextBlock Text="{Binding Sender}"
+                           FontWeight="SemiBold"
+                           FontSize="11"
+                           Opacity="0.7"
+                           Visibility="{Binding SenderVisibility}"
+                           HorizontalAlignment="{Binding BubbleAlignment}" />
+                <Border CornerRadius="12"
+                        Padding="12,8,12,8"
+                        Margin="0,2,0,0"
+                        Background="{Binding BackgroundBrush}"
+                        HorizontalAlignment="Stretch">
+                    <TextBlock Text="{Binding Text}"
+                               TextWrapping="Wrap"
+                               Foreground="{Binding TextBrush}" />
+                </Border>
+            </StackPanel>
+        </DataTemplate>
+
+        <!-- Rolled-up workflow status lines: one collapsed expander per run (#129). -->
+        <DataTemplate x:Key="ChatStatusTemplate">
+            <Expander Margin="0,4,0,4"
+                      HorizontalAlignment="Stretch"
+                      HorizontalContentAlignment="Stretch"
+                      IsExpanded="False"
+                      AutomationProperties.Name="{Binding StatusHeader, Mode=OneWay}">
+                <Expander.Header>
+                    <TextBlock Text="{Binding StatusHeader}"
+                               FontSize="11"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               TextTrimming="CharacterEllipsis" />
+                </Expander.Header>
+                <ItemsControl ItemsSource="{Binding Steps}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding}"
+                                       FontSize="11"
+                                       TextWrapping="Wrap"
+                                       Margin="0,1"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </Expander>
+        </DataTemplate>
+
+        <views:ChatMessageTemplateSelector x:Key="ChatTemplateSelector"
+                                           Bubble="{StaticResource ChatBubbleTemplate}"
+                                           Status="{StaticResource ChatStatusTemplate}" />
+    </Page.Resources>
     <Grid VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+        <!-- 3:2 split — the table needs the width more than the chat does. -->
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1*" />
-            <ColumnDefinition Width="1*" />
+            <ColumnDefinition Width="3*" />
+            <ColumnDefinition Width="2*" />
         </Grid.ColumnDefinitions>
 
         <!-- ========== Work column (full height; Property Updates takes leftover) ========== -->
         <Grid Grid.Column="0"
-              Margin="0,0,10,0"
+              Margin="0,0,12,0"
               VerticalAlignment="Stretch">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
@@ -67,11 +128,12 @@
             <Border Grid.Row="1"
                     Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                    BorderThickness="1" CornerRadius="4" Padding="10"
+                    BorderThickness="1" CornerRadius="8" Padding="14"
                     VerticalAlignment="Stretch"
                     HorizontalAlignment="Stretch">
                 <Grid VerticalAlignment="Stretch">
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
@@ -79,86 +141,100 @@
                                Text="{x:Bind ViewModel.PendingUpdatesHeader, Mode=OneWay}"
                                FontWeight="SemiBold"
                                Margin="0,0,0,8" />
-                    <!--
-                      Host sizes the ScrollViewer explicitly (infinite-measure breaks scrolling).
-                      Built-in bars overlay/fade; we paint a permanent track + thumb ourselves.
-                    -->
-                    <Grid x:Name="PendingUpdatesScrollHost"
-                          Grid.Row="1"
-                          VerticalAlignment="Stretch"
-                          SizeChanged="PendingUpdatesScrollHost_SizeChanged">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="16" />
-                        </Grid.ColumnDefinitions>
 
-                        <ScrollViewer x:Name="PendingUpdatesScroll"
-                                      Grid.Column="0"
-                                      VerticalScrollBarVisibility="Disabled"
-                                      VerticalScrollMode="Enabled"
-                                      HorizontalScrollBarVisibility="Disabled"
-                                      HorizontalScrollMode="Disabled"
-                                      ViewChanged="PendingUpdatesScroll_ViewChanged"
-                                      AutomationProperties.AutomationId="WorkflowPendingUpdatesList">
-                            <ItemsControl x:Name="PendingUpdatesItems"
-                                          ItemsSource="{x:Bind ViewModel.PendingUpdateItems, Mode=OneWay}"
-                                          SizeChanged="PendingUpdatesItems_SizeChanged">
-                                <ItemsControl.ItemTemplate>
+                    <!-- Table column headers; right margin matches the gutter the built-in
+                         scrollbar reserves (ScrollBarSize, 12px) so headers stay over their
+                         columns (#129). Column widths must stay in sync with the row template. -->
+                    <Grid Grid.Row="1"
+                          Margin="0,0,12,0"
+                          Padding="0,0,0,4"
+                          BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                          BorderThickness="0,0,0,1">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="160" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="110" />
+                            <ColumnDefinition Width="64" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Property" FontWeight="SemiBold"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        <TextBlock Grid.Column="1" Text="Proposed" FontWeight="SemiBold"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        <!-- Status column has no header; rows still render KindLabel there. -->
+                    </Grid>
+                    <!--
+                      VerticalScrollBarVisibility must be Visible, never Disabled: per WinUI's
+                      ScrollBarVisibility contract, Disabled also turns scrolling off and clamps
+                      content height to the viewport, so rows clip and the wheel does nothing
+                      (VerticalScrollMode does not override it). Visible keeps the built-in bar
+                      on screen whenever the list overflows: the scroll affordance #129 asks for.
+                    -->
+                    <ScrollViewer Grid.Row="2"
+                                  VerticalAlignment="Stretch"
+                                  VerticalScrollBarVisibility="Visible"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  AutomationProperties.AutomationId="WorkflowPendingUpdatesList">
+                        <ItemsControl ItemsSource="{x:Bind ViewModel.PendingUpdateItems, Mode=OneWay}">
+                            <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <!-- Template root: no AutomationId (TemplateSafety forbids it). -->
-                                        <Grid Margin="0,4"
+                                        <!-- Template root: no AutomationId (TemplateSafety forbids it).
+                                             Column widths match the header row above the list. -->
+                                        <Grid Padding="0,8"
+                                              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                              BorderThickness="0,0,0,1"
                                               AutomationProperties.Name="{Binding Key, Mode=OneWay}">
                                             <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="160" />
                                                 <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="110" />
+                                                <ColumnDefinition Width="64" />
                                             </Grid.ColumnDefinitions>
-                                            <StackPanel Grid.Column="0">
-                                                <TextBlock Text="{Binding Key}"
-                                                           FontWeight="SemiBold"
-                                                           FontSize="12"
-                                                           TextTrimming="CharacterEllipsis" />
-                                                <TextBlock Text="{Binding ProposedDisplay}"
-                                                           FontSize="11"
-                                                           Opacity="0.85"
-                                                           TextTrimming="CharacterEllipsis"
-                                                           MaxLines="1" />
-                                            </StackPanel>
+                                            <!-- Tooltip carries the raw key so the element is still discoverable
+                                                 without its own column. -->
+                                            <TextBlock Text="{Binding DisplayName}"
+                                                       FontWeight="SemiBold"
+                                                       VerticalAlignment="Top"
+                                                       TextWrapping="Wrap"
+                                                       ToolTipService.ToolTip="{Binding Key}" />
                                             <TextBlock Grid.Column="1"
-                                                       Text="{Binding SummaryLine}"
-                                                       FontSize="11"
-                                                       Margin="8,0,0,0"
-                                                       VerticalAlignment="Center"
+                                                       Text="{Binding ProposedDisplay}"
+                                                       Opacity="0.9"
+                                                       VerticalAlignment="Top"
+                                                       TextWrapping="Wrap"
+                                                       Margin="0,0,8,0" />
+                                            <TextBlock Grid.Column="2"
+                                                       Text="{Binding KindLabel}"
+                                                       VerticalAlignment="Top"
+                                                       TextTrimming="CharacterEllipsis"
                                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                            <StackPanel Grid.Column="3"
+                                                        Orientation="Horizontal"
+                                                        Spacing="4"
+                                                        VerticalAlignment="Top">
+                                                <Button Click="AcceptItemButton_Click"
+                                                        Padding="5"
+                                                        Background="Transparent"
+                                                        BorderThickness="0"
+                                                        ToolTipService.ToolTip="Accept this update"
+                                                        AutomationProperties.Name="Accept update">
+                                                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                              Glyph="&#xE73E;" FontSize="12" />
+                                                </Button>
+                                                <Button Click="SkipItemButton_Click"
+                                                        Padding="5"
+                                                        Background="Transparent"
+                                                        BorderThickness="0"
+                                                        ToolTipService.ToolTip="Skip this update"
+                                                        AutomationProperties.Name="Skip update">
+                                                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                              Glyph="&#xE711;" FontSize="12" />
+                                                </Button>
+                                            </StackPanel>
                                         </Grid>
                                     </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </ScrollViewer>
-
-                        <!-- Permanent non-overlay scrollbar track (always visible). -->
-                        <Border Grid.Column="1"
-                                Margin="4,0,0,0"
-                                Background="{ThemeResource ControlAltFillColorTertiaryBrush}"
-                                CornerRadius="4"
-                                PointerPressed="PendingUpdatesTrack_PointerPressed">
-                            <Canvas x:Name="PendingUpdatesTrackCanvas"
-                                    HorizontalAlignment="Stretch"
-                                    VerticalAlignment="Stretch"
-                                    SizeChanged="PendingUpdatesTrackCanvas_SizeChanged">
-                                <Border x:Name="PendingUpdatesThumb"
-                                        Width="8"
-                                        Canvas.Left="2"
-                                        Canvas.Top="0"
-                                        Height="24"
-                                        CornerRadius="4"
-                                        Background="{ThemeResource AccentFillColorDefaultBrush}"
-                                        PointerPressed="PendingUpdatesThumb_PointerPressed"
-                                        PointerMoved="PendingUpdatesThumb_PointerMoved"
-                                        PointerReleased="PendingUpdatesThumb_PointerReleased"
-                                        PointerCaptureLost="PendingUpdatesThumb_PointerCaptureLost" />
-                            </Canvas>
-                        </Border>
-                    </Grid>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
                 </Grid>
             </Border>
 
@@ -170,7 +246,7 @@
                 <Border Background="{ThemeResource SystemAccentColorLight2}"
                         CornerRadius="4" Padding="10" Margin="0,0,0,8">
                     <StackPanel>
-                        <TextBlock Text="{x:Bind ViewModel.CurrentReviewKey, Mode=OneWay}"
+                        <TextBlock Text="{x:Bind ViewModel.CurrentReviewDisplayName, Mode=OneWay}"
                                    FontWeight="Bold" FontSize="13" />
                         <TextBlock Text="Yours"
                                    FontSize="11"
@@ -215,7 +291,7 @@
 
         <!-- ========== Chat column (own height; input does not affect work column) ========== -->
         <Grid Grid.Column="1"
-              Margin="10,0,0,0"
+              Margin="12,0,0,0"
               VerticalAlignment="Stretch">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
@@ -227,52 +303,40 @@
                       Margin="0,0,0,10"
                       VerticalAlignment="Stretch"
                       SelectionMode="None"
+                      HorizontalContentAlignment="Stretch"
+                      ItemTemplateSelector="{StaticResource ChatTemplateSelector}"
                       AutomationProperties.AutomationId="WorkflowConversationList">
+                <!-- Containers must stretch, else the bubble template only ever gets its
+                     desired width and stretching inside the template does nothing. The
+                     stock ListViewItem padding/MinHeight would also inset every bubble. -->
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        <Setter Property="Padding" Value="0" />
+                        <Setter Property="MinHeight" Value="0" />
+                    </Style>
+                </ListView.ItemContainerStyle>
                 <ListView.ItemsPanel>
                     <ItemsPanelTemplate>
                         <ItemsStackPanel VerticalAlignment="Bottom"
                                          ItemsUpdatingScrollMode="KeepLastItemInView" />
                     </ItemsPanelTemplate>
                 </ListView.ItemsPanel>
-                <ListView.ItemTemplate>
-                    <DataTemplate>
-                        <!-- Template root: no AutomationId (TemplateSafety forbids it). -->
-                        <StackPanel Margin="0,4,0,4"
-                                    HorizontalAlignment="{Binding BubbleAlignment}"
-                                    AutomationProperties.Name="{Binding Text, Mode=OneWay}">
-                            <TextBlock Text="{Binding Sender}"
-                                       FontWeight="SemiBold"
-                                       FontSize="11"
-                                       Opacity="0.7"
-                                       HorizontalAlignment="{Binding BubbleAlignment}" />
-                            <Border CornerRadius="12"
-                                    Padding="12,8,12,8"
-                                    Margin="0,2,0,0"
-                                    Background="{Binding BackgroundBrush}"
-                                    HorizontalAlignment="{Binding BubbleAlignment}"
-                                    MaxWidth="350">
-                                <TextBlock Text="{Binding Text}"
-                                           TextWrapping="Wrap"
-                                           Foreground="{Binding TextBrush}" />
-                            </Border>
-                        </StackPanel>
-                    </DataTemplate>
-                </ListView.ItemTemplate>
             </ListView>
 
-            <StackPanel Grid.Row="1" Orientation="Vertical">
-                <!-- No Header/Placeholder: explicit Name (chat message input). -->
-                <TextBox x:Name="InputTextBox"
-                         HorizontalAlignment="Stretch"
-                         KeyDown="InputTextBox_KeyDown" TextWrapping="Wrap"
-                         Text="{x:Bind ViewModel.InputText, Mode=TwoWay}"
-                         MinHeight="60"
-                         AutomationProperties.AutomationId="InputTextBox"
-                         AutomationProperties.Name="Message" />
-                <Button x:Name="SendButton" Content="Send" Click="SendButton_Click"
-                        HorizontalAlignment="Right" Margin="0,5,0,0"
-                        AutomationProperties.AutomationId="SendButton" />
-            </StackPanel>
+            <!-- No suggestion items: used for its Enter-submits behavior and in-box send button.
+                 No Header/Placeholder: explicit Name (chat message input). -->
+            <AutoSuggestBox x:Name="InputTextBox"
+                            Grid.Row="1"
+                            HorizontalAlignment="Stretch"
+                            Text="{x:Bind ViewModel.InputText, Mode=TwoWay}"
+                            QuerySubmitted="InputTextBox_QuerySubmitted"
+                            AutomationProperties.AutomationId="InputTextBox"
+                            AutomationProperties.Name="Message">
+                <AutoSuggestBox.QueryIcon>
+                    <SymbolIcon Symbol="Send" />
+                </AutoSuggestBox.QueryIcon>
+            </AutoSuggestBox>
         </Grid>
 
         <!-- Progress over both columns, bottom edge of page -->

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
@@ -18,6 +18,9 @@
     to call Bindings.Update() when navigating, ensuring bindings refresh when DataContext changes.
 
     See: https://github.com/unoplatform/uno.extensions/issues/2363
+
+    Layout (#129): work and chat are independent columns so the chat input row does not
+    leave a blank band under Property Updates. Each column owns its own bottom Auto row.
 -->
 <Page
     x:Class="StoryCADLib.Collaborator.Views.WorkflowPage"
@@ -25,224 +28,231 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
-    <Grid>
-        <!-- Define column and row definitions to make the layout responsive -->
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <!-- Title and Description -->
-            <RowDefinition Height="Auto" />
-            <!-- Explanation -->
-            <RowDefinition Height="1*" />
-            <!-- PromptOutput (takes remaining space) -->
-            <RowDefinition Height="Auto" />
-            <!-- Progress bar -->
-        </Grid.RowDefinitions>
+    mc:Ignorable="d"
+    VerticalAlignment="Stretch"
+    HorizontalAlignment="Stretch">
+    <Grid VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1*" />
             <ColumnDefinition Width="1*" />
         </Grid.ColumnDefinitions>
 
-        <!-- Title and Description -->
-        <StackPanel Grid.Row="0" Grid.Column="0" Margin="0,0,0,10">
-            <TextBlock Text="{x:Bind ViewModel.Title, Mode=OneWay}"
-                       FontWeight="Bold" FontSize="16" TextWrapping="Wrap" />
-            <TextBlock Text="{x:Bind ViewModel.Description, Mode=OneWay}"
-                       FontStyle="Italic" TextWrapping="Wrap" Margin="0,5,0,0" />
-        </StackPanel>
+        <!-- ========== Work column (full height; Property Updates takes leftover) ========== -->
+        <Grid Grid.Column="0"
+              Margin="0,0,10,0"
+              VerticalAlignment="Stretch">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
 
-        <!-- Explanation -->
-        <TextBlock Text="{x:Bind ViewModel.Explanation, Mode=OneWay}"
-                   Grid.Row="1" Grid.Column="0"
-                   TextWrapping="Wrap" Margin="0,0,10,10" />
-
-        <!-- Selected Elements and Prompt Output -->
-        <ScrollViewer Grid.Row="2" Grid.Column="0" Margin="0,0,10,0">
-            <StackPanel>
-                <!-- Selected Elements Summary -->
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                        BorderThickness="1" CornerRadius="4" Padding="10" Margin="0,0,0,10">
-                    <StackPanel>
-                        <TextBlock Text="Selected Elements:" FontWeight="SemiBold" Margin="0,0,0,5" />
-                        <TextBlock Text="{x:Bind ViewModel.SelectedElementsSummary, Mode=OneWay}" TextWrapping="Wrap" />
-                    </StackPanel>
-                </Border>
-
-                <!-- Property Updates Panel - always shown when there are updates -->
-                <Border Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
-                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                        BorderThickness="1" CornerRadius="4" Padding="10" Margin="0,0,0,10">
-                    <StackPanel>
-                        <!-- Header -->
-                        <TextBlock Text="Property Updates" FontWeight="SemiBold" Margin="0,0,0,8" />
-
-                        <!-- Updates List (#116: current vs proposed + protect/craft labels) -->
-                        <ListView ItemsSource="{x:Bind ViewModel.PendingUpdateItems, Mode=OneWay}"
-                                  SelectionMode="None"
-                                  MaxHeight="220"
-                                  AutomationProperties.AutomationId="WorkflowPendingUpdatesList">
-                            <ListView.ItemTemplate>
-                                <DataTemplate>
-                                    <!-- Template root: no AutomationId (TemplateSafety forbids it). -->
-                                    <StackPanel Margin="0,4"
-                                                AutomationProperties.Name="{Binding Key, Mode=OneWay}">
-                                        <TextBlock Text="{Binding Key}" FontWeight="SemiBold" FontSize="12" />
-                                        <TextBlock Text="{Binding SummaryLine}"
-                                                   FontSize="11"
-                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                        <TextBlock Text="{Binding ProposedDisplay}"
-                                                   TextWrapping="Wrap"
-                                                   FontSize="12"
-                                                   MaxLines="3" />
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ListView.ItemTemplate>
-                        </ListView>
-
-                        <!-- Action buttons: page-prefixed, "Accept"/"Save"/etc. are common function
-                             names across dialogs elsewhere in scope. -->
-                        <StackPanel Orientation="Horizontal" Spacing="4" Margin="0,8,0,0">
-                            <Button Content="Accept All"
-                                    Command="{x:Bind ViewModel.AcceptAllCommand}"
-                                    IsEnabled="{x:Bind ViewModel.HasPendingUpdates, Mode=OneWay}"
-                                    Style="{ThemeResource AccentButtonStyle}"
-                                    AutomationProperties.AutomationId="WorkflowAcceptAllButton" />
-                            <Button Content="Review Each"
-                                    Command="{x:Bind ViewModel.ReviewEachCommand}"
-                                    IsEnabled="{x:Bind ViewModel.HasPendingUpdates, Mode=OneWay}"
-                                    AutomationProperties.AutomationId="WorkflowReviewEachButton" />
-                            <Button Content="Try Again"
-                                    Command="{x:Bind ViewModel.TryAgainCommand}"
-                                    IsEnabled="{x:Bind ViewModel.HasPendingUpdates, Mode=OneWay}"
-                                    AutomationProperties.AutomationId="WorkflowTryAgainButton" />
-                        </StackPanel>
-
-                        <!-- Review Mode UI -->
-                        <StackPanel Visibility="{x:Bind ViewModel.ReviewModeVisibility, Mode=OneWay}"
-                                    Margin="0,8,0,0">
-                            <TextBlock Text="Review Property Update" FontWeight="SemiBold" Margin="0,0,0,8" />
-
-                            <!-- Current property being reviewed (#116: yours vs proposed + craft) -->
-                            <Border Background="{ThemeResource SystemAccentColorLight2}"
-                                    CornerRadius="4" Padding="10" Margin="0,0,0,8">
-                                <StackPanel>
-                                    <TextBlock Text="{x:Bind ViewModel.CurrentReviewKey, Mode=OneWay}"
-                                               FontWeight="Bold" FontSize="13" />
-                                    <TextBlock Text="Yours"
-                                               FontSize="11"
-                                               Margin="0,8,0,0"
-                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                    <TextBlock Text="{x:Bind ViewModel.CurrentReviewExisting, Mode=OneWay}"
-                                               TextWrapping="Wrap" Margin="0,2,0,0" />
-                                    <TextBlock Text="Proposed"
-                                               FontSize="11"
-                                               Margin="0,8,0,0"
-                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                    <TextBlock Text="{x:Bind ViewModel.CurrentReviewValue, Mode=OneWay}"
-                                               TextWrapping="Wrap" Margin="0,2,0,0" />
-                                    <TextBlock Text="{x:Bind ViewModel.CurrentReviewCraft, Mode=OneWay}"
-                                               TextWrapping="Wrap"
-                                               Margin="0,8,0,0"
-                                               FontSize="12"
-                                               Visibility="{x:Bind ViewModel.CurrentReviewCraftVisibility, Mode=OneWay}" />
-                                </StackPanel>
-                            </Border>
-
-                            <!-- Review action buttons -->
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
-                                <Button Content="Accept"
-                                        Command="{x:Bind ViewModel.AcceptCurrentCommand}"
-                                        IsEnabled="{x:Bind ViewModel.IsInReviewMode, Mode=OneWay}"
-                                        Style="{ThemeResource AccentButtonStyle}"
-                                        AutomationProperties.AutomationId="WorkflowAcceptButton" />
-                                <Button Content="Skip"
-                                        Command="{x:Bind ViewModel.SkipCurrentCommand}"
-                                        IsEnabled="{x:Bind ViewModel.IsInReviewMode, Mode=OneWay}"
-                                        AutomationProperties.AutomationId="WorkflowSkipButton" />
-                                <Button Content="Accept Free Remaining"
-                                        Command="{x:Bind ViewModel.AcceptRemainingCommand}"
-                                        IsEnabled="{x:Bind ViewModel.IsInReviewMode, Mode=OneWay}"
-                                        AutomationProperties.AutomationId="WorkflowAcceptRemainingButton"
-                                        ToolTipService.ToolTip="Applies empty/session fields only; leaves fields that already have your text" />
-                            </StackPanel>
-
-                            <!-- Progress indicator -->
-                            <TextBlock Text="{x:Bind ViewModel.ReviewProgress, Mode=OneWay}"
-                                       HorizontalAlignment="Center"
-                                       Margin="0,8,0,0"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        </StackPanel>
-                    </StackPanel>
-                </Border>
-
-                <!-- Prompt Output -->
-                <TextBlock Text="{x:Bind ViewModel.PromptOutput, Mode=OneWay}" TextWrapping="Wrap" />
+            <!-- Brief description + explanation (title is on shell bar) -->
+            <StackPanel Grid.Row="0" Margin="0,0,0,8">
+                <TextBlock Text="{x:Bind ViewModel.Description, Mode=OneWay}"
+                           FontStyle="Italic"
+                           TextWrapping="Wrap"
+                           MaxLines="3"
+                           TextTrimming="CharacterEllipsis" />
+                <TextBlock Text="{x:Bind ViewModel.Explanation, Mode=OneWay}"
+                           TextWrapping="Wrap"
+                           Margin="0,6,0,0"
+                           MaxLines="5"
+                           TextTrimming="CharacterEllipsis"
+                           FontSize="12"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
             </StackPanel>
-        </ScrollViewer>
 
-        <!-- Chat history - spans rows 0-2 in column 1, grows from bottom up -->
-        <ListView ItemsSource="{x:Bind ViewModel.ConversationList, Mode=OneWay}"
-                  Grid.Column="1" Grid.Row="0" Grid.RowSpan="3"
-                  Margin="10,0,0,10"
-                  VerticalAlignment="Bottom"
-                  SelectionMode="None"
-                  AutomationProperties.AutomationId="WorkflowConversationList">
-            <ListView.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <ItemsStackPanel VerticalAlignment="Bottom"
-                                     ItemsUpdatingScrollMode="KeepLastItemInView" />
-                </ItemsPanelTemplate>
-            </ListView.ItemsPanel>
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <!-- Template root: no AutomationId (TemplateSafety forbids it). Item identity binds
-                         to the message Text (ChatMessage has no INotifyPropertyChanged, but Mode=OneWay
-                         is explicit per convention) rather than Sender, since the message content is what
-                         a screen reader user needs from a chat row; classic {Binding} matches the template. -->
-                    <StackPanel Margin="0,4,0,4"
-                                HorizontalAlignment="{Binding BubbleAlignment}"
-                                AutomationProperties.Name="{Binding Text, Mode=OneWay}">
-                        <TextBlock Text="{Binding Sender}"
-                                   FontWeight="SemiBold"
+            <!-- Selected Elements -->
+            <Border Grid.Row="1"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1" CornerRadius="4" Padding="10" Margin="0,0,0,8">
+                <StackPanel>
+                    <TextBlock Text="Selected Elements:" FontWeight="SemiBold" Margin="0,0,0,5" />
+                    <TextBlock Text="{x:Bind ViewModel.SelectedElementsSummary, Mode=OneWay}" TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
+
+            <!-- Property Updates: fills all remaining height down to review row / column bottom -->
+            <Border Grid.Row="2"
+                    Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1" CornerRadius="4" Padding="10"
+                    VerticalAlignment="Stretch"
+                    HorizontalAlignment="Stretch">
+                <Grid VerticalAlignment="Stretch">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <TextBlock Grid.Row="0"
+                               Text="{x:Bind ViewModel.PendingUpdatesHeader, Mode=OneWay}"
+                               FontWeight="SemiBold"
+                               Margin="0,0,0,8" />
+                    <ListView Grid.Row="1"
+                              ItemsSource="{x:Bind ViewModel.PendingUpdateItems, Mode=OneWay}"
+                              SelectionMode="None"
+                              VerticalAlignment="Stretch"
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"
+                              HorizontalContentAlignment="Stretch"
+                              AutomationProperties.AutomationId="WorkflowPendingUpdatesList">
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem">
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                <Setter Property="Padding" Value="0,2" />
+                                <Setter Property="MinHeight" Value="0" />
+                            </Style>
+                        </ListView.ItemContainerStyle>
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <!-- Template root: no AutomationId (TemplateSafety forbids it). -->
+                                <Grid AutomationProperties.Name="{Binding Key, Mode=OneWay}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <StackPanel Grid.Column="0">
+                                        <TextBlock Text="{Binding Key}"
+                                                   FontWeight="SemiBold"
+                                                   FontSize="12"
+                                                   TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Text="{Binding ProposedDisplay}"
+                                                   FontSize="11"
+                                                   Opacity="0.85"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   MaxLines="1" />
+                                    </StackPanel>
+                                    <TextBlock Grid.Column="1"
+                                               Text="{Binding SummaryLine}"
+                                               FontSize="11"
+                                               Margin="8,0,0,0"
+                                               VerticalAlignment="Center"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                </Grid>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </Grid>
+            </Border>
+
+            <!-- Review Mode (Accept/Skip); Accept All is on the shell bar -->
+            <StackPanel Grid.Row="3"
+                        Visibility="{x:Bind ViewModel.ReviewModeVisibility, Mode=OneWay}"
+                        Margin="0,8,0,0">
+                <TextBlock Text="Review Property Update" FontWeight="SemiBold" Margin="0,0,0,8" />
+                <Border Background="{ThemeResource SystemAccentColorLight2}"
+                        CornerRadius="4" Padding="10" Margin="0,0,0,8">
+                    <StackPanel>
+                        <TextBlock Text="{x:Bind ViewModel.CurrentReviewKey, Mode=OneWay}"
+                                   FontWeight="Bold" FontSize="13" />
+                        <TextBlock Text="Yours"
                                    FontSize="11"
-                                   Opacity="0.7"
-                                   HorizontalAlignment="{Binding BubbleAlignment}" />
-                        <Border CornerRadius="12"
-                                Padding="12,8,12,8"
-                                Margin="0,2,0,0"
-                                Background="{Binding BackgroundBrush}"
-                                HorizontalAlignment="{Binding BubbleAlignment}"
-                                MaxWidth="350">
-                            <TextBlock Text="{Binding Text}"
-                                       TextWrapping="Wrap"
-                                       Foreground="{Binding TextBrush}" />
-                        </Border>
+                                   Margin="0,8,0,0"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        <TextBlock Text="{x:Bind ViewModel.CurrentReviewExisting, Mode=OneWay}"
+                                   TextWrapping="Wrap" Margin="0,2,0,0" />
+                        <TextBlock Text="Proposed"
+                                   FontSize="11"
+                                   Margin="0,8,0,0"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        <TextBlock Text="{x:Bind ViewModel.CurrentReviewValue, Mode=OneWay}"
+                                   TextWrapping="Wrap" Margin="0,2,0,0" />
+                        <TextBlock Text="{x:Bind ViewModel.CurrentReviewCraft, Mode=OneWay}"
+                                   TextWrapping="Wrap"
+                                   Margin="0,8,0,0"
+                                   FontSize="12"
+                                   Visibility="{x:Bind ViewModel.CurrentReviewCraftVisibility, Mode=OneWay}" />
                     </StackPanel>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+                </Border>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Spacing="8">
+                    <Button Content="Accept"
+                            Command="{x:Bind ViewModel.AcceptCurrentCommand}"
+                            IsEnabled="{x:Bind ViewModel.IsInReviewMode, Mode=OneWay}"
+                            Style="{ThemeResource AccentButtonStyle}"
+                            AutomationProperties.AutomationId="WorkflowAcceptButton" />
+                    <Button Content="Skip"
+                            Command="{x:Bind ViewModel.SkipCurrentCommand}"
+                            IsEnabled="{x:Bind ViewModel.IsInReviewMode, Mode=OneWay}"
+                            AutomationProperties.AutomationId="WorkflowSkipButton" />
+                    <Button Content="Accept Free Remaining"
+                            Command="{x:Bind ViewModel.AcceptRemainingCommand}"
+                            IsEnabled="{x:Bind ViewModel.IsInReviewMode, Mode=OneWay}"
+                            AutomationProperties.AutomationId="WorkflowAcceptRemainingButton"
+                            ToolTipService.ToolTip="Applies empty/session fields only; leaves fields that already have your text" />
+                </StackPanel>
+                <TextBlock Text="{x:Bind ViewModel.ReviewProgress, Mode=OneWay}"
+                           Margin="0,8,0,0"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+            </StackPanel>
+        </Grid>
 
-        <!-- Input and send button -->
-        <StackPanel Grid.Column="1" Grid.Row="3" Orientation="Vertical" Margin="10,0,0,0">
-            <!-- No Header, no PlaceholderText, no sibling label TextBlock: explicit Name required,
-                 naming the function (chat message input) since no visible label text exists to reuse. -->
-            <TextBox x:Name="InputTextBox"
-                     HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                     KeyDown="InputTextBox_KeyDown" TextWrapping="Wrap"
-                     Text="{x:Bind ViewModel.InputText, Mode=TwoWay}"
-                     MinHeight="60"
-                     AutomationProperties.AutomationId="InputTextBox"
-                     AutomationProperties.Name="Message" />
-            <!-- Content="Send": framework-derived name, id only. -->
-            <Button x:Name="SendButton" Content="Send" Click="SendButton_Click"
-                    HorizontalAlignment="Right" Margin="0,5,0,0"
-                    AutomationProperties.AutomationId="SendButton" />
-        </StackPanel>
+        <!-- ========== Chat column (own height; input does not affect work column) ========== -->
+        <Grid Grid.Column="1"
+              Margin="10,0,0,0"
+              VerticalAlignment="Stretch">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
 
-        <!-- Progress bar - spans both columns at bottom -->
+            <ListView Grid.Row="0"
+                      ItemsSource="{x:Bind ViewModel.ConversationList, Mode=OneWay}"
+                      Margin="0,0,0,10"
+                      VerticalAlignment="Stretch"
+                      SelectionMode="None"
+                      AutomationProperties.AutomationId="WorkflowConversationList">
+                <ListView.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <ItemsStackPanel VerticalAlignment="Bottom"
+                                         ItemsUpdatingScrollMode="KeepLastItemInView" />
+                    </ItemsPanelTemplate>
+                </ListView.ItemsPanel>
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <!-- Template root: no AutomationId (TemplateSafety forbids it). -->
+                        <StackPanel Margin="0,4,0,4"
+                                    HorizontalAlignment="{Binding BubbleAlignment}"
+                                    AutomationProperties.Name="{Binding Text, Mode=OneWay}">
+                            <TextBlock Text="{Binding Sender}"
+                                       FontWeight="SemiBold"
+                                       FontSize="11"
+                                       Opacity="0.7"
+                                       HorizontalAlignment="{Binding BubbleAlignment}" />
+                            <Border CornerRadius="12"
+                                    Padding="12,8,12,8"
+                                    Margin="0,2,0,0"
+                                    Background="{Binding BackgroundBrush}"
+                                    HorizontalAlignment="{Binding BubbleAlignment}"
+                                    MaxWidth="350">
+                                <TextBlock Text="{Binding Text}"
+                                           TextWrapping="Wrap"
+                                           Foreground="{Binding TextBrush}" />
+                            </Border>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+
+            <StackPanel Grid.Row="1" Orientation="Vertical">
+                <!-- No Header/Placeholder: explicit Name (chat message input). -->
+                <TextBox x:Name="InputTextBox"
+                         HorizontalAlignment="Stretch"
+                         KeyDown="InputTextBox_KeyDown" TextWrapping="Wrap"
+                         Text="{x:Bind ViewModel.InputText, Mode=TwoWay}"
+                         MinHeight="60"
+                         AutomationProperties.AutomationId="InputTextBox"
+                         AutomationProperties.Name="Message" />
+                <Button x:Name="SendButton" Content="Send" Click="SendButton_Click"
+                        HorizontalAlignment="Right" Margin="0,5,0,0"
+                        AutomationProperties.AutomationId="SendButton" />
+            </StackPanel>
+        </Grid>
+
+        <!-- Progress over both columns, bottom edge of page -->
         <ProgressBar x:Name="ResponseProgressBar"
-                     Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
+                     Grid.Column="0" Grid.ColumnSpan="2"
                      VerticalAlignment="Bottom"
                      Height="5" IsIndeterminate="True"
                      Visibility="{x:Bind ViewModel.ProgressVisibility, Mode=TwoWay}" />

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
@@ -43,40 +43,28 @@
               VerticalAlignment="Stretch">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <!-- Brief description + explanation (title is on shell bar) -->
+            <!-- Brief purpose + topical Explanation (selected elements + what to do next) -->
             <StackPanel Grid.Row="0" Margin="0,0,0,8">
                 <TextBlock Text="{x:Bind ViewModel.Description, Mode=OneWay}"
                            FontStyle="Italic"
                            TextWrapping="Wrap"
-                           MaxLines="3"
+                           MaxLines="2"
                            TextTrimming="CharacterEllipsis" />
                 <TextBlock Text="{x:Bind ViewModel.Explanation, Mode=OneWay}"
                            TextWrapping="Wrap"
                            Margin="0,6,0,0"
-                           MaxLines="5"
+                           MaxLines="4"
                            TextTrimming="CharacterEllipsis"
                            FontSize="12"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
             </StackPanel>
 
-            <!-- Selected Elements -->
+            <!-- Property Updates: fills remaining height; always show scrollbar when list scrolls -->
             <Border Grid.Row="1"
-                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                    BorderThickness="1" CornerRadius="4" Padding="10" Margin="0,0,0,8">
-                <StackPanel>
-                    <TextBlock Text="Selected Elements:" FontWeight="SemiBold" Margin="0,0,0,5" />
-                    <TextBlock Text="{x:Bind ViewModel.SelectedElementsSummary, Mode=OneWay}" TextWrapping="Wrap" />
-                </StackPanel>
-            </Border>
-
-            <!-- Property Updates: fills all remaining height down to review row / column bottom -->
-            <Border Grid.Row="2"
                     Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1" CornerRadius="4" Padding="10"
@@ -95,7 +83,8 @@
                               ItemsSource="{x:Bind ViewModel.PendingUpdateItems, Mode=OneWay}"
                               SelectionMode="None"
                               VerticalAlignment="Stretch"
-                              ScrollViewer.VerticalScrollBarVisibility="Auto"
+                              ScrollViewer.VerticalScrollBarVisibility="Visible"
+                              ScrollViewer.VerticalScrollMode="Enabled"
                               HorizontalContentAlignment="Stretch"
                               AutomationProperties.AutomationId="WorkflowPendingUpdatesList">
                         <ListView.ItemContainerStyle>
@@ -138,7 +127,7 @@
             </Border>
 
             <!-- Review Mode (Accept/Skip); Accept All is on the shell bar -->
-            <StackPanel Grid.Row="3"
+            <StackPanel Grid.Row="2"
                         Visibility="{x:Bind ViewModel.ReviewModeVisibility, Mode=OneWay}"
                         Margin="0,8,0,0">
                 <TextBlock Text="Review Property Update" FontWeight="SemiBold" Margin="0,0,0,8" />

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
@@ -79,50 +79,47 @@
                                Text="{x:Bind ViewModel.PendingUpdatesHeader, Mode=OneWay}"
                                FontWeight="SemiBold"
                                Margin="0,0,0,8" />
-                    <ListView Grid.Row="1"
-                              ItemsSource="{x:Bind ViewModel.PendingUpdateItems, Mode=OneWay}"
-                              SelectionMode="None"
-                              VerticalAlignment="Stretch"
-                              ScrollViewer.VerticalScrollBarVisibility="Visible"
-                              ScrollViewer.VerticalScrollMode="Enabled"
-                              HorizontalContentAlignment="Stretch"
-                              AutomationProperties.AutomationId="WorkflowPendingUpdatesList">
-                        <ListView.ItemContainerStyle>
-                            <Style TargetType="ListViewItem">
-                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                                <Setter Property="Padding" Value="0,2" />
-                                <Setter Property="MinHeight" Value="0" />
-                            </Style>
-                        </ListView.ItemContainerStyle>
-                        <ListView.ItemTemplate>
-                            <DataTemplate>
-                                <!-- Template root: no AutomationId (TemplateSafety forbids it). -->
-                                <Grid AutomationProperties.Name="{Binding Key, Mode=OneWay}">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <StackPanel Grid.Column="0">
-                                        <TextBlock Text="{Binding Key}"
-                                                   FontWeight="SemiBold"
-                                                   FontSize="12"
-                                                   TextTrimming="CharacterEllipsis" />
-                                        <TextBlock Text="{Binding ProposedDisplay}"
+                    <!-- ScrollViewer (not ListView) so the vertical bar stays visible (#129).
+                         Pending lists are small; virtualization is not needed. -->
+                    <ScrollViewer Grid.Row="1"
+                                  VerticalAlignment="Stretch"
+                                  VerticalScrollBarVisibility="Visible"
+                                  VerticalScrollMode="Enabled"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  HorizontalScrollMode="Disabled"
+                                  AutomationProperties.AutomationId="WorkflowPendingUpdatesList">
+                        <ItemsControl ItemsSource="{x:Bind ViewModel.PendingUpdateItems, Mode=OneWay}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <!-- Template root: no AutomationId (TemplateSafety forbids it). -->
+                                    <Grid Margin="0,2"
+                                          AutomationProperties.Name="{Binding Key, Mode=OneWay}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Grid.Column="0">
+                                            <TextBlock Text="{Binding Key}"
+                                                       FontWeight="SemiBold"
+                                                       FontSize="12"
+                                                       TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Text="{Binding ProposedDisplay}"
+                                                       FontSize="11"
+                                                       Opacity="0.85"
+                                                       TextTrimming="CharacterEllipsis"
+                                                       MaxLines="1" />
+                                        </StackPanel>
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding SummaryLine}"
                                                    FontSize="11"
-                                                   Opacity="0.85"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   MaxLines="1" />
-                                    </StackPanel>
-                                    <TextBlock Grid.Column="1"
-                                               Text="{Binding SummaryLine}"
-                                               FontSize="11"
-                                               Margin="8,0,0,0"
-                                               VerticalAlignment="Center"
-                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                </Grid>
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                    </ListView>
+                                                   Margin="8,0,0,0"
+                                                   VerticalAlignment="Center"
+                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
                 </Grid>
             </Border>
 

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
@@ -79,21 +79,26 @@
                                Text="{x:Bind ViewModel.PendingUpdatesHeader, Mode=OneWay}"
                                FontWeight="SemiBold"
                                Margin="0,0,0,8" />
-                    <!-- Explicit ScrollBar (not overlay): WinUI ListView/ScrollViewer bars fade out. -->
-                    <Grid Grid.Row="1" VerticalAlignment="Stretch">
+                    <!--
+                      Host sizes the ScrollViewer explicitly (infinite-measure breaks scrolling).
+                      Built-in bars overlay/fade; we paint a permanent track + thumb ourselves.
+                    -->
+                    <Grid x:Name="PendingUpdatesScrollHost"
+                          Grid.Row="1"
+                          VerticalAlignment="Stretch"
+                          SizeChanged="PendingUpdatesScrollHost_SizeChanged">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="16" />
                         </Grid.ColumnDefinitions>
+
                         <ScrollViewer x:Name="PendingUpdatesScroll"
                                       Grid.Column="0"
-                                      VerticalAlignment="Stretch"
-                                      VerticalScrollBarVisibility="Hidden"
+                                      VerticalScrollBarVisibility="Disabled"
                                       VerticalScrollMode="Enabled"
                                       HorizontalScrollBarVisibility="Disabled"
                                       HorizontalScrollMode="Disabled"
                                       ViewChanged="PendingUpdatesScroll_ViewChanged"
-                                      SizeChanged="PendingUpdatesScroll_SizeChanged"
                                       AutomationProperties.AutomationId="WorkflowPendingUpdatesList">
                             <ItemsControl x:Name="PendingUpdatesItems"
                                           ItemsSource="{x:Bind ViewModel.PendingUpdateItems, Mode=OneWay}"
@@ -101,7 +106,7 @@
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
                                         <!-- Template root: no AutomationId (TemplateSafety forbids it). -->
-                                        <Grid Margin="0,2"
+                                        <Grid Margin="0,4"
                                               AutomationProperties.Name="{Binding Key, Mode=OneWay}">
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="*" />
@@ -129,15 +134,30 @@
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
                         </ScrollViewer>
-                        <ScrollBar x:Name="PendingUpdatesScrollBar"
-                                   Grid.Column="1"
-                                   Orientation="Vertical"
-                                   IndicatorMode="MouseIndicator"
-                                   Width="14"
-                                   Margin="2,0,0,0"
-                                   Minimum="0"
-                                   ValueChanged="PendingUpdatesScrollBar_ValueChanged"
-                                   AutomationProperties.Name="Property updates scroll" />
+
+                        <!-- Permanent non-overlay scrollbar track (always visible). -->
+                        <Border Grid.Column="1"
+                                Margin="4,0,0,0"
+                                Background="{ThemeResource ControlAltFillColorTertiaryBrush}"
+                                CornerRadius="4"
+                                PointerPressed="PendingUpdatesTrack_PointerPressed">
+                            <Canvas x:Name="PendingUpdatesTrackCanvas"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Stretch"
+                                    SizeChanged="PendingUpdatesTrackCanvas_SizeChanged">
+                                <Border x:Name="PendingUpdatesThumb"
+                                        Width="8"
+                                        Canvas.Left="2"
+                                        Canvas.Top="0"
+                                        Height="24"
+                                        CornerRadius="4"
+                                        Background="{ThemeResource AccentFillColorDefaultBrush}"
+                                        PointerPressed="PendingUpdatesThumb_PointerPressed"
+                                        PointerMoved="PendingUpdatesThumb_PointerMoved"
+                                        PointerReleased="PendingUpdatesThumb_PointerReleased"
+                                        PointerCaptureLost="PendingUpdatesThumb_PointerCaptureLost" />
+                            </Canvas>
+                        </Border>
                     </Grid>
                 </Grid>
             </Border>

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
@@ -79,47 +79,66 @@
                                Text="{x:Bind ViewModel.PendingUpdatesHeader, Mode=OneWay}"
                                FontWeight="SemiBold"
                                Margin="0,0,0,8" />
-                    <!-- ScrollViewer (not ListView) so the vertical bar stays visible (#129).
-                         Pending lists are small; virtualization is not needed. -->
-                    <ScrollViewer Grid.Row="1"
-                                  VerticalAlignment="Stretch"
-                                  VerticalScrollBarVisibility="Visible"
-                                  VerticalScrollMode="Enabled"
-                                  HorizontalScrollBarVisibility="Disabled"
-                                  HorizontalScrollMode="Disabled"
-                                  AutomationProperties.AutomationId="WorkflowPendingUpdatesList">
-                        <ItemsControl ItemsSource="{x:Bind ViewModel.PendingUpdateItems, Mode=OneWay}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <!-- Template root: no AutomationId (TemplateSafety forbids it). -->
-                                    <Grid Margin="0,2"
-                                          AutomationProperties.Name="{Binding Key, Mode=OneWay}">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
-                                        <StackPanel Grid.Column="0">
-                                            <TextBlock Text="{Binding Key}"
-                                                       FontWeight="SemiBold"
-                                                       FontSize="12"
-                                                       TextTrimming="CharacterEllipsis" />
-                                            <TextBlock Text="{Binding ProposedDisplay}"
+                    <!-- Explicit ScrollBar (not overlay): WinUI ListView/ScrollViewer bars fade out. -->
+                    <Grid Grid.Row="1" VerticalAlignment="Stretch">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <ScrollViewer x:Name="PendingUpdatesScroll"
+                                      Grid.Column="0"
+                                      VerticalAlignment="Stretch"
+                                      VerticalScrollBarVisibility="Hidden"
+                                      VerticalScrollMode="Enabled"
+                                      HorizontalScrollBarVisibility="Disabled"
+                                      HorizontalScrollMode="Disabled"
+                                      ViewChanged="PendingUpdatesScroll_ViewChanged"
+                                      SizeChanged="PendingUpdatesScroll_SizeChanged"
+                                      AutomationProperties.AutomationId="WorkflowPendingUpdatesList">
+                            <ItemsControl x:Name="PendingUpdatesItems"
+                                          ItemsSource="{x:Bind ViewModel.PendingUpdateItems, Mode=OneWay}"
+                                          SizeChanged="PendingUpdatesItems_SizeChanged">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <!-- Template root: no AutomationId (TemplateSafety forbids it). -->
+                                        <Grid Margin="0,2"
+                                              AutomationProperties.Name="{Binding Key, Mode=OneWay}">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+                                            <StackPanel Grid.Column="0">
+                                                <TextBlock Text="{Binding Key}"
+                                                           FontWeight="SemiBold"
+                                                           FontSize="12"
+                                                           TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Text="{Binding ProposedDisplay}"
+                                                           FontSize="11"
+                                                           Opacity="0.85"
+                                                           TextTrimming="CharacterEllipsis"
+                                                           MaxLines="1" />
+                                            </StackPanel>
+                                            <TextBlock Grid.Column="1"
+                                                       Text="{Binding SummaryLine}"
                                                        FontSize="11"
-                                                       Opacity="0.85"
-                                                       TextTrimming="CharacterEllipsis"
-                                                       MaxLines="1" />
-                                        </StackPanel>
-                                        <TextBlock Grid.Column="1"
-                                                   Text="{Binding SummaryLine}"
-                                                   FontSize="11"
-                                                   Margin="8,0,0,0"
-                                                   VerticalAlignment="Center"
-                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                    </Grid>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </ScrollViewer>
+                                                       Margin="8,0,0,0"
+                                                       VerticalAlignment="Center"
+                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+                        <ScrollBar x:Name="PendingUpdatesScrollBar"
+                                   Grid.Column="1"
+                                   Orientation="Vertical"
+                                   IndicatorMode="MouseIndicator"
+                                   Width="14"
+                                   Margin="2,0,0,0"
+                                   Minimum="0"
+                                   ValueChanged="PendingUpdatesScrollBar_ValueChanged"
+                                   AutomationProperties.Name="Property updates scroll" />
+                    </Grid>
                 </Grid>
             </Border>
 

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml.cs
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml.cs
@@ -1,5 +1,6 @@
 using Windows.System;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
@@ -20,10 +21,35 @@ namespace StoryCADLib.Collaborator.Views;
 /// </summary>
 public sealed partial class WorkflowPage : Page
 {
+    private bool _syncingPendingScroll;
+
     public WorkflowPage()
     {
         InitializeComponent();
         DataContext = new WorkflowViewModel();
+        Loaded += OnPageLoaded;
+        DataContextChanged += (_, _) => HookPendingUpdatesCollection();
+    }
+
+    private void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        HookPendingUpdatesCollection();
+        SyncPendingUpdatesScrollBar();
+    }
+
+    private void HookPendingUpdatesCollection()
+    {
+        if (ViewModel?.PendingUpdateItems == null)
+            return;
+
+        ViewModel.PendingUpdateItems.CollectionChanged -= PendingUpdateItems_CollectionChanged;
+        ViewModel.PendingUpdateItems.CollectionChanged += PendingUpdateItems_CollectionChanged;
+    }
+
+    private void PendingUpdateItems_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        // Layout updates after items arrive (workflow result).
+        DispatcherQueue.TryEnqueue(() => SyncPendingUpdatesScrollBar());
     }
 
     /// <summary>
@@ -45,6 +71,8 @@ public sealed partial class WorkflowPage : Page
         {
             await ViewModel.InitializeAsync(e.Parameter);
         }
+
+        SyncPendingUpdatesScrollBar();
     }
 
     private void InputTextBox_KeyDown(object sender, KeyRoutedEventArgs e)
@@ -60,6 +88,73 @@ public sealed partial class WorkflowPage : Page
         if (ViewModel != null)
         {
             await ViewModel.SendButtonClicked();
+        }
+    }
+
+    private void PendingUpdatesScroll_ViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
+        => SyncPendingUpdatesScrollBar();
+
+    private void PendingUpdatesScroll_SizeChanged(object sender, SizeChangedEventArgs e)
+        => SyncPendingUpdatesScrollBar();
+
+    private void PendingUpdatesItems_SizeChanged(object sender, SizeChangedEventArgs e)
+        => SyncPendingUpdatesScrollBar();
+
+    private void PendingUpdatesScrollBar_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
+    {
+        if (_syncingPendingScroll || PendingUpdatesScroll == null)
+            return;
+
+        PendingUpdatesScroll.ChangeView(null, e.NewValue, null, true);
+    }
+
+    /// <summary>
+    /// Keep the explicit vertical ScrollBar in sync. Overlay scrollbars fade; this one does not.
+    /// </summary>
+    private void SyncPendingUpdatesScrollBar()
+    {
+        if (PendingUpdatesScroll == null || PendingUpdatesScrollBar == null)
+            return;
+
+        _syncingPendingScroll = true;
+        try
+        {
+            var viewport = PendingUpdatesScroll.ViewportHeight;
+            var extent = PendingUpdatesScroll.ExtentHeight;
+            var scrollable = PendingUpdatesScroll.ScrollableHeight;
+
+            if (viewport <= 0)
+            {
+                // Not laid out yet.
+                PendingUpdatesScrollBar.Minimum = 0;
+                PendingUpdatesScrollBar.Maximum = 1;
+                PendingUpdatesScrollBar.ViewportSize = 1;
+                PendingUpdatesScrollBar.Value = 0;
+                PendingUpdatesScrollBar.IsEnabled = false;
+                return;
+            }
+
+            if (scrollable <= 0.5)
+            {
+                // Content fits: still show a full track so the affordance is obvious.
+                PendingUpdatesScrollBar.Minimum = 0;
+                PendingUpdatesScrollBar.Maximum = 1;
+                PendingUpdatesScrollBar.ViewportSize = 1;
+                PendingUpdatesScrollBar.Value = 0;
+                PendingUpdatesScrollBar.IsEnabled = false;
+            }
+            else
+            {
+                PendingUpdatesScrollBar.Minimum = 0;
+                PendingUpdatesScrollBar.Maximum = scrollable;
+                PendingUpdatesScrollBar.ViewportSize = viewport;
+                PendingUpdatesScrollBar.Value = PendingUpdatesScroll.VerticalOffset;
+                PendingUpdatesScrollBar.IsEnabled = true;
+            }
+        }
+        finally
+        {
+            _syncingPendingScroll = false;
         }
     }
 }

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml.cs
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml.cs
@@ -1,10 +1,7 @@
-using Windows.System;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using StoryCADLib.Collaborator.ViewModels;
-using Windows.Foundation;
 
 namespace StoryCADLib.Collaborator.Views;
 
@@ -21,37 +18,10 @@ namespace StoryCADLib.Collaborator.Views;
 /// </summary>
 public sealed partial class WorkflowPage : Page
 {
-    private bool _thumbDragging;
-    private double _thumbDragStartY;
-    private double _thumbDragStartOffset;
-
     public WorkflowPage()
     {
         InitializeComponent();
         DataContext = new WorkflowViewModel();
-        Loaded += OnPageLoaded;
-        DataContextChanged += (_, _) => HookPendingUpdatesCollection();
-    }
-
-    private void OnPageLoaded(object sender, RoutedEventArgs e)
-    {
-        HookPendingUpdatesCollection();
-        UpdatePendingUpdatesScrollLayout();
-    }
-
-    private void HookPendingUpdatesCollection()
-    {
-        if (ViewModel?.PendingUpdateItems == null)
-            return;
-
-        ViewModel.PendingUpdateItems.CollectionChanged -= PendingUpdateItems_CollectionChanged;
-        ViewModel.PendingUpdateItems.CollectionChanged += PendingUpdateItems_CollectionChanged;
-    }
-
-    private void PendingUpdateItems_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-    {
-        // Items arrive after workflow result; re-measure after layout.
-        DispatcherQueue.TryEnqueue(() => UpdatePendingUpdatesScrollLayout());
     }
 
     /// <summary>
@@ -73,174 +43,35 @@ public sealed partial class WorkflowPage : Page
         {
             await ViewModel.InitializeAsync(e.Parameter);
         }
-
-        HookPendingUpdatesCollection();
-        UpdatePendingUpdatesScrollLayout();
     }
 
-    private void InputTextBox_KeyDown(object sender, KeyRoutedEventArgs e)
+    // Fires on Enter and on the in-box send (query) button alike.
+    private async void InputTextBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
     {
-        if (e.Key == VirtualKey.Enter && !string.IsNullOrWhiteSpace(InputTextBox.Text))
+        if (ViewModel == null)
         {
-            SendButton_Click(this, new RoutedEventArgs());
+            return;
+        }
+
+        // QueryText is the box's current text; push it in case the TwoWay binding hasn't yet.
+        ViewModel.InputText = args.QueryText;
+        await ViewModel.SendButtonClicked();
+    }
+
+    // Per-row accept/skip ticks (#129): row item comes from the button's DataContext.
+    private void AcceptItemButton_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as FrameworkElement)?.DataContext is StoryCADLib.Collaborator.Models.PendingUpdateItem item)
+        {
+            ViewModel?.AcceptItem(item.Key);
         }
     }
 
-    private async void SendButton_Click(object sender, RoutedEventArgs e)
+    private void SkipItemButton_Click(object sender, RoutedEventArgs e)
     {
-        if (ViewModel != null)
+        if ((sender as FrameworkElement)?.DataContext is StoryCADLib.Collaborator.Models.PendingUpdateItem item)
         {
-            await ViewModel.SendButtonClicked();
+            ViewModel?.SkipItem(item.Key);
         }
-    }
-
-    private void PendingUpdatesScrollHost_SizeChanged(object sender, SizeChangedEventArgs e)
-        => UpdatePendingUpdatesScrollLayout();
-
-    private void PendingUpdatesScroll_ViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
-        => UpdatePendingUpdatesThumb();
-
-    private void PendingUpdatesItems_SizeChanged(object sender, SizeChangedEventArgs e)
-        => UpdatePendingUpdatesScrollLayout();
-
-    private void PendingUpdatesTrackCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
-        => UpdatePendingUpdatesThumb();
-
-    /// <summary>
-    /// Give the ScrollViewer a real pixel height. Without this, measure is often infinite
-    /// and the content never scrolls (it is only clipped by a parent).
-    /// </summary>
-    private void UpdatePendingUpdatesScrollLayout()
-    {
-        if (PendingUpdatesScrollHost == null || PendingUpdatesScroll == null)
-            return;
-
-        var hostHeight = PendingUpdatesScrollHost.ActualHeight;
-        if (hostHeight > 1)
-        {
-            PendingUpdatesScroll.Height = hostHeight;
-        }
-
-        UpdatePendingUpdatesThumb();
-    }
-
-    /// <summary>
-    /// Position the permanent thumb from ScrollViewer offset / extent.
-    /// </summary>
-    private void UpdatePendingUpdatesThumb()
-    {
-        if (PendingUpdatesScroll == null || PendingUpdatesThumb == null || PendingUpdatesTrackCanvas == null)
-            return;
-
-        var trackHeight = PendingUpdatesTrackCanvas.ActualHeight;
-        if (trackHeight <= 1)
-            return;
-
-        var viewport = PendingUpdatesScroll.ViewportHeight;
-        var extent = PendingUpdatesScroll.ExtentHeight;
-        if (viewport <= 0)
-            viewport = PendingUpdatesScroll.ActualHeight;
-        if (extent <= 0)
-            extent = PendingUpdatesItems?.ActualHeight ?? 0;
-
-        var scrollable = Math.Max(0, extent - viewport);
-
-        // Thumb size proportional to visible fraction; minimum so it stays grabbable.
-        double thumbHeight;
-        if (extent <= 0 || scrollable <= 0.5)
-        {
-            thumbHeight = trackHeight;
-            Canvas.SetTop(PendingUpdatesThumb, 0);
-            PendingUpdatesThumb.Opacity = 0.35;
-            PendingUpdatesThumb.IsHitTestVisible = false;
-        }
-        else
-        {
-            thumbHeight = Math.Max(24, trackHeight * (viewport / extent));
-            thumbHeight = Math.Min(thumbHeight, trackHeight);
-            var maxTop = trackHeight - thumbHeight;
-            var top = maxTop * (PendingUpdatesScroll.VerticalOffset / scrollable);
-            Canvas.SetTop(PendingUpdatesThumb, top);
-            PendingUpdatesThumb.Opacity = 1.0;
-            PendingUpdatesThumb.IsHitTestVisible = true;
-        }
-
-        PendingUpdatesThumb.Height = thumbHeight;
-        PendingUpdatesThumb.Width = Math.Max(8, PendingUpdatesTrackCanvas.ActualWidth - 4);
-        Canvas.SetLeft(PendingUpdatesThumb, 2);
-    }
-
-    private void PendingUpdatesTrack_PointerPressed(object sender, PointerRoutedEventArgs e)
-    {
-        if (PendingUpdatesScroll == null || PendingUpdatesTrackCanvas == null)
-            return;
-
-        var pos = e.GetCurrentPoint(PendingUpdatesTrackCanvas).Position;
-        JumpScrollToTrackY(pos.Y);
-        e.Handled = true;
-    }
-
-    private void PendingUpdatesThumb_PointerPressed(object sender, PointerRoutedEventArgs e)
-    {
-        if (PendingUpdatesScroll == null || PendingUpdatesThumb == null)
-            return;
-
-        _thumbDragging = true;
-        _thumbDragStartY = e.GetCurrentPoint(PendingUpdatesTrackCanvas).Position.Y;
-        _thumbDragStartOffset = PendingUpdatesScroll.VerticalOffset;
-        PendingUpdatesThumb.CapturePointer(e.Pointer);
-        e.Handled = true;
-    }
-
-    private void PendingUpdatesThumb_PointerMoved(object sender, PointerRoutedEventArgs e)
-    {
-        if (!_thumbDragging || PendingUpdatesScroll == null || PendingUpdatesTrackCanvas == null)
-            return;
-
-        var y = e.GetCurrentPoint(PendingUpdatesTrackCanvas).Position.Y;
-        var delta = y - _thumbDragStartY;
-        var trackHeight = PendingUpdatesTrackCanvas.ActualHeight;
-        var thumbHeight = PendingUpdatesThumb.Height;
-        var maxTop = Math.Max(1, trackHeight - thumbHeight);
-        var scrollable = PendingUpdatesScroll.ScrollableHeight;
-        if (scrollable <= 0)
-            scrollable = Math.Max(0, PendingUpdatesScroll.ExtentHeight - PendingUpdatesScroll.ViewportHeight);
-
-        var newOffset = _thumbDragStartOffset + (delta / maxTop) * scrollable;
-        newOffset = Math.Max(0, Math.Min(scrollable, newOffset));
-        PendingUpdatesScroll.ChangeView(null, newOffset, null, true);
-        e.Handled = true;
-    }
-
-    private void PendingUpdatesThumb_PointerReleased(object sender, PointerRoutedEventArgs e)
-    {
-        if (!_thumbDragging)
-            return;
-
-        _thumbDragging = false;
-        PendingUpdatesThumb.ReleasePointerCapture(e.Pointer);
-        e.Handled = true;
-    }
-
-    private void PendingUpdatesThumb_PointerCaptureLost(object sender, PointerRoutedEventArgs e)
-    {
-        _thumbDragging = false;
-    }
-
-    private void JumpScrollToTrackY(double trackY)
-    {
-        if (PendingUpdatesScroll == null || PendingUpdatesTrackCanvas == null)
-            return;
-
-        var trackHeight = PendingUpdatesTrackCanvas.ActualHeight;
-        var thumbHeight = PendingUpdatesThumb?.Height ?? 24;
-        var maxTop = Math.Max(1, trackHeight - thumbHeight);
-        var scrollable = PendingUpdatesScroll.ScrollableHeight;
-        if (scrollable <= 0)
-            scrollable = Math.Max(0, PendingUpdatesScroll.ExtentHeight - PendingUpdatesScroll.ViewportHeight);
-
-        var top = Math.Max(0, Math.Min(maxTop, trackY - thumbHeight / 2));
-        var offset = (top / maxTop) * scrollable;
-        PendingUpdatesScroll.ChangeView(null, offset, null, true);
     }
 }

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml.cs
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml.cs
@@ -1,10 +1,10 @@
 using Windows.System;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using StoryCADLib.Collaborator.ViewModels;
+using Windows.Foundation;
 
 namespace StoryCADLib.Collaborator.Views;
 
@@ -15,13 +15,15 @@ namespace StoryCADLib.Collaborator.Views;
 /// - Public ViewModel property exposes DataContext as WorkflowViewModel
 /// - XAML uses {x:Bind ViewModel.Property, Mode=OneWay} for compile-time binding
 /// - DataContext is set by Uno Navigation automatically, or via OnNavigatedTo fallback
-/// 
+///
 /// NOTE: x:DataType at Page level is NOT supported on Skia/Desktop targets.
 /// Instead, expose a public ViewModel property and bind to ViewModel.Property.
 /// </summary>
 public sealed partial class WorkflowPage : Page
 {
-    private bool _syncingPendingScroll;
+    private bool _thumbDragging;
+    private double _thumbDragStartY;
+    private double _thumbDragStartOffset;
 
     public WorkflowPage()
     {
@@ -34,7 +36,7 @@ public sealed partial class WorkflowPage : Page
     private void OnPageLoaded(object sender, RoutedEventArgs e)
     {
         HookPendingUpdatesCollection();
-        SyncPendingUpdatesScrollBar();
+        UpdatePendingUpdatesScrollLayout();
     }
 
     private void HookPendingUpdatesCollection()
@@ -48,8 +50,8 @@ public sealed partial class WorkflowPage : Page
 
     private void PendingUpdateItems_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {
-        // Layout updates after items arrive (workflow result).
-        DispatcherQueue.TryEnqueue(() => SyncPendingUpdatesScrollBar());
+        // Items arrive after workflow result; re-measure after layout.
+        DispatcherQueue.TryEnqueue(() => UpdatePendingUpdatesScrollLayout());
     }
 
     /// <summary>
@@ -72,7 +74,8 @@ public sealed partial class WorkflowPage : Page
             await ViewModel.InitializeAsync(e.Parameter);
         }
 
-        SyncPendingUpdatesScrollBar();
+        HookPendingUpdatesCollection();
+        UpdatePendingUpdatesScrollLayout();
     }
 
     private void InputTextBox_KeyDown(object sender, KeyRoutedEventArgs e)
@@ -91,70 +94,153 @@ public sealed partial class WorkflowPage : Page
         }
     }
 
-    private void PendingUpdatesScroll_ViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
-        => SyncPendingUpdatesScrollBar();
+    private void PendingUpdatesScrollHost_SizeChanged(object sender, SizeChangedEventArgs e)
+        => UpdatePendingUpdatesScrollLayout();
 
-    private void PendingUpdatesScroll_SizeChanged(object sender, SizeChangedEventArgs e)
-        => SyncPendingUpdatesScrollBar();
+    private void PendingUpdatesScroll_ViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
+        => UpdatePendingUpdatesThumb();
 
     private void PendingUpdatesItems_SizeChanged(object sender, SizeChangedEventArgs e)
-        => SyncPendingUpdatesScrollBar();
+        => UpdatePendingUpdatesScrollLayout();
 
-    private void PendingUpdatesScrollBar_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
+    private void PendingUpdatesTrackCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
+        => UpdatePendingUpdatesThumb();
+
+    /// <summary>
+    /// Give the ScrollViewer a real pixel height. Without this, measure is often infinite
+    /// and the content never scrolls (it is only clipped by a parent).
+    /// </summary>
+    private void UpdatePendingUpdatesScrollLayout()
     {
-        if (_syncingPendingScroll || PendingUpdatesScroll == null)
+        if (PendingUpdatesScrollHost == null || PendingUpdatesScroll == null)
             return;
 
-        PendingUpdatesScroll.ChangeView(null, e.NewValue, null, true);
+        var hostHeight = PendingUpdatesScrollHost.ActualHeight;
+        if (hostHeight > 1)
+        {
+            PendingUpdatesScroll.Height = hostHeight;
+        }
+
+        UpdatePendingUpdatesThumb();
     }
 
     /// <summary>
-    /// Keep the explicit vertical ScrollBar in sync. Overlay scrollbars fade; this one does not.
+    /// Position the permanent thumb from ScrollViewer offset / extent.
     /// </summary>
-    private void SyncPendingUpdatesScrollBar()
+    private void UpdatePendingUpdatesThumb()
     {
-        if (PendingUpdatesScroll == null || PendingUpdatesScrollBar == null)
+        if (PendingUpdatesScroll == null || PendingUpdatesThumb == null || PendingUpdatesTrackCanvas == null)
             return;
 
-        _syncingPendingScroll = true;
-        try
-        {
-            var viewport = PendingUpdatesScroll.ViewportHeight;
-            var extent = PendingUpdatesScroll.ExtentHeight;
-            var scrollable = PendingUpdatesScroll.ScrollableHeight;
+        var trackHeight = PendingUpdatesTrackCanvas.ActualHeight;
+        if (trackHeight <= 1)
+            return;
 
-            if (viewport <= 0)
-            {
-                // Not laid out yet.
-                PendingUpdatesScrollBar.Minimum = 0;
-                PendingUpdatesScrollBar.Maximum = 1;
-                PendingUpdatesScrollBar.ViewportSize = 1;
-                PendingUpdatesScrollBar.Value = 0;
-                PendingUpdatesScrollBar.IsEnabled = false;
-                return;
-            }
+        var viewport = PendingUpdatesScroll.ViewportHeight;
+        var extent = PendingUpdatesScroll.ExtentHeight;
+        if (viewport <= 0)
+            viewport = PendingUpdatesScroll.ActualHeight;
+        if (extent <= 0)
+            extent = PendingUpdatesItems?.ActualHeight ?? 0;
 
-            if (scrollable <= 0.5)
-            {
-                // Content fits: still show a full track so the affordance is obvious.
-                PendingUpdatesScrollBar.Minimum = 0;
-                PendingUpdatesScrollBar.Maximum = 1;
-                PendingUpdatesScrollBar.ViewportSize = 1;
-                PendingUpdatesScrollBar.Value = 0;
-                PendingUpdatesScrollBar.IsEnabled = false;
-            }
-            else
-            {
-                PendingUpdatesScrollBar.Minimum = 0;
-                PendingUpdatesScrollBar.Maximum = scrollable;
-                PendingUpdatesScrollBar.ViewportSize = viewport;
-                PendingUpdatesScrollBar.Value = PendingUpdatesScroll.VerticalOffset;
-                PendingUpdatesScrollBar.IsEnabled = true;
-            }
-        }
-        finally
+        var scrollable = Math.Max(0, extent - viewport);
+
+        // Thumb size proportional to visible fraction; minimum so it stays grabbable.
+        double thumbHeight;
+        if (extent <= 0 || scrollable <= 0.5)
         {
-            _syncingPendingScroll = false;
+            thumbHeight = trackHeight;
+            Canvas.SetTop(PendingUpdatesThumb, 0);
+            PendingUpdatesThumb.Opacity = 0.35;
+            PendingUpdatesThumb.IsHitTestVisible = false;
         }
+        else
+        {
+            thumbHeight = Math.Max(24, trackHeight * (viewport / extent));
+            thumbHeight = Math.Min(thumbHeight, trackHeight);
+            var maxTop = trackHeight - thumbHeight;
+            var top = maxTop * (PendingUpdatesScroll.VerticalOffset / scrollable);
+            Canvas.SetTop(PendingUpdatesThumb, top);
+            PendingUpdatesThumb.Opacity = 1.0;
+            PendingUpdatesThumb.IsHitTestVisible = true;
+        }
+
+        PendingUpdatesThumb.Height = thumbHeight;
+        PendingUpdatesThumb.Width = Math.Max(8, PendingUpdatesTrackCanvas.ActualWidth - 4);
+        Canvas.SetLeft(PendingUpdatesThumb, 2);
+    }
+
+    private void PendingUpdatesTrack_PointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        if (PendingUpdatesScroll == null || PendingUpdatesTrackCanvas == null)
+            return;
+
+        var pos = e.GetCurrentPoint(PendingUpdatesTrackCanvas).Position;
+        JumpScrollToTrackY(pos.Y);
+        e.Handled = true;
+    }
+
+    private void PendingUpdatesThumb_PointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        if (PendingUpdatesScroll == null || PendingUpdatesThumb == null)
+            return;
+
+        _thumbDragging = true;
+        _thumbDragStartY = e.GetCurrentPoint(PendingUpdatesTrackCanvas).Position.Y;
+        _thumbDragStartOffset = PendingUpdatesScroll.VerticalOffset;
+        PendingUpdatesThumb.CapturePointer(e.Pointer);
+        e.Handled = true;
+    }
+
+    private void PendingUpdatesThumb_PointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_thumbDragging || PendingUpdatesScroll == null || PendingUpdatesTrackCanvas == null)
+            return;
+
+        var y = e.GetCurrentPoint(PendingUpdatesTrackCanvas).Position.Y;
+        var delta = y - _thumbDragStartY;
+        var trackHeight = PendingUpdatesTrackCanvas.ActualHeight;
+        var thumbHeight = PendingUpdatesThumb.Height;
+        var maxTop = Math.Max(1, trackHeight - thumbHeight);
+        var scrollable = PendingUpdatesScroll.ScrollableHeight;
+        if (scrollable <= 0)
+            scrollable = Math.Max(0, PendingUpdatesScroll.ExtentHeight - PendingUpdatesScroll.ViewportHeight);
+
+        var newOffset = _thumbDragStartOffset + (delta / maxTop) * scrollable;
+        newOffset = Math.Max(0, Math.Min(scrollable, newOffset));
+        PendingUpdatesScroll.ChangeView(null, newOffset, null, true);
+        e.Handled = true;
+    }
+
+    private void PendingUpdatesThumb_PointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_thumbDragging)
+            return;
+
+        _thumbDragging = false;
+        PendingUpdatesThumb.ReleasePointerCapture(e.Pointer);
+        e.Handled = true;
+    }
+
+    private void PendingUpdatesThumb_PointerCaptureLost(object sender, PointerRoutedEventArgs e)
+    {
+        _thumbDragging = false;
+    }
+
+    private void JumpScrollToTrackY(double trackY)
+    {
+        if (PendingUpdatesScroll == null || PendingUpdatesTrackCanvas == null)
+            return;
+
+        var trackHeight = PendingUpdatesTrackCanvas.ActualHeight;
+        var thumbHeight = PendingUpdatesThumb?.Height ?? 24;
+        var maxTop = Math.Max(1, trackHeight - thumbHeight);
+        var scrollable = PendingUpdatesScroll.ScrollableHeight;
+        if (scrollable <= 0)
+            scrollable = Math.Max(0, PendingUpdatesScroll.ExtentHeight - PendingUpdatesScroll.ViewportHeight);
+
+        var top = Math.Max(0, Math.Min(maxTop, trackY - thumbHeight / 2));
+        var offset = (top / maxTop) * scrollable;
+        PendingUpdatesScroll.ChangeView(null, offset, null, true);
     }
 }

--- a/StoryCADLib/Collaborator/Views/WorkflowShell.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowShell.xaml
@@ -16,42 +16,62 @@
     mc:Ignorable="d">
     <Grid>
         <Grid.RowDefinitions>
+            <!-- Top actions (StoryCAD-like): short workflow name + buttons -->
+            <RowDefinition Height="Auto" />
+            <!-- Nav + work + chat -->
             <RowDefinition Height="*" />
+            <!-- Bottom status only -->
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <!-- Main navigation view UI -->
-        <!-- Container id only; MenuItemsSource-bound, so there are no NavigationViewItem
-             elements in this XAML to annotate (Unit 6 NavigationView convention row). -->
-        <NavigationView x:Name="NavView"
-                        Grid.Row="0"
-                        IsBackButtonVisible="Collapsed"
-                        MenuItemsSource="{x:Bind ShellViewModel.MenuItems, Mode=OneWay}"
-                        SelectedItem="{x:Bind ShellViewModel.CurrentItem, Mode=TwoWay}"
-                        IsSettingsVisible="False"
-                        SelectionChanged="NavView_SelectionChanged"
-                        PaneDisplayMode="Left"
-                        AutomationProperties.AutomationId="WorkflowNav">
 
-            <Frame x:Name="StepFrame" Navigated="StepFrame_OnNavigated" Margin="5,0,5,5" />
-        </NavigationView>
+        <!-- Top bar: everything left-aligned (CommandBar PrimaryCommands are right by default). -->
+        <Border Grid.Row="0"
+                Background="{ThemeResource CommandBarBackground}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="0,0,0,1"
+                Padding="4,2">
+            <StackPanel Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
+                <!-- Short workflow name -->
+                <TextBlock Text="{x:Bind ShellViewModel.ActiveWorkflowName, Mode=OneWay}"
+                           VerticalAlignment="Center"
+                           Margin="8,0,12,0"
+                           FontWeight="SemiBold"
+                           FontSize="14"
+                           TextTrimming="CharacterEllipsis"
+                           MaxWidth="200"
+                           AutomationProperties.Name="Current workflow" />
 
-        <!-- Shell actions + status (status survives empty content frame / gather cancel) -->
-        <CommandBar Grid.Row="1" HorizontalAlignment="Stretch" OverflowButtonVisibility="Collapsed">
-            <CommandBar.Content>
-                <!-- InfoBar: approved #1420 suffix (Unit 7). Content TextBlocks must not carry AutomationId. -->
-                <InfoBar IsOpen="{x:Bind ShellViewModel.HasStatus, Mode=OneWay}"
-                         Severity="Warning"
-                         IsClosable="False"
-                         Message="{x:Bind ShellViewModel.StatusText, Mode=OneWay}"
-                         MaxWidth="480"
-                         Margin="8,0,8,0"
-                         VerticalAlignment="Center"
-                         AutomationProperties.AutomationId="WorkflowShellStatusInfoBar" />
-            </CommandBar.Content>
-            <CommandBar.PrimaryCommands>
-                <!-- Prefixed: Shell.xaml already claims HelpButton. Label present: name announces
-                     natively, id only (convention Name/LabeledBy rule). -->
-                <AppBarButton Label="Help" ToolTipService.ToolTip="Help" Margin="5"
+                <!-- Workflow result actions (enabled when pending updates exist) -->
+                <AppBarButton Label="Accept All"
+                              ToolTipService.ToolTip="Apply free property updates"
+                              Command="{x:Bind ShellViewModel.AcceptAllCommand, Mode=OneWay}"
+                              IsEnabled="{x:Bind ShellViewModel.HasPendingUpdates, Mode=OneWay}"
+                              AutomationProperties.AutomationId="WorkflowAcceptAllButton">
+                    <AppBarButton.Icon>
+                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE73E;" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarButton Label="Review Each"
+                              ToolTipService.ToolTip="Review each property update"
+                              Command="{x:Bind ShellViewModel.ReviewEachCommand, Mode=OneWay}"
+                              IsEnabled="{x:Bind ShellViewModel.HasPendingUpdates, Mode=OneWay}"
+                              AutomationProperties.AutomationId="WorkflowReviewEachButton">
+                    <AppBarButton.Icon>
+                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8FD;" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarButton Label="Try Again"
+                              ToolTipService.ToolTip="Run the workflow again"
+                              Command="{x:Bind ShellViewModel.TryAgainCommand, Mode=OneWay}"
+                              IsEnabled="{x:Bind ShellViewModel.HasPendingUpdates, Mode=OneWay}"
+                              AutomationProperties.AutomationId="WorkflowTryAgainButton">
+                    <AppBarButton.Icon>
+                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE72C;" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+
+                <!-- Prefixed: Shell.xaml already claims HelpButton. -->
+                <AppBarButton Label="Help" ToolTipService.ToolTip="Help" Margin="8,0,0,0"
                               AutomationProperties.AutomationId="WorkflowHelpButton">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE897;" />
@@ -78,31 +98,65 @@
                         </Flyout>
                     </AppBarButton.Flyout>
                 </AppBarButton>
-                <!-- Prefixed: "Settings" is a common function name across dialogs, prefix to avoid collision. -->
-                <AppBarButton Label="Settings" ToolTipService.ToolTip="Collaborator Settings" Margin="5"
+                <AppBarButton Label="Settings" ToolTipService.ToolTip="Collaborator Settings"
                               Click="SettingsButton_Click"
                               AutomationProperties.AutomationId="WorkflowSettingsButton">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE713;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-                <!-- Prefixed: Shell.xaml already claims SaveStatusButton/SaveStoryMenuItem for "Save". -->
-                <AppBarButton Label="Save" ToolTipService.ToolTip="Save outline changes" Margin="5"
+                <AppBarButton Label="Save" ToolTipService.ToolTip="Save outline changes"
                               Command="{x:Bind ShellViewModel.SaveCommand, Mode=OneWay}"
                               AutomationProperties.AutomationId="WorkflowSaveButton">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE74E;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-                <!-- Prefixed: Shell.xaml already claims ExitMenuItem for "Exit". -->
-                <AppBarButton Label="Exit" ToolTipService.ToolTip="Exit Collaborator" Margin="5"
+                <AppBarButton Label="Exit" ToolTipService.ToolTip="Exit Collaborator"
                               Command="{x:Bind ShellViewModel.ExitCommand, Mode=OneWay}"
                               AutomationProperties.AutomationId="WorkflowExitButton">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8BB;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-            </CommandBar.PrimaryCommands>
-        </CommandBar>
+            </StackPanel>
+        </Border>
+
+        <!-- Main navigation view UI -->
+        <!-- Container id only; MenuItemsSource-bound, so there are no NavigationViewItem
+             elements in this XAML to annotate (Unit 6 NavigationView convention row). -->
+        <NavigationView x:Name="NavView"
+                        Grid.Row="1"
+                        IsBackButtonVisible="Collapsed"
+                        MenuItemsSource="{x:Bind ShellViewModel.MenuItems, Mode=OneWay}"
+                        SelectedItem="{x:Bind ShellViewModel.CurrentItem, Mode=TwoWay}"
+                        IsSettingsVisible="False"
+                        SelectionChanged="NavView_SelectionChanged"
+                        PaneDisplayMode="Left"
+                        AutomationProperties.AutomationId="WorkflowNav">
+
+            <Frame x:Name="StepFrame"
+                   Navigated="StepFrame_OnNavigated"
+                   Margin="5,0,5,5"
+                   VerticalAlignment="Stretch"
+                   HorizontalAlignment="Stretch" />
+        </NavigationView>
+
+        <!-- Bottom status (survives empty content frame / gather cancel). Not a second title. -->
+        <Border Grid.Row="2"
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="0,1,0,0"
+                MinHeight="36"
+                Padding="8,4">
+            <!-- InfoBar: approved #1420 suffix (Unit 7). Content TextBlocks must not carry AutomationId. -->
+            <InfoBar IsOpen="{x:Bind ShellViewModel.HasStatus, Mode=OneWay}"
+                     Severity="Warning"
+                     IsClosable="False"
+                     Message="{x:Bind ShellViewModel.StatusText, Mode=OneWay}"
+                     HorizontalAlignment="Stretch"
+                     VerticalAlignment="Center"
+                     AutomationProperties.AutomationId="WorkflowShellStatusInfoBar" />
+        </Border>
     </Grid>
 </Page>

--- a/StoryCADLib/Collaborator/Views/WorkflowShell.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowShell.xaml
@@ -31,10 +31,20 @@
                 BorderThickness="0,0,0,1"
                 Padding="4,2">
             <StackPanel Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
+                <!-- Pane toggle (replaces NavigationView hamburger) -->
+                <AppBarButton Label="Workflows"
+                              ToolTipService.ToolTip="Show or hide the workflow list"
+                              Command="{x:Bind ShellViewModel.TogglePaneCommand, Mode=OneWay}"
+                              AutomationProperties.AutomationId="WorkflowPaneToggleButton">
+                    <AppBarButton.Icon>
+                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE700;" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+
                 <!-- Short workflow name -->
                 <TextBlock Text="{x:Bind ShellViewModel.ActiveWorkflowName, Mode=OneWay}"
                            VerticalAlignment="Center"
-                           Margin="8,0,12,0"
+                           Margin="4,0,12,0"
                            FontWeight="SemiBold"
                            FontSize="14"
                            TextTrimming="CharacterEllipsis"
@@ -128,6 +138,8 @@
         <NavigationView x:Name="NavView"
                         Grid.Row="1"
                         IsBackButtonVisible="Collapsed"
+                        IsPaneToggleButtonVisible="False"
+                        IsPaneOpen="{x:Bind ShellViewModel.IsPaneOpen, Mode=TwoWay}"
                         MenuItemsSource="{x:Bind ShellViewModel.MenuItems, Mode=OneWay}"
                         SelectedItem="{x:Bind ShellViewModel.CurrentItem, Mode=TwoWay}"
                         IsSettingsVisible="False"

--- a/StoryCADLib/Collaborator/Views/WorkflowShell.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowShell.xaml
@@ -30,18 +30,17 @@
                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                 BorderThickness="0,0,0,1"
                 Padding="4,2">
-            <StackPanel Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
-                <!-- Pane toggle (replaces NavigationView hamburger) -->
-                <AppBarButton Label="Workflows"
-                              ToolTipService.ToolTip="Show or hide the workflow list"
+            <!-- Icons only; name on hover (ToolTip). Labels wasted horizontal space. -->
+            <StackPanel Orientation="Horizontal" Spacing="0" VerticalAlignment="Center">
+                <AppBarButton ToolTipService.ToolTip="Workflows"
                               Command="{x:Bind ShellViewModel.TogglePaneCommand, Mode=OneWay}"
-                              AutomationProperties.AutomationId="WorkflowPaneToggleButton">
+                              AutomationProperties.AutomationId="WorkflowPaneToggleButton"
+                              AutomationProperties.Name="Workflows">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE700;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
 
-                <!-- Short workflow name -->
                 <TextBlock Text="{x:Bind ShellViewModel.ActiveWorkflowName, Mode=OneWay}"
                            VerticalAlignment="Center"
                            Margin="4,0,12,0"
@@ -51,38 +50,37 @@
                            MaxWidth="200"
                            AutomationProperties.Name="Current workflow" />
 
-                <!-- Workflow result actions (enabled when pending updates exist) -->
-                <AppBarButton Label="Accept All"
-                              ToolTipService.ToolTip="Apply free property updates"
+                <AppBarButton ToolTipService.ToolTip="Accept All"
                               Command="{x:Bind ShellViewModel.AcceptAllCommand, Mode=OneWay}"
                               IsEnabled="{x:Bind ShellViewModel.HasPendingUpdates, Mode=OneWay}"
-                              AutomationProperties.AutomationId="WorkflowAcceptAllButton">
+                              AutomationProperties.AutomationId="WorkflowAcceptAllButton"
+                              AutomationProperties.Name="Accept All">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE73E;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-                <AppBarButton Label="Review Each"
-                              ToolTipService.ToolTip="Review each property update"
+                <AppBarButton ToolTipService.ToolTip="Review Each"
                               Command="{x:Bind ShellViewModel.ReviewEachCommand, Mode=OneWay}"
                               IsEnabled="{x:Bind ShellViewModel.HasPendingUpdates, Mode=OneWay}"
-                              AutomationProperties.AutomationId="WorkflowReviewEachButton">
+                              AutomationProperties.AutomationId="WorkflowReviewEachButton"
+                              AutomationProperties.Name="Review Each">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8FD;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-                <AppBarButton Label="Try Again"
-                              ToolTipService.ToolTip="Run the workflow again"
+                <AppBarButton ToolTipService.ToolTip="Try Again"
                               Command="{x:Bind ShellViewModel.TryAgainCommand, Mode=OneWay}"
                               IsEnabled="{x:Bind ShellViewModel.HasPendingUpdates, Mode=OneWay}"
-                              AutomationProperties.AutomationId="WorkflowTryAgainButton">
+                              AutomationProperties.AutomationId="WorkflowTryAgainButton"
+                              AutomationProperties.Name="Try Again">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE72C;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
 
-                <!-- Prefixed: Shell.xaml already claims HelpButton. -->
-                <AppBarButton Label="Help" ToolTipService.ToolTip="Help" Margin="8,0,0,0"
-                              AutomationProperties.AutomationId="WorkflowHelpButton">
+                <AppBarButton ToolTipService.ToolTip="Help" Margin="8,0,0,0"
+                              AutomationProperties.AutomationId="WorkflowHelpButton"
+                              AutomationProperties.Name="Help">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE897;" />
                     </AppBarButton.Icon>
@@ -108,23 +106,26 @@
                         </Flyout>
                     </AppBarButton.Flyout>
                 </AppBarButton>
-                <AppBarButton Label="Settings" ToolTipService.ToolTip="Collaborator Settings"
+                <AppBarButton ToolTipService.ToolTip="Settings"
                               Click="SettingsButton_Click"
-                              AutomationProperties.AutomationId="WorkflowSettingsButton">
+                              AutomationProperties.AutomationId="WorkflowSettingsButton"
+                              AutomationProperties.Name="Settings">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE713;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-                <AppBarButton Label="Save" ToolTipService.ToolTip="Save outline changes"
+                <AppBarButton ToolTipService.ToolTip="Save"
                               Command="{x:Bind ShellViewModel.SaveCommand, Mode=OneWay}"
-                              AutomationProperties.AutomationId="WorkflowSaveButton">
+                              AutomationProperties.AutomationId="WorkflowSaveButton"
+                              AutomationProperties.Name="Save">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE74E;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-                <AppBarButton Label="Exit" ToolTipService.ToolTip="Exit Collaborator"
+                <AppBarButton ToolTipService.ToolTip="Exit"
                               Command="{x:Bind ShellViewModel.ExitCommand, Mode=OneWay}"
-                              AutomationProperties.AutomationId="WorkflowExitButton">
+                              AutomationProperties.AutomationId="WorkflowExitButton"
+                              AutomationProperties.Name="Exit">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8BB;" />
                     </AppBarButton.Icon>

--- a/StoryCADLib/Collaborator/Views/WorkflowShell.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowShell.xaml
@@ -150,7 +150,7 @@
 
             <Frame x:Name="StepFrame"
                    Navigated="StepFrame_OnNavigated"
-                   Margin="5,0,5,5"
+                   Margin="12,8,12,10"
                    VerticalAlignment="Stretch"
                    HorizontalAlignment="Stretch" />
         </NavigationView>

--- a/StoryCADLib/Collaborator/Views/WorkflowShell.xaml.cs
+++ b/StoryCADLib/Collaborator/Views/WorkflowShell.xaml.cs
@@ -31,6 +31,8 @@ public sealed partial class WorkflowShell : Page
         {
             shellVm.ContentFrame = StepFrame;
             shellVm.NavView = NavView;
+            // Keep VM pane flag in sync with control default after load.
+            shellVm.IsPaneOpen = NavView.IsPaneOpen;
             // Menu population is handled by Collaborator after navigation
         }
     }

--- a/StoryCADLib/Services/API/StoryCADAPI.cs
+++ b/StoryCADLib/Services/API/StoryCADAPI.cs
@@ -3,10 +3,13 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using StoryCADLib.Models.Tools;
 using StoryCADLib.Services.Collaborator.Contracts;
 using StoryCADLib.Services.Outline;
+using StoryCADLib.ViewModels;
 using StoryCADLib.ViewModels.Tools;
 
 namespace StoryCADLib.Services.API;
@@ -2008,6 +2011,41 @@ public class StoryCADApi(OutlineService outlineService, ListData listData, Contr
         }
 
         return null;
+    }
+
+    /// <inheritdoc />
+    public OperationResult<bool> SelectStoryElement(Guid elementGuid)
+    {
+        try
+        {
+            if (CurrentModel == null)
+                return OperationResult<bool>.Failure("No current model");
+
+            if (CurrentModel.ExplorerView == null || CurrentModel.ExplorerView.Count == 0)
+                return OperationResult<bool>.Failure("Explorer view is empty");
+
+            StoryNodeItem node = null;
+            foreach (var root in CurrentModel.ExplorerView)
+            {
+                node = FindNodeInTree(root, elementGuid);
+                if (node != null)
+                    break;
+            }
+
+            if (node == null)
+                return OperationResult<bool>.Failure($"No tree node for element {elementGuid}");
+
+            var shell = Ioc.Default.GetService<ShellViewModel>();
+            if (shell == null)
+                return OperationResult<bool>.Failure("ShellViewModel not available");
+
+            shell.TreeViewNodeClicked(node);
+            return OperationResult<bool>.Success(true);
+        }
+        catch (Exception ex)
+        {
+            return OperationResult<bool>.Failure(ex.Message);
+        }
     }
 
     /// <summary>

--- a/StoryCADLib/Services/Collaborator/Contracts/IStoryCADAPI.cs
+++ b/StoryCADLib/Services/Collaborator/Contracts/IStoryCADAPI.cs
@@ -74,6 +74,12 @@ public interface IStoryCADAPI
     /// <returns>OperationResult containing the story element if found, or error message if not</returns>
     OperationResult<StoryElement> GetStoryElement(Guid guid);
 
+    /// <summary>
+    ///     Selects a story element in the host StoryCAD tree and opens its page
+    ///     (Collaborator gap workflow, issue #107 phase 6).
+    /// </summary>
+    OperationResult<bool> SelectStoryElement(Guid elementGuid);
+
     OperationResult<Guid> AddElement(StoryItemType typeToAdd, string parentGUID, string name, string GUIDOverride = "");
 
     OperationResult<Guid> AddElement(StoryItemType typeToAdd, string parentGUID, string name, Dictionary<string, object> properties, string GUIDOverride = "");

--- a/StoryCADLib/Services/Store/StoreKitInterop.cs
+++ b/StoryCADLib/Services/Store/StoreKitInterop.cs
@@ -184,8 +184,12 @@ internal static partial class StoreKitInterop
         }
     }
 
-    // Prefer the signed copy in Contents/Frameworks; fall back to beside the executable for local
-    // dev runs; last resort let the OS search (rpath/DYLD).
+    // Beside the executable, which covers both shapes the build produces: Contents/MacOS/ in a
+    // published bundle (StoryCAD.csproj's _BuildAndCopyStoreKitShim, placed there so the packaging
+    // pipeline's `find Contents/MacOS -name *.dylib` codesign step signs it) and $(OutDir) in a
+    // plain dev build (_BuildAndCopyStoreKitShimToOutput). Last resort, let the OS search
+    // (rpath/DYLD). There was a Contents/Frameworks probe ahead of these; nothing in the build ever
+    // wrote there, so it only cost a stat on every resolve.
     private static IntPtr Resolve(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {
         if (libraryName != Library)
@@ -193,20 +197,13 @@ internal static partial class StoreKitInterop
             return IntPtr.Zero;
         }
 
-        var baseDir = AppContext.BaseDirectory;
-        var frameworks = Path.Combine(baseDir, "..", "Frameworks", DylibFile);
-        if (File.Exists(frameworks) && NativeLibrary.TryLoad(frameworks, out var h1))
+        var beside = Path.Combine(AppContext.BaseDirectory, DylibFile);
+        if (File.Exists(beside) && NativeLibrary.TryLoad(beside, out var handle))
         {
-            return h1;
+            return handle;
         }
 
-        var beside = Path.Combine(baseDir, DylibFile);
-        if (File.Exists(beside) && NativeLibrary.TryLoad(beside, out var h2))
-        {
-            return h2;
-        }
-
-        return NativeLibrary.TryLoad(DylibFile, out var h3) ? h3 : IntPtr.Zero;
+        return NativeLibrary.TryLoad(DylibFile, out var fallback) ? fallback : IntPtr.Zero;
     }
 }
 #endif

--- a/StoryCADTests/Collaborator/StoryProblemRegistryTests.cs
+++ b/StoryCADTests/Collaborator/StoryProblemRegistryTests.cs
@@ -10,6 +10,17 @@ namespace StoryCADTests.Collaborator;
 public class StoryProblemRegistryTests
 {
     [TestMethod]
+    public void AllWorkflows_HavePrimaryElementType_ForNavGrouping()
+    {
+        // #129: nav menu groups by PrimaryElementType; Unknown would orphan a workflow.
+        foreach (var workflow in WorkflowRegistry.All)
+        {
+            Assert.AreNotEqual(StoryCADLib.Models.StoryItemType.Unknown, workflow.PrimaryElementType,
+                $"Workflow '{workflow.Label}' has no PrimaryElementType.");
+        }
+    }
+
+    [TestMethod]
     public void StoryProblem_OptionalInputs_WriteStructuralLinksOnGather()
     {
         var workflow = WorkflowRegistry.Get("StoryProblem");

--- a/StoryCADTests/Collaborator/ValueDisplayTests.cs
+++ b/StoryCADTests/Collaborator/ValueDisplayTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using StoryCollaborator.Models;
+
+#nullable disable
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>
+/// Unit tests for ValueDisplay (#129 display formatting).
+/// </summary>
+[TestClass]
+public class ValueDisplayTests
+{
+    #region SplitPascalCase Tests
+
+    [TestMethod]
+    public void SplitPascalCase_WithPascalCase_InsertsSpaces()
+    {
+        Assert.AreEqual("Structure Title", ValueDisplay.SplitPascalCase("StructureTitle"));
+    }
+
+    [TestMethod]
+    public void SplitPascalCase_WithAcronym_KeepsAcronymTogether()
+    {
+        Assert.AreEqual("GMC Notes", ValueDisplay.SplitPascalCase("GMCNotes"));
+    }
+
+    [TestMethod]
+    public void SplitPascalCase_WithSingleWord_ReturnsUnchanged()
+    {
+        Assert.AreEqual("Premise", ValueDisplay.SplitPascalCase("Premise"));
+    }
+
+    [TestMethod]
+    public void SplitPascalCase_WithNullOrEmpty_ReturnsEmpty()
+    {
+        Assert.AreEqual(string.Empty, ValueDisplay.SplitPascalCase(null));
+        Assert.AreEqual(string.Empty, ValueDisplay.SplitPascalCase("  "));
+    }
+
+    #endregion
+
+    #region Format Tests
+
+    [TestMethod]
+    public void Format_WithNull_ReturnsEmpty()
+    {
+        Assert.AreEqual(string.Empty, ValueDisplay.Format(null));
+    }
+
+    [TestMethod]
+    public void Format_WithString_ReturnsSameString()
+    {
+        Assert.AreEqual("hello", ValueDisplay.Format("hello"));
+    }
+
+    [TestMethod]
+    public void Format_WithStringList_ReturnsBulletedLines()
+    {
+        var result = ValueDisplay.Format(new List<string> { "one", "two" });
+
+        Assert.AreEqual("• one\n• two", result);
+    }
+
+    [TestMethod]
+    public void Format_WithBeatList_ReturnsNumberedTitlesAndDescriptions()
+    {
+        var beats = new List<BeatInfo>
+        {
+            new("Act I", "Setup"),
+            new("Act II", "")
+        };
+
+        var result = ValueDisplay.Format(beats);
+
+        Assert.AreEqual("1. Act I — Setup\n2. Act II", result);
+    }
+
+    [TestMethod]
+    public void Format_WithGuidList_ResolvesElementNames()
+    {
+        var guid = Guid.NewGuid();
+
+        var result = ValueDisplay.Format(new List<Guid> { guid }, g => g == guid ? "Greta" : null);
+
+        Assert.AreEqual("• Greta", result);
+    }
+
+    [TestMethod]
+    public void Format_WithUnresolvedGuid_FallsBackToGuidString()
+    {
+        var guid = Guid.NewGuid();
+
+        var result = ValueDisplay.Format(new List<Guid> { guid });
+
+        Assert.AreEqual($"• {guid:D}", result);
+    }
+
+    [TestMethod]
+    public void Format_WithRelationshipList_ResolvesNameAndDescription()
+    {
+        var guid = Guid.NewGuid();
+        var relationships = new List<RelationshipInfo> { new(guid, "rival") };
+
+        var result = ValueDisplay.Format(relationships, _ => "Herold");
+
+        Assert.AreEqual("• Herold — rival", result);
+    }
+
+    [TestMethod]
+    public void Format_WithJsonElementList_ReturnsReadablePairs()
+    {
+        using var doc = JsonDocument.Parse("""{"TraitName":"Brave","TraitNotes":"Under fire"}""");
+        var entries = new List<JsonElement> { doc.RootElement.Clone() };
+
+        var result = ValueDisplay.Format(entries);
+
+        Assert.AreEqual("• Trait Name: Brave; Trait Notes: Under fire", result);
+    }
+
+    [TestMethod]
+    public void Format_WithList_NeverReturnsClrTypeName()
+    {
+        var result = ValueDisplay.Format(new List<string> { "x" });
+
+        Assert.IsFalse(result.Contains("System.Collections"));
+    }
+
+    #endregion
+}

--- a/StoryCADTests/Collaborator/ViewModels/WorkflowShellViewModelTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/WorkflowShellViewModelTests.cs
@@ -83,6 +83,19 @@ public class WorkflowShellViewModelTests
     }
 
     [TestMethod]
+    public void ActiveWorkflowName_Initially_IsEmpty()
+    {
+        Assert.AreEqual(string.Empty, _viewModel.ActiveWorkflowName);
+    }
+
+    [TestMethod]
+    public void ActiveWorkflowName_WhenSet_ReturnsNewValue()
+    {
+        _viewModel.ActiveWorkflowName = "Premise";
+        Assert.AreEqual("Premise", _viewModel.ActiveWorkflowName);
+    }
+
+    [TestMethod]
     public void StatusText_Initially_IsEmpty()
     {
         Assert.AreEqual(string.Empty, _viewModel.StatusText);

--- a/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
@@ -449,6 +449,22 @@ public class WorkflowViewModelTests
     }
 
     [TestMethod]
+    public void RefreshTopicalExplanation_IncludesSelectedAndPendingCounts()
+    {
+        _viewModel.SelectedElementsSummary = "Overview: Test Story";
+        _viewModel.SetPendingUpdates(new List<PendingUpdateItem>
+        {
+            Item("A", isProtected: false),
+            Item("B", isProtected: true)
+        });
+
+        StringAssert.Contains(_viewModel.Explanation, "Selected: Overview: Test Story");
+        StringAssert.Contains(_viewModel.Explanation, "2 property update(s)");
+        StringAssert.Contains(_viewModel.Explanation, "1 free");
+        StringAssert.Contains(_viewModel.Explanation, "1 need review");
+    }
+
+    [TestMethod]
     public void ReviewEach_AcceptCurrent_DoesNotSkipMiddleProperty()
     {
         // Arrange — three updates (Ideation: Description, Concept, Premise)

--- a/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
@@ -433,6 +433,22 @@ public class WorkflowViewModelTests
     }
 
     [TestMethod]
+    public void PendingUpdatesHeader_ReflectsFreeAndProtectedCounts()
+    {
+        _viewModel.SetPendingUpdates(new List<PendingUpdateItem>
+        {
+            Item("A", isProtected: false),
+            Item("B", isProtected: true),
+            Item("C", isProtected: true)
+        });
+
+        Assert.AreEqual("Property Updates (3: 1 free, 2 need review)", _viewModel.PendingUpdatesHeader);
+
+        _viewModel.ClearPendingUpdates();
+        Assert.AreEqual("Property Updates", _viewModel.PendingUpdatesHeader);
+    }
+
+    [TestMethod]
     public void ReviewEach_AcceptCurrent_DoesNotSkipMiddleProperty()
     {
         // Arrange — three updates (Ideation: Description, Concept, Premise)

--- a/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
@@ -545,6 +545,140 @@ public class WorkflowViewModelTests
         Assert.AreEqual(0, store.Count);
     }
 
+    [TestMethod]
+    public void CurrentReviewDisplayName_WithDisplayFields_FormatsFriendlyName()
+    {
+        var item = Item("Problem.StructureTitle", "v");
+        item.ElementName = "Problem";
+        item.PropertyDisplayName = "Structure Title";
+        _viewModel.SetPendingUpdates(new List<PendingUpdateItem> { item });
+        _viewModel.ReviewEachCommand.Execute(null);
+
+        Assert.AreEqual("Structure Title (Problem)", _viewModel.CurrentReviewDisplayName);
+        Assert.AreEqual("Problem.StructureTitle", _viewModel.CurrentReviewKey);
+    }
+
+    [TestMethod]
+    public void CurrentReviewDisplayName_WithoutDisplayFields_FallsBackToKey()
+    {
+        _viewModel.SetPendingUpdates(new List<PendingUpdateItem> { Item("Problem.StructureTitle", "v") });
+        _viewModel.ReviewEachCommand.Execute(null);
+
+        Assert.AreEqual("Problem.StructureTitle", _viewModel.CurrentReviewDisplayName);
+    }
+
+    [TestMethod]
+    public void AcceptItem_WithPendingUpdate_InvokesCallbackAndRemovesRow()
+    {
+        var store = new List<PendingUpdateItem> { Item("Overview.Premise", "v"), Item("Overview.Concept", "v") };
+        _viewModel.SetPendingUpdates(store);
+        WireRemoveOnAcceptOrSkip(store);
+
+        _viewModel.AcceptItem("Overview.Concept");
+
+        Assert.AreEqual(1, store.Count);
+        Assert.AreEqual("Overview.Premise", store[0].Key);
+        Assert.AreEqual(1, _viewModel.PendingUpdateItems.Count);
+    }
+
+    [TestMethod]
+    public void SkipItem_DuringReviewMode_ClampsIndexAndExitsWhenEmpty()
+    {
+        var store = new List<PendingUpdateItem> { Item("A", "1"), Item("B", "2") };
+        _viewModel.SetPendingUpdates(store);
+        WireRemoveOnAcceptOrSkip(store);
+        _viewModel.ReviewEachCommand.Execute(null);
+
+        _viewModel.SkipItem("B");
+        Assert.IsTrue(_viewModel.IsInReviewMode);
+        Assert.AreEqual("A", _viewModel.CurrentReviewKey);
+
+        _viewModel.SkipItem("A");
+        Assert.IsFalse(_viewModel.IsInReviewMode, "Review mode must end when inline ticks empty the list.");
+    }
+
+    [TestMethod]
+    public void AcceptItem_WithNoPendingUpdates_DoesNotInvokeCallback()
+    {
+        var invoked = false;
+        _viewModel.OnAcceptProperty = _ => invoked = true;
+
+        _viewModel.AcceptItem("Overview.Premise");
+
+        Assert.IsFalse(invoked);
+    }
+
+    [TestMethod]
+    public void AddStatusMessage_ConsecutiveLines_RollUpIntoOneGroup()
+    {
+        _viewModel.AddStatusMessage("Starting workflow: Problem Structure");
+        _viewModel.AddStatusMessage("Built request body from 1 elements");
+        _viewModel.AddStatusMessage("Received AI response");
+
+        Assert.AreEqual(1, _viewModel.ConversationList.Count);
+        var group = _viewModel.ConversationList[0];
+        Assert.IsTrue(group.IsStatusGroup);
+        Assert.AreEqual(3, group.Steps.Count);
+        StringAssert.Contains(group.StatusHeader, "3 steps");
+        StringAssert.Contains(group.StatusHeader, "Received AI response");
+    }
+
+    [TestMethod]
+    public void AddStatusMessage_AfterBubble_StartsNewGroup()
+    {
+        _viewModel.AddStatusMessage("Running Problem Structure...");
+        _viewModel.ConversationList.Add(ChatMessage.FromCollaborator("Here's my explanation."));
+        _viewModel.AddStatusMessage("Applied Problem.StructureTitle");
+
+        Assert.AreEqual(3, _viewModel.ConversationList.Count);
+        Assert.IsTrue(_viewModel.ConversationList[0].IsStatusGroup);
+        Assert.IsFalse(_viewModel.ConversationList[1].IsStatusGroup);
+        Assert.IsTrue(_viewModel.ConversationList[2].IsStatusGroup);
+    }
+
+    [TestMethod]
+    public void AddStatusMessage_StripsDashHeaders()
+    {
+        _viewModel.AddStatusMessage("--- Gathering input elements ---");
+
+        Assert.AreEqual("Gathering input elements", _viewModel.ConversationList[0].Steps[0]);
+    }
+
+    [TestMethod]
+    public void ConversationList_SenderLabel_ShownOncePerRun()
+    {
+        _viewModel.ConversationList.Add(ChatMessage.FromCollaborator("first"));
+        _viewModel.ConversationList.Add(ChatMessage.FromCollaborator("second"));
+        _viewModel.ConversationList.Add(ChatMessage.FromUser("mine"));
+        _viewModel.ConversationList.Add(ChatMessage.FromCollaborator("reply"));
+
+        Assert.IsTrue(_viewModel.ConversationList[0].ShowSender);
+        Assert.IsFalse(_viewModel.ConversationList[1].ShowSender, "Second Collaborator bubble in a run repeats no label.");
+        Assert.IsTrue(_viewModel.ConversationList[2].ShowSender);
+        Assert.IsTrue(_viewModel.ConversationList[3].ShowSender);
+    }
+
+    [TestMethod]
+    public void ConversationList_StatusGroup_NeverShowsSender()
+    {
+        _viewModel.AddStatusMessage("Running...");
+
+        Assert.IsFalse(_viewModel.ConversationList[0].ShowSender);
+    }
+
+    [TestMethod]
+    public void PendingUpdateItem_DisplayName_FallsBackToKey()
+    {
+        var bare = Item("Overview.Premise", "v");
+        Assert.AreEqual("Overview.Premise", bare.DisplayName);
+        Assert.AreEqual(bare.SummaryLine, bare.ElementAndKind);
+
+        bare.ElementName = "Overview";
+        bare.PropertyDisplayName = "Premise";
+        Assert.AreEqual("Premise", bare.DisplayName);
+        Assert.AreEqual("Overview · New", bare.ElementAndKind);
+    }
+
     #endregion
 
     #region ObservableRecipient Tests


### PR DESCRIPTION
## Summary
- Fixes Property Updates scrollbar (#129)
- Updates workflow changes UI; adjustable chat bubbles
- Adds Outline gaps navigate-only workflow (issue **#107 phase 6**): conditional nav entry, gap page, field→workflow links

## Issues
- **#129** — Property Updates layout / scroll
- **#107** — partial only (phase 6 UI). **Do not close #107** on merge; readiness profile and product pass remain open.

## Notes
- Outline gaps is navigate-only (no Accept All on that page).
- Accept wipe / stale Overview after Collaborator exit is a separate host bug; not fixed here.