### PR TITLE
feat: confirm Protect overwrites; stage Review Each (Collaborator #140)

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -44,6 +44,7 @@ public class Collaborator : ICollaborator
     private ElementResolver? _elementResolver;
     private string? _filePath;
     private Window? _hostWindow;
+    private Frame? _hostFrame;
     private WorkflowShellViewModel? _shellViewModel;
     private bool _disposed;
     private StoryCADLib.Services.Logging.ILogService? _auditLogger;
@@ -104,6 +105,7 @@ public class Collaborator : ICollaborator
         _storyModel = model;
         _filePath = filePath;
         _hostWindow = hostWindow;
+        _hostFrame = hostFrame;
         _auditLogger = logger;
 
         // Initialize logging and services
@@ -699,42 +701,124 @@ public class Collaborator : ICollaborator
                 {
                     PushPendingToViewModel(viewModel, result);
 
+                    // #140 / #116 rev: Protect accepts are staged until end-of-queue confirm.
+                    var stageSession = new OverwriteAcceptanceSession();
+
+                    int ApplyPendingList(IReadOnlyList<PendingUpdate> list)
+                    {
+                        if (list.Count == 0) return 0;
+                        var slice = WorkflowResult.Succeeded();
+                        foreach (var u in list)
+                            slice.PendingUpdates.Add(u);
+                        var applied = runner.ApplyUpdates(slice, gatheredElements);
+                        foreach (var u in list)
+                            _sessionTouchedFields.Add(u.SessionTouchKey);
+                        return applied;
+                    }
+
+                    void RemovePendingKeys(IEnumerable<string> keys)
+                    {
+                        var set = keys.ToHashSet(StringComparer.OrdinalIgnoreCase);
+                        result.PendingUpdates.RemoveAll(u => set.Contains(u.Key));
+                        foreach (var key in set)
+                            result.UpdatedProperties.Remove(key);
+                    }
+
+                    void FinishPendingUi()
+                    {
+                        if (result.PendingUpdates.Count == 0 && !stageSession.HasStaged)
+                        {
+                            viewModel.MarkUpdatesApplied();
+                            SyncShellPending(viewModel);
+                        }
+                        else
+                            PushPendingToViewModel(viewModel, result);
+                        _storyModel?.RefreshCurrentView();
+                    }
+
+                    void AutoSaveFireAndForget(string reason)
+                    {
+                        _ = Task.Run(async () =>
+                        {
+                            var saved = await SaveAsync();
+                            if (saved)
+                                _logger?.LogInformation("Auto-save completed after {Reason}", reason);
+                        });
+                    }
+
+                    async Task FlushStagedIfQueueDoneAsync()
+                    {
+                        if (!stageSession.ShouldConfirmStaged(result.PendingUpdates.Count))
+                            return;
+
+                        var staged = stageSession.StagedProtect.ToList();
+                        var ok = await ConfirmOverwriteAsync(staged);
+                        if (ok)
+                        {
+                            var n = ApplyPendingList(staged);
+                            viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
+                                n > 0
+                                    ? $"Applied {n} overwrite(s) after confirmation."
+                                    : "No overwrites were applied."));
+                            _logger?.LogInformation("StagedProtect confirmed: Applied {Count}", n);
+                            _auditLogger?.Log(StoryCADLib.Services.Logging.LogLevel.Info,
+                                $"Applied {n} confirmed overwrites from workflow: {workflow.Title}");
+                            stageSession.ClearStage();
+                            AutoSaveFireAndForget("confirmed overwrites");
+                        }
+                        else
+                        {
+                            viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
+                                $"Cancelled: left {staged.Count} existing field(s) unchanged."));
+                            _logger?.LogInformation("StagedProtect cancelled: {Count}", staged.Count);
+                            stageSession.ClearStage();
+                        }
+
+                        FinishPendingUi();
+                    }
+
                     // Wire up command callbacks using closures (captures local state)
