### PR TITLE
fix(#1500): only Story Problem syncs Premise to Overview

### DIFF
--- a/StoryCADLib/ViewModels/ProblemViewModel.cs
+++ b/StoryCADLib/ViewModels/ProblemViewModel.cs
@@ -94,10 +94,8 @@ public class ProblemViewModel : ObservableRecipient, INavigable, ISaveable, IRel
 
     // Premise sync fields
 
-
-    // True if _overviewModel.StoryProblem has been set, in which
-    // case any ProblemViewModel Premise changes must also be made
-    // to the _overviewModel.Premise property.
+    // True only when this Problem is Overview.StoryProblem (#1500).
+    // Then Premise edits save both Problem and Overview.
     private bool _syncPremise;
 
     #endregion
@@ -440,14 +438,11 @@ public class ProblemViewModel : ObservableRecipient, INavigable, ISaveable, IRel
         var root = _storyModel.ExplorerView[0].Uuid;
         var outlineService = Ioc.Default.GetService<OutlineService>();
         _overviewModel = (OverviewModel)outlineService!.GetStoryElementByGuid(_storyModel, root);
-        if (_overviewModel.StoryProblem != Guid.Empty)
-        {
-            _syncPremise = true;
-        }
-        else
-        {
-            _syncPremise = false;
-        }
+        // Only the designated Story Problem may push Premise to Overview (#1500).
+        // A non-empty Overview.StoryProblem GUID alone must not enable sync for every Problem.
+        _syncPremise = Model != null
+            && _overviewModel.StoryProblem != Guid.Empty
+            && _overviewModel.StoryProblem == Model.Uuid;
 
         // Delegate beat-related loading to BeatSheetsViewModel
         BeatSheetsVm.LoadBeats(Model, _storyModel);

--- a/StoryCADTests/ViewModels/ProblemViewModelTests.cs
+++ b/StoryCADTests/ViewModels/ProblemViewModelTests.cs
@@ -307,6 +307,58 @@ public class ProblemViewModelTests
     }
 
     [TestMethod]
+    public void SaveModel_NonStoryProblem_DoesNotClearOverviewPremise()
+    {
+        // #1500: _syncPremise must require this Problem == Overview.StoryProblem.
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var overview = (OverviewModel)_storyModel.StoryElements
+            .First(e => e.ElementType == StoryItemType.StoryOverview);
+
+        var storyProblem = new ProblemModel("Main Story Problem", _storyModel, overview.Node);
+        storyProblem.Premise = "Spine premise text";
+        overview.StoryProblem = storyProblem.Uuid;
+        overview.Premise = "Spine premise text";
+
+        var inner = new ProblemModel("Inner Problem", _storyModel, overview.Node);
+        inner.Premise = string.Empty;
+
+        appState.CurrentDocument = new StoryDocument(_storyModel);
+
+        _viewModel.Activate(inner);
+        _viewModel.Premise = string.Empty;
+        _viewModel.Description = "touch field to simulate edit";
+        _viewModel.Deactivate(null);
+
+        Assert.AreEqual("Spine premise text", overview.Premise,
+            "Saving a non–Story Problem must not push empty Premise to Overview");
+        Assert.AreEqual("Spine premise text", storyProblem.Premise,
+            "Story Problem Premise must remain untouched");
+    }
+
+    [TestMethod]
+    public void SaveModel_StoryProblem_StillSyncsPremiseToOverview()
+    {
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var overview = (OverviewModel)_storyModel.StoryElements
+            .First(e => e.ElementType == StoryItemType.StoryOverview);
+
+        var storyProblem = new ProblemModel("Main Story Problem", _storyModel, overview.Node);
+        storyProblem.Premise = "Old premise";
+        overview.StoryProblem = storyProblem.Uuid;
+        overview.Premise = "Old premise";
+
+        appState.CurrentDocument = new StoryDocument(_storyModel);
+
+        _viewModel.Activate(storyProblem);
+        _viewModel.Premise = "Updated spine premise";
+        _viewModel.Deactivate(null);
+
+        Assert.AreEqual("Updated spine premise", storyProblem.Premise);
+        Assert.AreEqual("Updated spine premise", overview.Premise,
+            "Story Problem SaveModel must still sync Premise to Overview");
+    }
+
+    [TestMethod]
     public void SelectedElementSource_WhenSetToScene_SetsCurrentElementSourceToScenes()
     {
         // Arrange - Setup AppState with CurrentDocument


### PR DESCRIPTION
## Summary
- Gate `ProblemViewModel._syncPremise` on **this** Problem being `Overview.StoryProblem`.
- Prevents saving Inner Problem / subplots with empty Premise from wiping `Overview.Premise` (AutoSave flush path).
- Story Problem → Overview Premise sync still works.

## Why
Closes #1500. Evidence: backup pair `1915` (Overview Premise present) vs `1916` (Overview empty, Story Problem Premise intact) after navigating to Inner Problem and AutoSave.

## Test plan
- [x] `SaveModel_NonStoryProblem_DoesNotClearOverviewPremise`
- [x] `SaveModel_StoryProblem_StillSyncsPremiseToOverview`
- [ ] Manual: Overview Premise set; open Inner Problem; edit Description; AutoSave; Overview Premise still present.