### PR TITLE
fix(#1503): set ProblemCategory when Overview.StoryProblem is linked

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -1336,6 +1336,12 @@ public class Collaborator : ICollaborator
                         $"Found {requirement.ElementLabel}: {currentElement.Name} (from {requirement.ReferencedElementLabel})");
                     _logger?.LogDebug("Resolved {Label} via {Ref} to '{Name}'",
                         requirement.ElementLabel, requirement.ReferencedElementLabel, currentElement.Name);
+                    if (string.Equals(
+                            requirement.ReferencedElementLabel, "Overview.StoryProblem",
+                            StringComparison.OrdinalIgnoreCase))
+                    {
+                        ApplyStoryProblemCategory(currentElement.Uuid, statusMessages);
+                    }
                     return currentElement;
                 }
 
@@ -1436,11 +1442,47 @@ public class Collaborator : ICollaborator
         {
             statusMessages.Add($"  (Updated {sourceLabel}.{propertyName})");
             _logger?.LogDebug("Updated {Source}.{Property} = {Guid}", sourceLabel, propertyName, pickedElementGuid);
+
+            // Linking Overview.StoryProblem means this Problem is the main story problem —
+            // ProblemCategory is that structural fact (Lists.json), not an Accept/Protect field.
+            if (string.Equals(sourceLabel, "Overview", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(propertyName, "StoryProblem", StringComparison.OrdinalIgnoreCase))
+            {
+                ApplyStoryProblemCategory(pickedElementGuid, statusMessages);
+            }
         }
         else
         {
             _logger?.LogWarning("Failed to update {Source}.{Property}: {Error}",
                 sourceLabel, propertyName, result?.ErrorMessage);
+        }
+    }
+
+    /// <summary>
+    /// Exact Lists.json ProblemCategory value when a Problem is the Overview StoryProblem.
+    /// </summary>
+    internal const string StoryProblemCategoryListValue = "Story problem";
+
+    /// <summary>
+    /// Writes Problem.ProblemCategory = "Story problem" immediately (not pending / not Accept).
+    /// Call whenever Overview.StoryProblem is linked to this Problem.
+    /// </summary>
+    internal void ApplyStoryProblemCategory(Guid problemGuid, List<string>? statusMessages = null)
+    {
+        var catResult = _storyApi?.UpdateElementProperty(
+            problemGuid, "ProblemCategory", StoryProblemCategoryListValue);
+        if (catResult?.IsSuccess == true)
+        {
+            statusMessages?.Add($"  (Set Problem.ProblemCategory = {StoryProblemCategoryListValue})");
+            _logger?.LogDebug(
+                "Set Problem {Guid} ProblemCategory = {Category}",
+                problemGuid, StoryProblemCategoryListValue);
+        }
+        else
+        {
+            _logger?.LogWarning(
+                "Failed to set ProblemCategory on {Guid}: {Error}",
+                problemGuid, catResult?.ErrorMessage);
         }
     }
 

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -158,6 +158,7 @@ namespace StoryCollaborator.Workflows
                                 PropertiesToUpdate = new List<PropertySpec>
                                 {
                                     new PropertySpec("Name"),
+                                    // ProblemCategory is not LLM: set at gather when Overview.StoryProblem is linked.
                                     new PropertySpec("ProblemType"),
                                     new PropertySpec("ConflictType"),
                                     new PropertySpec("Subject"),

--- a/StoryCADTests/Collaborator/StoryProblemRegistryTests.cs
+++ b/StoryCADTests/Collaborator/StoryProblemRegistryTests.cs
@@ -1,10 +1,17 @@
+using CommunityToolkit.Mvvm.DependencyInjection;
 using StoryCADLib.Models;
+using StoryCADLib.Models.Tools;
+using StoryCADLib.Services.API;
+using StoryCADLib.Services.Outline;
+using StoryCADLib.ViewModels;
+using StoryCollaborator;
 using StoryCollaborator.Workflows;
 
 namespace StoryCADTests.Collaborator;
 
 /// <summary>
-/// Registry contract for Story Problem gather links (Collaborator #118).
+/// Registry contract for Story Problem gather links (Collaborator #118)
+/// and immediate ProblemCategory write when Overview.StoryProblem is set.
 /// </summary>
 [TestClass]
 public class StoryProblemRegistryTests
@@ -74,5 +81,35 @@ public class StoryProblemRegistryTests
         Assert.IsTrue(props.Contains("Method"), "Method (Resolution tab)");
         Assert.IsTrue(props.Contains("Theme"), "Theme (Resolution tab)");
         Assert.IsTrue(props.Contains("Premise"), "Premise stays on Problem outputs");
+        Assert.IsFalse(props.Contains("ProblemCategory"),
+            "ProblemCategory is link-time structural write, not LLM pending");
+    }
+
+    [TestMethod]
+    public async Task StoryProblemCategory_ListValue_WritesViaApiImmediately()
+    {
+        // Contract: linking StoryProblem sets this exact Lists.json value on the Problem
+        // (Collaborator.ApplyStoryProblemCategory → UpdateElementProperty, not pending).
+        var api = new StoryCADApi(
+            Ioc.Default.GetRequiredService<OutlineService>(),
+            Ioc.Default.GetRequiredService<ListData>(),
+            Ioc.Default.GetRequiredService<ControlData>(),
+            Ioc.Default.GetRequiredService<ToolsData>());
+        var create = await api.CreateEmptyOutline("Category Link", "Author", "0");
+        Assert.IsTrue(create.IsSuccess);
+
+        var model = api.CurrentModel!;
+        var overview = model.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var add = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "Do Not Open the Box");
+        Assert.IsTrue(add.IsSuccess);
+        var problem = (ProblemModel)model.StoryElements.StoryElementGuids[add.Payload];
+        Assert.IsTrue(string.IsNullOrEmpty(problem.ProblemCategory));
+
+        var write = api.UpdateElementProperty(
+            problem.Uuid, "ProblemCategory", StoryCollaborator.Collaborator.StoryProblemCategoryListValue);
+        Assert.IsTrue(write.IsSuccess);
+        Assert.AreEqual("Story problem", problem.ProblemCategory);
+        Assert.AreEqual(
+            StoryCollaborator.Collaborator.StoryProblemCategoryListValue, problem.ProblemCategory);
     }
 }


### PR DESCRIPTION
## Summary
- When **Story Problem** gather links a Problem as `Overview.StoryProblem`, write `ProblemCategory = \"Story problem\"` (Lists.json) immediately.
- Same write when required gather resolves an existing `Overview.StoryProblem` link.
- Structural fact, not LLM pending / not Accept.

## Why
Closes #1503. Outline gaps kept reporting Problem Category missing after Story Problem had set Premise and the Overview link.

## Test plan
- [x] `StoryProblemRegistryTests` (6/6)
- [ ] Manual: run Story Problem, pick/create main problem → category is Story problem; gap clears.