-                    viewModel.OnAcceptAll = () =>
+                    viewModel.OnAcceptAll = async () =>
                     {
                         try
                         {
-                            var free = result.PendingUpdates.Where(WorkflowRunner.AcceptAllMayApply).ToList();
-                            var protect = result.PendingUpdates
-                                .Where(u => u.Kind == UpdateKind.Protect)
-                                .ToList();
+                            var (free, protect) = OverwriteAcceptanceSession.Partition(result.PendingUpdates);
+                            stageSession.ClearStage();
 
-                            var applySlice = WorkflowResult.Succeeded();
-                            foreach (var u in free)
-                                applySlice.PendingUpdates.Add(u);
+                            var applyList = new List<PendingUpdate>(free);
+                            if (protect.Count > 0)
+                            {
+                                if (!await ConfirmOverwriteAsync(protect))
+                                {
+                                    // Cancel overwrites: still apply free rows; leave Protect pending.
+                                    var freeOnly = ApplyPendingList(free);
+                                    RemovePendingKeys(free.Select(u => u.Key));
+                                    viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
+                                        freeOnly > 0
+                                            ? $"Applied {freeOnly} free update(s). Left {protect.Count} field(s) with existing text unchanged."
+                                            : $"Left {protect.Count} field(s) with existing text unchanged."));
+                                    _logger?.LogInformation(
+                                        "AcceptAll cancelled overwrites: free={Free} protect={Protect}",
+                                        freeOnly, protect.Count);
+                                    FinishPendingUi();
+                                    if (freeOnly > 0)
+                                        AutoSaveFireAndForget("Accept All free-only");
+                                    return;
+                                }
 
-                            var count = free.Count == 0
-                                ? 0
-                                : runner.ApplyUpdates(applySlice, gatheredElements);
+                                applyList.AddRange(protect);
+                            }
 
-                            foreach (var u in free)
-                                _sessionTouchedFields.Add(u.SessionTouchKey);
-
-                            // Rebuild remaining pending = Protect only
+                            var count = ApplyPendingList(applyList);
                             result.PendingUpdates.Clear();
                             result.UpdatedProperties.Clear();
-                            foreach (var u in protect)
-                            {
-                                result.PendingUpdates.Add(u);
-                                result.UpdatedProperties[u.Key] = u.Value ?? string.Empty;
-                            }
 
                             var sb = new System.Text.StringBuilder();
                             if (count > 0)
                             {
                                 sb.AppendLine($"Applied {count} update(s) to your outline:");
                                 sb.AppendLine();
-                                foreach (var u in free)
+                                foreach (var u in applyList)
                                 {
                                     var valuePreview = TruncateForChat(FormatValueForDisplay(u.Value));
                                     sb.AppendLine($"**{u.Key}**: {valuePreview}");
@@ -742,48 +826,20 @@ public class Collaborator : ICollaborator
                                 }
                             }
                             else
-                            {
-                                sb.AppendLine("No free updates to apply (nothing empty or already written by Collaborator this session).");
-                            }
-
-                            if (protect.Count > 0)
-                            {
-                                sb.AppendLine();
-                                sb.AppendLine(
-                                    $"Left {protect.Count} alone because those fields already have your content. " +
-                                    "Use Review Each to keep or replace them.");
-                                foreach (var u in protect)
-                                {
-                                    sb.AppendLine($"- **{u.Key}** (yours vs proposed)");
-                                    if (!string.IsNullOrWhiteSpace(u.CraftExplanation))
-                                        sb.AppendLine($"  {u.CraftExplanation}");
-                                }
-                            }
+                                sb.AppendLine("No updates to apply.");
 
                             viewModel.ConversationList.Add(ChatMessage.FromCollaborator(sb.ToString().TrimEnd()));
                             _logger?.LogInformation(
-                                "AcceptAll: Applied {Count}, protected {Protected}", count, protect.Count);
+                                "AcceptAll: Applied {Count} (free={Free} protect={Protect})",
+                                count, free.Count, protect.Count);
                             _auditLogger?.Log(StoryCADLib.Services.Logging.LogLevel.Info,
                                 $"Applied {count} updates from workflow: {workflow.Title}");
 
