### PR TITLE
feat: Role and Story Role outputs Character Sketch (Collaborator #142)

### DIFF
--- a/CollaboratorLib/Context/GapWorkflowOwnership.cs
+++ b/CollaboratorLib/Context/GapWorkflowOwnership.cs
@@ -41,7 +41,8 @@ public static class GapWorkflowOwnership
 
             (StoryItemType.Character, "Role") => new[] { "RoleAndStoryRole" },
             (StoryItemType.Character, "StoryRole") => new[] { "RoleAndStoryRole" },
-            (StoryItemType.Character, "Description") => Array.Empty<string>(),
+            // Character Sketch — Role and Story Role (#142)
+            (StoryItemType.Character, "Description") => new[] { "RoleAndStoryRole" },
             (StoryItemType.Character, "Name") => Array.Empty<string>(),
 
             (StoryItemType.Setting, "Description") => new[] { "SettingTimeSpace" },

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -388,14 +388,21 @@ namespace StoryCollaborator.Workflows
                 // === Character Workflows ===
                 new Workflow(
                     "RoleAndStoryRole", "Role and Story Role",
-                    "Define a character's archetypal role and their function in the story.",
+                    "Define a character's archetypal role, story function, and a short Character Sketch.",
                     StoryItemType.Character,
-                    explanation: "Every character serves a purpose. Role defines their relationship to the protagonist " +
-                                "(ally, mentor, love interest, antagonist). Story Role captures their narrative function " +
-                                "(provides comic relief, delivers exposition, represents theme). Archetype connects them " +
-                                "to universal patterns readers instinctively recognize—the Hero, Trickster, Shadow, or " +
-                                "Shapeshifter. This workflow helps you cast your character deliberately.",
-                    outputProperties: new List<PropertySpec> { new PropertySpec("Role"), new PropertySpec("StoryRole"), new PropertySpec("Archetype") },
+                    explanation: "Every character serves a purpose. Role is occupation/function in the world. " +
+                                "Story Role is narrative function (Protagonist, Antagonist, Supporting). " +
+                                "Archetype is the universal pattern (Hero, Mentor, Shadow). " +
+                                "Character Sketch (Description) is short story-function prose from those choices, " +
+                                "Related Problems, Flaw when present, and story premise—not a physical biography.",
+                    outputProperties: new List<PropertySpec>
+                    {
+                        new PropertySpec("Role"),
+                        new PropertySpec("StoryRole"),
+                        new PropertySpec("Archetype"),
+                        // Character Sketch (gap label); Collaborator #142
+                        new PropertySpec("Description")
+                    },
                     exampleLists: new List<string> { "Role", "StoryRole", "Archetype" }),
                 new Workflow(
                     "PhysicalAppearance", "Physical and Appearance",

--- a/StoryCADTests/Collaborator/RoleAndStoryRoleSketchTests.cs
+++ b/StoryCADTests/Collaborator/RoleAndStoryRoleSketchTests.cs
@@ -1,0 +1,40 @@
+using CollaboratorLib.Context;
+using StoryCADLib.Models;
+using StoryCollaborator.Workflows;
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>
+/// Collaborator #142: Role and Story Role owns Character Sketch (Description).
+/// </summary>
+[TestClass]
+public class RoleAndStoryRoleSketchTests
+{
+    [TestMethod]
+    public void RoleAndStoryRole_Outputs_IncludeDescription()
+    {
+        var wf = WorkflowRegistry.Get("RoleAndStoryRole");
+        Assert.IsNotNull(wf);
+        var props = wf!.GetIO().Outputs
+            .SelectMany(o => o.PropertiesToUpdate)
+            .Select(p => p.Property)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        Assert.IsTrue(props.Contains("Role"));
+        Assert.IsTrue(props.Contains("StoryRole"));
+        Assert.IsTrue(props.Contains("Archetype"));
+        Assert.IsTrue(props.Contains("Description"),
+            "Character Sketch is Description on Character");
+    }
+
+    [TestMethod]
+    public void GapOwnership_CharacterDescription_PointsToRoleAndStoryRole()
+    {
+        var owners = GapWorkflowOwnership.WorkflowsFor(
+            StoryItemType.Character, "Description");
+        Assert.AreEqual(1, owners.Count);
+        Assert.AreEqual("RoleAndStoryRole", owners[0]);
+        Assert.AreEqual("Character Sketch",
+            GapWorkflowOwnership.DisplayLabel(StoryItemType.Character, "Description"));
+    }
+}


### PR DESCRIPTION
## Summary
- RoleAndStoryRole registry now includes Description (Character Sketch).
- Gap ownership: Character Description maps to RoleAndStoryRole.
- Unit tests for registry and ownership.

## Pairing
Worker prompt: Collaborator PR on the same issue #142. Deploy dev Worker after that merges for live runs.

## Related
- Collaborator #142
- #107 (gaps surface the field; RelatedProblems already wired)

## Test plan
- [x] RoleAndStoryRoleSketchTests (2/2)
- [ ] Manual after Worker deploy: Role and Story Role, Accept Description, Character Sketch gap clears