-                            if (protect.Count == 0)
-                            {
-                                viewModel.MarkUpdatesApplied();
-                                SyncShellPending(viewModel);
-                            }
-                            else
-                            {
-                                PushPendingToViewModel(viewModel, result);
-                            }
-
+                            viewModel.MarkUpdatesApplied();
+                            SyncShellPending(viewModel);
                             _storyModel?.RefreshCurrentView();
-
-                            _ = Task.Run(async () =>
-                            {
-                                var saved = await SaveAsync();
-                                if (saved)
-                                    _logger?.LogInformation("Auto-save completed after Accept All");
-                            });
+                            if (count > 0)
+                                AutoSaveFireAndForget("Accept All");
                         }
                         catch (Exception ex)
                         {
@@ -796,6 +852,7 @@ public class Collaborator : ICollaborator
                     {
                         try
                         {
+                            stageSession.ClearStage();
                             viewModel.ClearPendingUpdates();
                             viewModel.AddStatusMessage("Re-running workflow...");
                             await ExecuteWorkflowWithFeedback(viewModel, workflow, gatheredElements);
@@ -807,7 +864,7 @@ public class Collaborator : ICollaborator
                         }
                     };
 
-                    viewModel.OnAcceptProperty = (propertyKey) =>
+                    viewModel.OnAcceptProperty = async (propertyKey) =>
                     {
                         if (string.IsNullOrEmpty(propertyKey))
                         {
@@ -825,24 +882,35 @@ public class Collaborator : ICollaborator
                                 return;
                             }
 
-                            var single = WorkflowResult.Succeeded();
-                            single.PendingUpdates.Add(pending);
-                            var applied = runner.ApplyUpdates(single, gatheredElements);
+                            if (pending.Kind == UpdateKind.Protect)
+                            {
+                                // Stage overwrite; confirm once when the queue is fully decided (#140).
+                                stageSession.StageProtect(pending);
+                                RemovePendingKeys(new[] { propertyKey });
+                                viewModel.AddStatusMessage($"Queued overwrite: {propertyKey}");
+                                _logger?.LogInformation("AcceptProperty: Staged Protect {Key}", propertyKey);
+                                PushPendingToViewModel(viewModel, result);
+                                await FlushStagedIfQueueDoneAsync();
+                                return;
+                            }
 
+                            var applied = ApplyPendingList(new[] { pending });
                             if (applied > 0)
                             {
-                                _sessionTouchedFields.Add(pending.SessionTouchKey);
                                 viewModel.AddStatusMessage($"Applied {propertyKey}");
                                 _logger?.LogInformation("AcceptProperty: Applied {Key}", propertyKey);
                                 _auditLogger?.Log(StoryCADLib.Services.Logging.LogLevel.Info,
                                     $"Applied update: {propertyKey}");
-
-                                result.PendingUpdates.RemoveAll(u =>
-                                    string.Equals(u.Key, propertyKey, StringComparison.OrdinalIgnoreCase));
-                                result.UpdatedProperties.Remove(propertyKey);
+                                RemovePendingKeys(new[] { propertyKey });
                                 PushPendingToViewModel(viewModel, result);
-
                                 _storyModel?.RefreshCurrentView();
+                                await FlushStagedIfQueueDoneAsync();
+                                if (result.PendingUpdates.Count == 0 && !stageSession.HasStaged)
+                                {
+                                    viewModel.MarkUpdatesApplied();
+                                    SyncShellPending(viewModel);
+                                    AutoSaveFireAndForget("AcceptProperty");
+                                }
                             }
                             else
                             {
@@ -858,7 +926,7 @@ public class Collaborator : ICollaborator
                         }
                     };
 
-                    viewModel.OnSkipProperty = (propertyKey) =>
+                    viewModel.OnSkipProperty = async (propertyKey) =>
                     {
                         if (string.IsNullOrEmpty(propertyKey))
                         {
@@ -876,6 +944,12 @@ public class Collaborator : ICollaborator
                                 viewModel.AddStatusMessage($"Skipped {propertyKey}");
                                 _logger?.LogInformation("SkipProperty: Skipped {Key}", propertyKey);
                                 PushPendingToViewModel(viewModel, result);
+                                await FlushStagedIfQueueDoneAsync();
+                                if (result.PendingUpdates.Count == 0 && !stageSession.HasStaged)
+                                {
+                                    viewModel.MarkUpdatesApplied();
+                                    SyncShellPending(viewModel);
+                                }
                             }
                             else
                             {
@@ -889,46 +963,37 @@ public class Collaborator : ICollaborator
                         }
                     };
 
-                    // Accept Remaining: only free rows (Fill/Refresh/Unclassified); leave Protect.
-                    viewModel.OnAcceptRemainingFree = () =>
+                    // Accept Remaining: free apply now; remaining Protect staged → end confirm if queue empty.
+                    viewModel.OnAcceptRemainingFree = async () =>
                     {
                         try
                         {
-                            var free = result.PendingUpdates.Where(WorkflowRunner.AcceptAllMayApply).ToList();
-                            if (free.Count == 0)
+                            var (free, protect) = OverwriteAcceptanceSession.Partition(result.PendingUpdates);
+                            var freeCount = ApplyPendingList(free);
+                            RemovePendingKeys(free.Select(u => u.Key));
+
+                            foreach (var u in protect)
+                                stageSession.StageProtect(u);
+                            RemovePendingKeys(protect.Select(u => u.Key));
+
+                            if (freeCount > 0)
                             {
                                 viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
-                                    "No remaining free updates. Use Accept or Skip on each protected field."));
-                                return;
+                                    $"Applied {freeCount} free update(s)."));
                             }
 
-                            var applySlice = WorkflowResult.Succeeded();
-                            foreach (var u in free)
-                                applySlice.PendingUpdates.Add(u);
-                            var count = runner.ApplyUpdates(applySlice, gatheredElements);
-                            foreach (var u in free)
-                                _sessionTouchedFields.Add(u.SessionTouchKey);
+                            PushPendingToViewModel(viewModel, result);
+                            _storyModel?.RefreshCurrentView();
+                            await FlushStagedIfQueueDoneAsync();
 
-                            var freeKeys = free.Select(u => u.Key).ToHashSet(StringComparer.OrdinalIgnoreCase);
-                            result.PendingUpdates.RemoveAll(u => freeKeys.Contains(u.Key));
-                            foreach (var key in freeKeys)
-                                result.UpdatedProperties.Remove(key);
-
-                            viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
-                                $"Applied {count} free update(s). " +
-                                (result.PendingUpdates.Count > 0
-                                    ? $"{result.PendingUpdates.Count} protected field(s) still need Accept or Skip."
-                                    : "All done.")));
-
-                            if (result.PendingUpdates.Count == 0)
+                            if (result.PendingUpdates.Count == 0 && !stageSession.HasStaged)
                             {
                                 viewModel.MarkUpdatesApplied();
                                 SyncShellPending(viewModel);
                             }
-                            else
-                                PushPendingToViewModel(viewModel, result);
 
-                            _storyModel?.RefreshCurrentView();
+                            if (freeCount > 0)
+                                AutoSaveFireAndForget("Accept Remaining free");
                         }
                         catch (Exception ex)
                         {
@@ -941,7 +1006,7 @@ public class Collaborator : ICollaborator
                     var protectCount = result.PendingUpdates.Count(u => u.Kind == UpdateKind.Protect);
                     viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
                         $"Found {result.PendingUpdates.Count} property update(s) " +
-                        $"({fillCount} ready for Accept All, {protectCount} need your OK because the field already has text). " +
+                        $"({fillCount} free, {protectCount} replace existing text — confirmation required). " +
                         "Choose Accept All, Review Each, or Try Again."));
                 }
                 else
@@ -969,6 +1034,38 @@ public class Collaborator : ICollaborator
             viewModel.ConversationList.Add(ChatMessage.Error($"Error executing workflow: {ex.Message}"));
             _logger?.LogError(ex, "Error executing workflow {Workflow}", workflow.Title);
         }
+    }
+
+    /// <summary>
+    /// #140: confirm before applying Protect (non-empty field) overwrites.
+    /// Headless / no XamlRoot → false (do not silent-overwrite).
+    /// </summary>
+    internal async Task<bool> ConfirmOverwriteAsync(IReadOnlyList<PendingUpdate> protect)
+    {
+        if (protect == null || protect.Count == 0)
+            return true;
+
+        var xamlRoot = _hostFrame?.XamlRoot;
+        if (xamlRoot == null)
+        {
+            _logger?.LogWarning(
+                "ConfirmOverwriteAsync: no XamlRoot; refusing {Count} Protect overwrite(s)",
+                protect.Count);
+            return false;
+        }
+
+        var dialog = new ContentDialog
+        {
+            Title = "Replace existing content?",
+            Content = OverwriteAcceptanceSession.BuildConfirmMessage(protect),
+            PrimaryButtonText = "Replace",
+            CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Primary,
+            XamlRoot = xamlRoot
+        };
+
+        var result = await dialog.ShowAsync();
+        return result == ContentDialogResult.Primary;
     }
 
     /// <summary>

--- a/CollaboratorLib/Services/OverwriteAcceptanceSession.cs
+++ b/CollaboratorLib/Services/OverwriteAcceptanceSession.cs
@@ -1,0 +1,75 @@
+using StoryCollaborator.Models;
+
+namespace StoryCollaborator.Services;
+
+/// <summary>
+/// Collaborator #140 (#116 rev): Protect overwrites require confirmation.
+/// Free updates apply without a dialog. Protect Accepts are staged during Review Each
+/// / per-row Accept; one confirm runs when the pending queue is fully decided.
+/// </summary>
+public sealed class OverwriteAcceptanceSession
+{
+    private readonly List<PendingUpdate> _stagedProtect = new();
+
+    public IReadOnlyList<PendingUpdate> StagedProtect => _stagedProtect;
+
+    public int StagedCount => _stagedProtect.Count;
+
+    public bool HasStaged => _stagedProtect.Count > 0;
+
+    /// <summary>Stage a Protect update for later confirm+apply (idempotent by key).</summary>
+    public void StageProtect(PendingUpdate update)
+    {
+        if (update.Kind != UpdateKind.Protect)
+            throw new ArgumentException("Only Protect updates may be staged.", nameof(update));
+
+        if (_stagedProtect.Any(u =>
+                string.Equals(u.Key, update.Key, StringComparison.OrdinalIgnoreCase)))
+            return;
+
+        _stagedProtect.Add(update);
+    }
+
+    public void ClearStage() => _stagedProtect.Clear();
+
+    /// <summary>
+    /// True when every pending row has been decided (list empty) and Protect accepts are waiting.
+    /// </summary>
+    public bool ShouldConfirmStaged(int remainingPendingCount) =>
+        remainingPendingCount == 0 && _stagedProtect.Count > 0;
+
+    /// <summary>Partition pending into free (Accept All may apply) vs Protect.</summary>
+    public static (List<PendingUpdate> Free, List<PendingUpdate> Protect) Partition(
+        IEnumerable<PendingUpdate> pending)
+    {
+        var free = new List<PendingUpdate>();
+        var protect = new List<PendingUpdate>();
+        foreach (var u in pending)
+        {
+            if (u.Kind == UpdateKind.Protect)
+                protect.Add(u);
+            else if (u.AcceptAllMayApply)
+                free.Add(u);
+            else
+                free.Add(u); // Unclassified treated as free
+        }
+        return (free, protect);
+    }
+
+    /// <summary>Dialog body for Confirm overwrite of Protect fields.</summary>
+    public static string BuildConfirmMessage(IReadOnlyList<PendingUpdate> protect)
+    {
+        if (protect == null || protect.Count == 0)
+            return "No fields need overwrite confirmation.";
+
+        var sb = new System.Text.StringBuilder();
+        sb.Append(protect.Count == 1
+            ? "This field already has your content. Replace it with Collaborator's proposal?"
+            : $"These {protect.Count} fields already have your content. Replace them with Collaborator's proposals?");
+        sb.AppendLine();
+        sb.AppendLine();
+        foreach (var u in protect)
+            sb.AppendLine($"• {u.Key}");
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
@@ -28,15 +28,15 @@ public partial class WorkflowViewModel : ObservableRecipient
         AcceptCommand = new RelayCommand(SaveOutputs);
         SendCommand = new RelayCommand(async () => await SendButtonClicked());
 
-        // Property update commands
-        AcceptAllCommand = new RelayCommand(ExecuteAcceptAll);
+        // Property update commands (#140: Accept paths may await overwrite confirm)
+        AcceptAllCommand = new RelayCommand(async () => await ExecuteAcceptAllAsync());
         ReviewEachCommand = new RelayCommand(ExecuteReviewEach);
         TryAgainCommand = new RelayCommand(async () => await ExecuteTryAgain());
 
         // Review mode commands
-        AcceptCurrentCommand = new RelayCommand(ExecuteAcceptCurrent);
-        SkipCurrentCommand = new RelayCommand(ExecuteSkipCurrent);
-        AcceptRemainingCommand = new RelayCommand(ExecuteAcceptRemaining);
+        AcceptCurrentCommand = new RelayCommand(async () => await ExecuteAcceptCurrentAsync());
+        SkipCurrentCommand = new RelayCommand(async () => await ExecuteSkipCurrentAsync());
+        AcceptRemainingCommand = new RelayCommand(async () => await ExecuteAcceptRemainingAsync());
     }
 
     /// <summary>
@@ -298,15 +298,15 @@ public partial class WorkflowViewModel : ObservableRecipient
         ? $"{CurrentReviewIndex + 1} of {PendingUpdateItems?.Count ?? 0}"
         : string.Empty;
 
-    public Action OnAcceptAll { get; set; }
+    public Func<Task> OnAcceptAll { get; set; }
     public Func<Task> OnTryAgain { get; set; }
-    public Action<string> OnAcceptProperty { get; set; }
-    public Action<string> OnSkipProperty { get; set; }
+    public Func<string, Task> OnAcceptProperty { get; set; }
+    public Func<string, Task> OnSkipProperty { get; set; }
 
     /// <summary>
-    /// Accept remaining Fill/Refresh only; leave Protect rows (issue #116).
+    /// Accept remaining free now; stage remaining Protect and confirm when the queue is done (#140).
     /// </summary>
-    public Action OnAcceptRemainingFree { get; set; }
+    public Func<Task> OnAcceptRemainingFree { get; set; }
 
     private bool _updatesApplied;
     public bool UpdatesApplied
@@ -406,12 +406,11 @@ public partial class WorkflowViewModel : ObservableRecipient
 
     #region Property Update Command Handlers
 
-    private void ExecuteAcceptAll()
+    private async Task ExecuteAcceptAllAsync()
     {
         if (!HasPendingUpdates) return;
-
-        // Collaborator applies free rows, may leave Protect, and updates this collection.
-        OnAcceptAll?.Invoke();
+        if (OnAcceptAll != null)
+            await OnAcceptAll();
     }
 
     private void ExecuteReviewEach()
@@ -434,57 +433,69 @@ public partial class WorkflowViewModel : ObservableRecipient
 
     /// <summary>
     /// Accepts a single row from its inline tick (#129); works outside review mode.
-    /// Collaborator's handler applies the update, removes the key, and re-syncs the list.
+    /// Protect rows are staged for end-of-queue confirm (#140).
     /// </summary>
-    public void AcceptItem(string key)
+    public async Task AcceptItemAsync(string key)
     {
         if (string.IsNullOrEmpty(key) || !HasPendingUpdates) return;
-        OnAcceptProperty?.Invoke(key);
+        if (OnAcceptProperty != null)
+            await OnAcceptProperty(key);
     }
+
+    /// <summary>Sync wrapper for XAML/command binding that cannot await.</summary>
+    public void AcceptItem(string key) =>
+        _ = AcceptItemAsync(key);
 
     /// <summary>
     /// Skips (discards) a single row from its inline dismiss button (#129).
     /// </summary>
-    public void SkipItem(string key)
+    public async Task SkipItemAsync(string key)
     {
         if (string.IsNullOrEmpty(key) || !HasPendingUpdates) return;
-        OnSkipProperty?.Invoke(key);
+        if (OnSkipProperty != null)
+            await OnSkipProperty(key);
     }
 
-    private void ExecuteAcceptCurrent()
+    public void SkipItem(string key) =>
+        _ = SkipItemAsync(key);
+
+    private async Task ExecuteAcceptCurrentAsync()
     {
         if (!IsInReviewMode || !HasPendingUpdates) return;
 
         var key = CurrentReviewKey;
-        OnAcceptProperty?.Invoke(key);
+        if (OnAcceptProperty != null)
+            await OnAcceptProperty(key);
         AdvanceReview();
     }
 
-    private void ExecuteSkipCurrent()
+    private async Task ExecuteSkipCurrentAsync()
     {
         if (!IsInReviewMode || !HasPendingUpdates) return;
 
         var key = CurrentReviewKey;
-        OnSkipProperty?.Invoke(key);
+        if (OnSkipProperty != null)
+            await OnSkipProperty(key);
         AdvanceReview();
     }
 
-    private void ExecuteAcceptRemaining()
+    private async Task ExecuteAcceptRemainingAsync()
     {
         if (!IsInReviewMode) return;
 
-        // #116: only free updates; Protect stays for Accept/Skip.
+        // #140: free apply now; remaining Protect staged → one confirm when queue done.
         if (OnAcceptRemainingFree != null)
-            OnAcceptRemainingFree.Invoke();
+            await OnAcceptRemainingFree();
         else
         {
-            // Fallback: accept free-looking rows only (no Protect label).
             var keys = PendingUpdateItems
-                .Where(i => !i.IsProtected)
                 .Select(i => i.Key)
                 .ToList();
             foreach (var key in keys)
-                OnAcceptProperty?.Invoke(key);
+            {
+                if (OnAcceptProperty != null)
+                    await OnAcceptProperty(key);
+            }
         }
 
         if (PendingUpdateItems == null || PendingUpdateItems.Count == 0)

--- a/StoryCADTests/Collaborator/OverwriteAcceptanceSessionTests.cs
+++ b/StoryCADTests/Collaborator/OverwriteAcceptanceSessionTests.cs
@@ -1,0 +1,81 @@
+using StoryCollaborator.Models;
+using StoryCollaborator.Services;
+
+namespace StoryCADTests.Collaborator;
+
+[TestClass]
+public class OverwriteAcceptanceSessionTests
+{
+    private static PendingUpdate Make(string key, UpdateKind kind, string value = "proposed")
+    {
+        var parts = key.Split('.', 2);
+        var label = parts.Length == 2 ? parts[0] : "Overview";
+        var prop = parts.Length == 2 ? parts[1] : key;
+        return new PendingUpdate(label, Guid.NewGuid(), new PropertySpec(prop), value, kind, "current");
+    }
+
+    [TestMethod]
+    public void Partition_SplitsFreeAndProtect()
+    {
+        var pending = new List<PendingUpdate>
+        {
+            Make("Overview.Premise", UpdateKind.Fill),
+            Make("Overview.Concept", UpdateKind.Protect),
+            Make("Overview.Description", UpdateKind.Refresh),
+        };
+
+        var (free, protect) = OverwriteAcceptanceSession.Partition(pending);
+
+        Assert.AreEqual(2, free.Count);
+        Assert.AreEqual(1, protect.Count);
+        Assert.AreEqual("Overview.Concept", protect[0].Key);
+    }
+
+    [TestMethod]
+    public void StageProtect_OnlyProtect_AndIdempotent()
+    {
+        var session = new OverwriteAcceptanceSession();
+        var p = Make("Problem.ProtGoal", UpdateKind.Protect);
+
+        session.StageProtect(p);
+        session.StageProtect(p);
+
+        Assert.AreEqual(1, session.StagedCount);
+        try
+        {
+            session.StageProtect(Make("Problem.Premise", UpdateKind.Fill));
+            Assert.Fail("Expected ArgumentException for non-Protect stage");
+        }
+        catch (ArgumentException)
+        {
+            // expected
+        }
+    }
+
+    [TestMethod]
+    public void ShouldConfirmStaged_OnlyWhenQueueEmptyAndStaged()
+    {
+        var session = new OverwriteAcceptanceSession();
+        session.StageProtect(Make("A.B", UpdateKind.Protect));
+
+        Assert.IsFalse(session.ShouldConfirmStaged(remainingPendingCount: 2));
+        Assert.IsTrue(session.ShouldConfirmStaged(remainingPendingCount: 0));
+
+        session.ClearStage();
+        Assert.IsFalse(session.ShouldConfirmStaged(remainingPendingCount: 0));
+    }
+
+    [TestMethod]
+    public void BuildConfirmMessage_ListsKeys()
+    {
+        var msg = OverwriteAcceptanceSession.BuildConfirmMessage(new[]
+        {
+            Make("Problem.ProtGoal", UpdateKind.Protect),
+            Make("Problem.ProtMotive", UpdateKind.Protect),
+        });
+
+        StringAssert.Contains(msg, "2 fields");
+        StringAssert.Contains(msg, "Problem.ProtGoal");
+        StringAssert.Contains(msg, "Problem.ProtMotive");
+    }
+}

--- a/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
@@ -424,11 +424,13 @@ public class WorkflowViewModelTests
         {
             store.RemoveAll(i => i.Key == key);
             _viewModel.SetPendingUpdates(store);
+            return Task.CompletedTask;
         };
         _viewModel.OnSkipProperty = key =>
         {
             store.RemoveAll(i => i.Key == key);
             _viewModel.SetPendingUpdates(store);
+            return Task.CompletedTask;
         };
     }
 
@@ -601,7 +603,11 @@ public class WorkflowViewModelTests
     public void AcceptItem_WithNoPendingUpdates_DoesNotInvokeCallback()
     {
         var invoked = false;
-        _viewModel.OnAcceptProperty = _ => invoked = true;
+        _viewModel.OnAcceptProperty = _ =>
+        {
+            invoked = true;
+            return Task.CompletedTask;
+        };
 
         _viewModel.AcceptItem("Overview.Premise");
 


### PR DESCRIPTION
## Summary
Implements [Collaborator #140](https://github.com/storybuilder-org/Collaborator/issues/140) (#116 rev):

- **Free** (empty / session refresh): apply without dialog.
- **Protect** (already has text): apply only after confirmation.
- **Accept All:** one ContentDialog if any Protect rows; Replace → free + Protect; Cancel → free only, Protect stay pending.
- **Review Each / per-row Accept:** stage Protect accepts; **one** confirm when the pending queue is fully decided (not a popup per field). Skip discards. Free still applies immediately.

## Files
- `OverwriteAcceptanceSession` — partition / stage / confirm message (unit-tested)
- `Collaborator.cs` — Accept All / Accept / Skip / Accept Remaining handlers
- `WorkflowViewModel` — async accept callbacks

## Test plan
- [x] `OverwriteAcceptanceSessionTests` (4)
- [x] Existing AcceptItem / SkipItem VM tests
- [ ] Manual: GMC with 7 Protect + 1 New → Accept All → dialog → Replace applies all
- [ ] Manual: Review Each Accept all Protect rows → one dialog at end