### PR TITLE
feat: proposal chat seeds session set and JSON patches (Collaborator #145)

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -38,6 +38,14 @@ public class Collaborator : ICollaborator
     private bool _kernelInitialized;
     private readonly object _kernelLock = new();
 
+    /// <summary>Collaborator #145: last workflow run proposals for proposal-chat.</summary>
+    private SessionProposalSet? _sessionProposals;
+
+    /// <summary>Live result for the open workflow page (pending list + chat patches).</summary>
+    private WorkflowResult? _activeWorkflowResult;
+
+    private StoryCADLib.Collaborator.ViewModels.WorkflowViewModel? _activeWorkflowViewModel;
+
     // State
     private IStoryCADAPI? _storyApi;
     private StoryModel? _storyModel;
@@ -505,48 +513,63 @@ public class Collaborator : ICollaborator
     }
 
     /// <summary>
-    /// Wires up the chat callback for a WorkflowViewModel.
-    /// Creates a new ChatHistory for each workflow and handles message processing.
+    /// Wires chat for a workflow. Send stays disabled until
+    /// <see cref="BeginProposalChatSession"/> after the one-shot produces proposals (#145).
     /// </summary>
     private void WireUpChatCallback(
         StoryCADLib.Collaborator.ViewModels.WorkflowViewModel viewModel,
         Workflow workflow,
         Dictionary<string, StoryElement> gatheredElements)
     {
-        // Create fresh chat history for this workflow session
+        _sessionProposals = null;
+        _activeWorkflowResult = null;
+        _activeWorkflowViewModel = viewModel;
         _chatHistory = new ChatHistory();
+        viewModel.IsChatEnabled = false;
+        viewModel.ChatPlaceholder = "Waiting for proposals…";
 
-        // Build context from gathered elements
-        var elementContext = BuildElementContext(gatheredElements);
-
-        // Add system message with workflow context and story elements
-        _chatHistory.AddSystemMessage(
-            $"You are a story development assistant helping with the '{workflow.Title}' workflow. " +
-            $"{workflow.Description}\n\n" +
-            $"## Current Story Context\n{elementContext}\n\n" +
-            "Provide helpful, constructive feedback to help the writer develop their story. " +
-            "Reference the story elements above when giving advice.\n\n" +
-            // The chat pane renders replies in a plain TextBlock; any markup arrives verbatim.
-            "Respond in plain text only. Never use Markdown, HTML, RTF, or any other markup: " +
-            "no headings, asterisks for bold or italics, backticks, tables, or links. " +
-            "The display cannot render formatting, so markup characters would appear literally. " +
-            "For lists, use simple lines starting with a hyphen. Separate ideas with blank lines.");
-
-        // Wire up the callback
         viewModel.OnSendMessage = async (userMessage) =>
         {
             try
             {
+                if (_sessionProposals == null || _sessionProposals.Count == 0)
+                {
+                    return "Chat unlocks after the workflow produces property proposals.";
+                }
+
+                EnsureKernelInitialized();
                 _chatHistory?.AddUserMessage(userMessage);
                 _logger?.LogDebug("User message added to chat: {Message}", userMessage);
 
                 var response = await _chatService!.GetChatMessageContentAsync(_chatHistory!);
                 var responseText = response.Content ?? "No response received.";
 
-                _chatHistory?.AddAssistantMessage(responseText);
-                _logger?.LogDebug("Assistant response: {Response}", responseText);
+                ChatPatchParser.TryParse(responseText, out var display, out var patches);
+                _chatHistory?.AddAssistantMessage(display);
 
-                return responseText;
+                if (patches.Count > 0 && _sessionProposals != null)
+                {
+                    var applied = 0;
+                    foreach (var p in patches)
+                    {
+                        if (_sessionProposals.TryApplyPatch(p.Key, p.Value, out _))
+                            applied++;
+                        else
+                            _logger?.LogDebug("Ignored chat patch for unknown key {Key}", p.Key);
+                    }
+
+                    if (applied > 0)
+                    {
+                        SyncWorkflowResultFromSession();
+                        RefreshProposalSnapshotInHistory();
+                        display = string.IsNullOrWhiteSpace(display)
+                            ? $"Updated {applied} proposal(s). Accept to write the outline."
+                            : display + $"\n\n({applied} proposal(s) updated — Accept to write the outline.)";
+                    }
+                }
+
+                _logger?.LogDebug("Assistant response (display): {Response}", display);
+                return display;
             }
             catch (Exception ex)
             {
@@ -555,8 +578,87 @@ public class Collaborator : ICollaborator
             }
         };
 
-        _logger?.LogInformation("Chat callback wired for workflow: {Workflow} with {Count} elements in context",
-            workflow.Title, gatheredElements.Count);
+        _logger?.LogInformation(
+            "Chat callback wired for workflow: {Workflow} (proposal-chat; Send locked until seed)",
+            workflow.Title);
+    }
+
+    /// <summary>
+    /// #145: clear chat, seed system + proposal snapshot, unlock Send.
+    /// Call after the workflow one-shot has classified pending updates.
+    /// </summary>
+    private void BeginProposalChatSession(
+        StoryCADLib.Collaborator.ViewModels.WorkflowViewModel viewModel,
+        Workflow workflow,
+        WorkflowResult result)
+    {
+        _activeWorkflowResult = result;
+        _activeWorkflowViewModel = viewModel;
+
+        if (result.PendingUpdates.Count == 0)
+        {
+            viewModel.IsChatEnabled = false;
+            viewModel.ChatPlaceholder = "No proposals to edit in chat";
+            _sessionProposals = null;
+            return;
+        }
+
+        EnsureKernelInitialized();
+        _sessionProposals = new SessionProposalSet();
+        _sessionProposals.ReplaceFromPending(result.PendingUpdates);
+
+        _chatHistory = new ChatHistory();
+        _chatHistory.AddSystemMessage(SessionProposalSet.BuildSystemInstructions(workflow.Title));
+        _chatHistory.AddSystemMessage(_sessionProposals.BuildSnapshotText());
+
+        viewModel.ConversationList.Clear();
+        viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
+            "Proposals are ready. Ask about them or request changes (for example, rename a field). " +
+            "Accept still writes the outline. This chat is only for these proposals."));
+
+        viewModel.IsChatEnabled = true;
+        viewModel.ChatPlaceholder = "Ask about or change proposals…";
+        _logger?.LogInformation(
+            "Proposal chat seeded for {Workflow} with {Count} keys",
+            workflow.Title, _sessionProposals.Count);
+    }
+
+    /// <summary>
+    /// Mid-chat: append an updated proposal snapshot (keeps user/assistant turns).
+    /// </summary>
+    private void RefreshProposalSnapshotInHistory()
+    {
+        if (_chatHistory == null || _sessionProposals == null)
+            return;
+        _chatHistory.AddSystemMessage(
+            "Updated property proposals:\n" + _sessionProposals.BuildSnapshotText());
+    }
+
+    /// <summary>
+    /// Push open session proposals into WorkflowResult + Property Updates UI.
+    /// </summary>
+    private void SyncWorkflowResultFromSession()
+    {
+        if (_sessionProposals == null || _activeWorkflowResult == null || _activeWorkflowViewModel == null)
+            return;
+
+        var open = _sessionProposals.OpenAsPendingUpdates().ToList();
+        _activeWorkflowResult.PendingUpdates.Clear();
+        _activeWorkflowResult.UpdatedProperties.Clear();
+        foreach (var u in open)
+        {
+            _activeWorkflowResult.PendingUpdates.Add(u);
+            _activeWorkflowResult.UpdatedProperties[u.Key] = FormatValueForDisplay(u.Value);
+        }
+
+        PushPendingToViewModel(_activeWorkflowViewModel, _activeWorkflowResult);
+        if (open.Count == 0)
+        {
+            _activeWorkflowViewModel.MarkUpdatesApplied();
+            SyncShellPending(_activeWorkflowViewModel);
+        }
+        else
+            SyncShellPending(_activeWorkflowViewModel);
     }
 
     /// <summary>
@@ -756,6 +858,8 @@ public class Collaborator : ICollaborator
                         if (ok)
                         {
                             var n = ApplyPendingList(staged);
+                            foreach (var u in staged)
+                                _sessionProposals?.MarkAccepted(u.Key);
                             viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
                                 n > 0
                                     ? $"Applied {n} overwrite(s) after confirmation."
@@ -764,6 +868,7 @@ public class Collaborator : ICollaborator
                             _auditLogger?.Log(StoryCADLib.Services.Logging.LogLevel.Info,
                                 $"Applied {n} confirmed overwrites from workflow: {workflow.Title}");
                             stageSession.ClearStage();
+                            RefreshProposalSnapshotInHistory();
                             AutoSaveFireAndForget("confirmed overwrites");
                         }
                         else
@@ -792,6 +897,8 @@ public class Collaborator : ICollaborator
                                 {
                                     // Cancel overwrites: still apply free rows; leave Protect pending.
                                     var freeOnly = ApplyPendingList(free);
+                                    foreach (var u in free)
+                                        _sessionProposals?.MarkAccepted(u.Key);
                                     RemovePendingKeys(free.Select(u => u.Key));
                                     viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
                                         freeOnly > 0
@@ -800,6 +907,7 @@ public class Collaborator : ICollaborator
                                     _logger?.LogInformation(
                                         "AcceptAll cancelled overwrites: free={Free} protect={Protect}",
                                         freeOnly, protect.Count);
+                                    RefreshProposalSnapshotInHistory();
                                     FinishPendingUi();
                                     if (freeOnly > 0)
                                         AutoSaveFireAndForget("Accept All free-only");
@@ -810,6 +918,8 @@ public class Collaborator : ICollaborator
                             }
 
                             var count = ApplyPendingList(applyList);
+                            foreach (var u in applyList)
+                                _sessionProposals?.MarkAccepted(u.Key);
                             result.PendingUpdates.Clear();
                             result.UpdatedProperties.Clear();
 
@@ -837,6 +947,7 @@ public class Collaborator : ICollaborator
 
                             viewModel.MarkUpdatesApplied();
                             SyncShellPending(viewModel);
+                            RefreshProposalSnapshotInHistory();
                             _storyModel?.RefreshCurrentView();
                             if (count > 0)
                                 AutoSaveFireAndForget("Accept All");
@@ -891,6 +1002,7 @@ public class Collaborator : ICollaborator
                                 _logger?.LogInformation("AcceptProperty: Staged Protect {Key}", propertyKey);
                                 PushPendingToViewModel(viewModel, result);
                                 await FlushStagedIfQueueDoneAsync();
+                                // Staged confirm marks accepted when applied
                                 return;
                             }
 
@@ -901,8 +1013,10 @@ public class Collaborator : ICollaborator
                                 _logger?.LogInformation("AcceptProperty: Applied {Key}", propertyKey);
                                 _auditLogger?.Log(StoryCADLib.Services.Logging.LogLevel.Info,
                                     $"Applied update: {propertyKey}");
+                                _sessionProposals?.MarkAccepted(propertyKey);
                                 RemovePendingKeys(new[] { propertyKey });
                                 PushPendingToViewModel(viewModel, result);
+                                RefreshProposalSnapshotInHistory();
                                 _storyModel?.RefreshCurrentView();
                                 await FlushStagedIfQueueDoneAsync();
                                 if (result.PendingUpdates.Count == 0 && !stageSession.HasStaged)
@@ -941,9 +1055,11 @@ public class Collaborator : ICollaborator
                             result.UpdatedProperties.Remove(propertyKey);
                             if (removed > 0)
                             {
+                                _sessionProposals?.MarkSkipped(propertyKey);
                                 viewModel.AddStatusMessage($"Skipped {propertyKey}");
                                 _logger?.LogInformation("SkipProperty: Skipped {Key}", propertyKey);
                                 PushPendingToViewModel(viewModel, result);
+                                RefreshProposalSnapshotInHistory();
                                 await FlushStagedIfQueueDoneAsync();
                                 if (result.PendingUpdates.Count == 0 && !stageSession.HasStaged)
                                 {
@@ -1004,17 +1120,19 @@ public class Collaborator : ICollaborator
 
                     var fillCount = result.PendingUpdates.Count(u => u.Kind is UpdateKind.Fill or UpdateKind.Refresh or UpdateKind.Unclassified);
                     var protectCount = result.PendingUpdates.Count(u => u.Kind == UpdateKind.Protect);
+                    // #145: clear chat, seed proposal set, unlock Send
+                    BeginProposalChatSession(viewModel, workflow, result);
                     viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
                         $"Found {result.PendingUpdates.Count} property update(s) " +
                         $"({fillCount} free, {protectCount} replace existing text — confirmation required). " +
-                        "Choose Accept All, Review Each, or Try Again."));
+                        "Choose Accept All, Review Each, or Try Again. Chat can revise these proposals."));
                 }
                 else
                 {
+                    viewModel.IsChatEnabled = false;
+                    viewModel.ChatPlaceholder = "No proposals to edit in chat";
                     viewModel.ConversationList.Add(ChatMessage.FromCollaborator("No property updates were extracted from the response."));
                 }
-
-                viewModel.ConversationList.Add(ChatMessage.FromCollaborator("You can ask questions or request changes using the chat below."));
             }
             else
             {

--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -635,7 +635,8 @@ public class Collaborator : ICollaborator
     }
 
     /// <summary>
-    /// Push open session proposals into WorkflowResult + Property Updates UI.
+    /// Push session proposals into WorkflowResult (open only for Accept) and
+    /// Property Updates UI (all statuses so Skip does not blank the panel — #145).
     /// </summary>
     private void SyncWorkflowResultFromSession()
     {
@@ -651,14 +652,62 @@ public class Collaborator : ICollaborator
             _activeWorkflowResult.UpdatedProperties[u.Key] = FormatValueForDisplay(u.Value);
         }
 
-        PushPendingToViewModel(_activeWorkflowViewModel, _activeWorkflowResult);
-        if (open.Count == 0)
+        PushSessionSetToViewModel(_activeWorkflowViewModel);
+    }
+
+    /// <summary>
+    /// Show the full session proposal set on the left (open + accepted + skipped).
+    /// Accept handlers still use <see cref="_activeWorkflowResult"/> open rows only.
+    /// </summary>
+    private void PushSessionSetToViewModel(
+        StoryCADLib.Collaborator.ViewModels.WorkflowViewModel viewModel)
+    {
+        if (_sessionProposals == null || _sessionProposals.Count == 0)
         {
-            _activeWorkflowViewModel.MarkUpdatesApplied();
-            SyncShellPending(_activeWorkflowViewModel);
+            viewModel.SetPendingUpdates(Array.Empty<PendingUpdateItem>());
+            SyncShellPending(viewModel);
+            return;
         }
-        else
-            SyncShellPending(_activeWorkflowViewModel);
+
+        var items = _sessionProposals.All
+            .OrderBy(e => e.Update.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(ToSessionPendingUpdateItem)
+            .ToList();
+        viewModel.SetPendingUpdates(items);
+        // Shell Accept All only when something is still open
+        if (_shellViewModel != null)
+            _shellViewModel.HasPendingUpdates = _sessionProposals.OpenCount > 0;
+    }
+
+    private PendingUpdateItem ToSessionPendingUpdateItem(SessionProposalSet.Entry e)
+    {
+        var u = e.Update with { Value = e.ProposedText };
+        var proposed = TruncateForChat(FormatValueForDisplay(u.Value), 500);
+        var current = TruncateForChat(u.CurrentDisplay ?? string.Empty, 300);
+        var kindLabel = e.Status switch
+        {
+            ProposalSessionStatus.Accepted => "Accepted",
+            ProposalSessionStatus.Skipped => "Skipped",
+            _ => u.Kind switch
+            {
+                UpdateKind.Fill => "New",
+                UpdateKind.Refresh => "Refresh",
+                UpdateKind.Protect => "Has your text",
+                _ => "Update"
+            }
+        };
+        return new PendingUpdateItem
+        {
+            Key = u.Key,
+            ElementName = u.ElementLabel,
+            PropertyDisplayName = u.Spec.Property,
+            ProposedDisplay = proposed,
+            CurrentDisplay = current,
+            KindLabel = kindLabel,
+            IsProtected = e.Status == ProposalSessionStatus.Open && u.Kind == UpdateKind.Protect,
+            CraftExplanation = u.CraftExplanation ?? string.Empty,
+            SummaryLine = kindLabel
+        };
     }
 
     /// <summary>
@@ -828,7 +877,10 @@ public class Collaborator : ICollaborator
 
                     void FinishPendingUi()
                     {
-                        if (result.PendingUpdates.Count == 0 && !stageSession.HasStaged)
+                        // Keep full session set visible (skipped/accepted stay on the left).
+                        if (_sessionProposals != null && _sessionProposals.Count > 0)
+                            PushSessionSetToViewModel(viewModel);
+                        else if (result.PendingUpdates.Count == 0 && !stageSession.HasStaged)
                         {
                             viewModel.MarkUpdatesApplied();
                             SyncShellPending(viewModel);
@@ -945,8 +997,7 @@ public class Collaborator : ICollaborator
                             _auditLogger?.Log(StoryCADLib.Services.Logging.LogLevel.Info,
                                 $"Applied {count} updates from workflow: {workflow.Title}");
 
-                            viewModel.MarkUpdatesApplied();
-                            SyncShellPending(viewModel);
+                            PushSessionSetToViewModel(viewModel);
                             RefreshProposalSnapshotInHistory();
                             _storyModel?.RefreshCurrentView();
                             if (count > 0)
@@ -1000,7 +1051,7 @@ public class Collaborator : ICollaborator
                                 RemovePendingKeys(new[] { propertyKey });
                                 viewModel.AddStatusMessage($"Queued overwrite: {propertyKey}");
                                 _logger?.LogInformation("AcceptProperty: Staged Protect {Key}", propertyKey);
-                                PushPendingToViewModel(viewModel, result);
+                                PushSessionSetToViewModel(viewModel);
                                 await FlushStagedIfQueueDoneAsync();
                                 // Staged confirm marks accepted when applied
                                 return;
@@ -1015,16 +1066,12 @@ public class Collaborator : ICollaborator
                                     $"Applied update: {propertyKey}");
                                 _sessionProposals?.MarkAccepted(propertyKey);
                                 RemovePendingKeys(new[] { propertyKey });
-                                PushPendingToViewModel(viewModel, result);
+                                PushSessionSetToViewModel(viewModel);
                                 RefreshProposalSnapshotInHistory();
                                 _storyModel?.RefreshCurrentView();
                                 await FlushStagedIfQueueDoneAsync();
                                 if (result.PendingUpdates.Count == 0 && !stageSession.HasStaged)
-                                {
-                                    viewModel.MarkUpdatesApplied();
-                                    SyncShellPending(viewModel);
                                     AutoSaveFireAndForget("AcceptProperty");
-                                }
                             }
                             else
                             {
@@ -1058,14 +1105,9 @@ public class Collaborator : ICollaborator
                                 _sessionProposals?.MarkSkipped(propertyKey);
                                 viewModel.AddStatusMessage($"Skipped {propertyKey}");
                                 _logger?.LogInformation("SkipProperty: Skipped {Key}", propertyKey);
-                                PushPendingToViewModel(viewModel, result);
+                                PushSessionSetToViewModel(viewModel);
                                 RefreshProposalSnapshotInHistory();
                                 await FlushStagedIfQueueDoneAsync();
-                                if (result.PendingUpdates.Count == 0 && !stageSession.HasStaged)
-                                {
-                                    viewModel.MarkUpdatesApplied();
-                                    SyncShellPending(viewModel);
-                                }
                             }
                             else
                             {
@@ -1120,8 +1162,9 @@ public class Collaborator : ICollaborator
 
                     var fillCount = result.PendingUpdates.Count(u => u.Kind is UpdateKind.Fill or UpdateKind.Refresh or UpdateKind.Unclassified);
                     var protectCount = result.PendingUpdates.Count(u => u.Kind == UpdateKind.Protect);
-                    // #145: clear chat, seed proposal set, unlock Send
+                    // #145: clear chat, seed proposal set, unlock Send; show full set on the left
                     BeginProposalChatSession(viewModel, workflow, result);
+                    PushSessionSetToViewModel(viewModel);
                     viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
                         $"Found {result.PendingUpdates.Count} property update(s) " +
                         $"({fillCount} free, {protectCount} replace existing text — confirmation required). " +

--- a/CollaboratorLib/Services/ChatPatchParser.cs
+++ b/CollaboratorLib/Services/ChatPatchParser.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace StoryCollaborator.Services;
+
+/// <summary>
+/// Collaborator #145: extract JSON patches from a chat model reply and a human-visible remainder.
+/// </summary>
+public static class ChatPatchParser
+{
+    private static readonly Regex FencedJson = new(
+        @"```(?:json)?\s*(\{[\s\S]*?\})\s*```",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex LoosePatchesObject = new(
+        @"\{\s*""patches""\s*:\s*\[[\s\S]*?\]\s*\}",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    public readonly record struct Patch(string Key, string Value);
+
+    /// <summary>
+    /// Always returns true for non-null input; patches may be empty.
+    /// </summary>
+    public static bool TryParse(string? raw, out string displayText, out IReadOnlyList<Patch> patches)
+    {
+        displayText = raw?.Trim() ?? string.Empty;
+        patches = Array.Empty<Patch>();
+        if (string.IsNullOrWhiteSpace(raw))
+            return true;
+
+        var list = new List<Patch>();
+        var working = raw;
+
+        foreach (Match m in FencedJson.Matches(raw))
+        {
+            if (TryReadPatchesObject(m.Groups[1].Value, list))
+                working = working.Replace(m.Value, "\n");
+        }
+
+        // Unfenced object containing "patches"
+        foreach (Match m in LoosePatchesObject.Matches(working))
+        {
+            if (TryReadPatchesObject(m.Value, list))
+                working = working.Replace(m.Value, "\n");
+        }
+
+        // Entire reply is the JSON object
+        if (list.Count == 0 && raw.TrimStart().StartsWith('{'))
+            TryReadPatchesObject(raw.Trim(), list);
+
+        patches = list;
+        displayText = CollapseBlankLines(working.Trim());
+        if (string.IsNullOrWhiteSpace(displayText) && list.Count > 0)
+            displayText = list.Count == 1
+                ? $"Updated {list[0].Key}."
+                : $"Updated {list.Count} proposals.";
+        return true;
+    }
+
+    private static bool TryReadPatchesObject(string json, List<Patch> into)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("patches", out var arr) ||
+                arr.ValueKind != JsonValueKind.Array)
+                return false;
+
+            var any = false;
+            foreach (var el in arr.EnumerateArray())
+            {
+                if (!el.TryGetProperty("key", out var k) || !el.TryGetProperty("value", out var v))
+                    continue;
+                var key = k.GetString();
+                if (string.IsNullOrWhiteSpace(key))
+                    continue;
+                var value = v.ValueKind == JsonValueKind.String
+                    ? v.GetString() ?? string.Empty
+                    : v.ToString();
+                into.Add(new Patch(key.Trim(), value));
+                any = true;
+            }
+            return any;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static string CollapseBlankLines(string s)
+    {
+        var lines = s.Replace("\r\n", "\n").Split('\n')
+            .Select(l => l.TrimEnd())
+            .ToList();
+        var sb = new System.Text.StringBuilder();
+        var blank = false;
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                if (!blank && sb.Length > 0)
+                {
+                    sb.AppendLine();
+                    blank = true;
+                }
+                continue;
+            }
+            sb.AppendLine(line);
+            blank = false;
+        }
+        return sb.ToString().Trim();
+    }
+}

--- a/CollaboratorLib/Services/SessionProposalSet.cs
+++ b/CollaboratorLib/Services/SessionProposalSet.cs
@@ -1,0 +1,130 @@
+using System.Text;
+using StoryCollaborator.Models;
+
+namespace StoryCollaborator.Services;
+
+/// <summary>Status of one proposal in the chat session set (#145).</summary>
+public enum ProposalSessionStatus
+{
+    Open,
+    Accepted,
+    Skipped
+}
+
+/// <summary>
+/// Full proposal set from the last workflow run for the chat session (#145).
+/// Keys survive Accept/Skip; chat may patch any key; unknown keys are rejected.
+/// </summary>
+public sealed class SessionProposalSet
+{
+    private readonly Dictionary<string, Entry> _entries =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public int Count => _entries.Count;
+
+    public bool ContainsKey(string key) => _entries.ContainsKey(key);
+
+    public Entry? Get(string key) =>
+        _entries.TryGetValue(key, out var e) ? e : null;
+
+    public IEnumerable<Entry> All => _entries.Values;
+
+    /// <summary>Replace session set from a new workflow extract (open rows).</summary>
+    public void ReplaceFromPending(IEnumerable<PendingUpdate> pending)
+    {
+        _entries.Clear();
+        foreach (var u in pending)
+        {
+            _entries[u.Key] = new Entry(u, ProposalSessionStatus.Open, FormatValue(u.Value));
+        }
+    }
+
+    public void MarkAccepted(string key)
+    {
+        if (_entries.TryGetValue(key, out var e))
+            _entries[key] = e with { Status = ProposalSessionStatus.Accepted };
+    }
+
+    public void MarkSkipped(string key)
+    {
+        if (_entries.TryGetValue(key, out var e))
+            _entries[key] = e with { Status = ProposalSessionStatus.Skipped };
+    }
+
+    /// <summary>
+    /// Apply a chat patch. Re-opens Accepted/Skipped as Open.
+    /// Returns false if key is not in the session set.
+    /// </summary>
+    public bool TryApplyPatch(string key, string newValue, out bool reopened)
+    {
+        reopened = false;
+        if (!_entries.TryGetValue(key, out var e))
+            return false;
+
+        reopened = e.Status is ProposalSessionStatus.Accepted or ProposalSessionStatus.Skipped;
+        var updatedUpdate = e.Update with { Value = newValue };
+        _entries[key] = e with
+        {
+            Update = updatedUpdate,
+            ProposedText = newValue ?? string.Empty,
+            Status = ProposalSessionStatus.Open
+        };
+        return true;
+    }
+
+    public IEnumerable<PendingUpdate> OpenAsPendingUpdates() =>
+        _entries.Values
+            .Where(e => e.Status == ProposalSessionStatus.Open)
+            .Select(e => e.Update with { Value = e.ProposedText });
+
+    /// <summary>Plain-text snapshot for chat history seed / refresh.</summary>
+    public string BuildSnapshotText(int maxValueChars = 280)
+    {
+        if (_entries.Count == 0)
+            return "(No proposals in this session.)";
+
+        var sb = new StringBuilder();
+        sb.AppendLine("Property proposals for this workflow run:");
+        foreach (var e in _entries.Values.OrderBy(x => x.Update.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            var status = e.Status switch
+            {
+                ProposalSessionStatus.Open => "open",
+                ProposalSessionStatus.Accepted => "accepted",
+                ProposalSessionStatus.Skipped => "skipped",
+                _ => "?"
+            };
+            var val = e.ProposedText ?? string.Empty;
+            if (val.Length > maxValueChars)
+                val = val.Substring(0, maxValueChars) + "…";
+            val = val.Replace("\r\n", " ").Replace("\n", " ");
+            sb.AppendLine($"- {e.Update.Key} [{status}]: {val}");
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    public static string BuildSystemInstructions(string workflowTitle) =>
+        "You help revise property proposals from the '" + workflowTitle + "' workflow run. " +
+        "This is not general story chat and you do not have the full outline loaded.\n\n" +
+        "Rules:\n" +
+        "- Answer the writer in plain text only (no Markdown).\n" +
+        "- You may only change keys listed in the property proposals snapshot.\n" +
+        "- If the writer wants a field changed, include a JSON block (optionally fenced) of the form: " +
+        "{\"patches\":[{\"key\":\"ElementLabel.Property\",\"value\":\"new text\"}]}\n" +
+        "- If the request is not about those proposals, say clearly it is out of scope for this chat. " +
+        "Do not invent patches. Suggest Accept, Try Again, another workflow, or editing the outline.\n" +
+        "- Do not invent element IDs or properties outside the proposal list.";
+
+    private static string FormatValue(object? value) =>
+        value switch
+        {
+            null => string.Empty,
+            string s => s,
+            _ => value.ToString() ?? string.Empty
+        };
+
+    public sealed record Entry(
+        PendingUpdate Update,
+        ProposalSessionStatus Status,
+        string ProposedText);
+}

--- a/CollaboratorLib/Services/SessionProposalSet.cs
+++ b/CollaboratorLib/Services/SessionProposalSet.cs
@@ -77,14 +77,17 @@ public sealed class SessionProposalSet
             .Where(e => e.Status == ProposalSessionStatus.Open)
             .Select(e => e.Update with { Value = e.ProposedText });
 
-    /// <summary>Plain-text snapshot for chat history seed / refresh.</summary>
-    public string BuildSnapshotText(int maxValueChars = 280)
+    /// <summary>
+    /// Plain-text snapshot for chat history seed / refresh.
+    /// Full proposal text (high cap) so "show me Description" works after Skip (#145 UX).
+    /// </summary>
+    public string BuildSnapshotText(int maxValueChars = 8000)
     {
         if (_entries.Count == 0)
             return "(No proposals in this session.)";
 
         var sb = new StringBuilder();
-        sb.AppendLine("Property proposals for this workflow run:");
+        sb.AppendLine("Property proposals for this workflow run (full text; status open/accepted/skipped):");
         foreach (var e in _entries.Values.OrderBy(x => x.Update.Key, StringComparer.OrdinalIgnoreCase))
         {
             var status = e.Status switch
@@ -95,13 +98,19 @@ public sealed class SessionProposalSet
                 _ => "?"
             };
             var val = e.ProposedText ?? string.Empty;
-            if (val.Length > maxValueChars)
+            if (maxValueChars > 0 && val.Length > maxValueChars)
                 val = val.Substring(0, maxValueChars) + "…";
-            val = val.Replace("\r\n", " ").Replace("\n", " ");
-            sb.AppendLine($"- {e.Update.Key} [{status}]: {val}");
+            // Keep newlines for long sketches; model needs readable prose
+            sb.AppendLine($"- {e.Update.Key} [{status}]:");
+            sb.AppendLine(val);
+            sb.AppendLine();
         }
         return sb.ToString().TrimEnd();
     }
+
+    /// <summary>Open count (still need Accept/Skip on the left list).</summary>
+    public int OpenCount =>
+        _entries.Values.Count(e => e.Status == ProposalSessionStatus.Open);
 
     public static string BuildSystemInstructions(string workflowTitle) =>
         "You help revise property proposals from the '" + workflowTitle + "' workflow run. " +

--- a/CollaboratorLib/Services/SessionProposalSet.cs
+++ b/CollaboratorLib/Services/SessionProposalSet.cs
@@ -35,7 +35,11 @@ public sealed class SessionProposalSet
         _entries.Clear();
         foreach (var u in pending)
         {
-            _entries[u.Key] = new Entry(u, ProposalSessionStatus.Open, FormatValue(u.Value));
+            // Keep full outline value at classify time — needed after Skip when the writer
+            // asks "what is this field now?" (outline text, not a truncated proposal).
+            var outline = u.CurrentDisplay ?? string.Empty;
+            _entries[u.Key] = new Entry(
+                u, ProposalSessionStatus.Open, FormatValue(u.Value), outline);
         }
     }
 
@@ -78,16 +82,20 @@ public sealed class SessionProposalSet
             .Select(e => e.Update with { Value = e.ProposedText });
 
     /// <summary>
-    /// Plain-text snapshot for chat history seed / refresh.
-    /// Full proposal text (high cap) so "show me Description" works after Skip (#145 UX).
+    /// Snapshot for chat history: full proposed text and full outline value at capture time.
+    /// After Skip, "as it is now" is OutlineText (what stayed on the story element).
     /// </summary>
-    public string BuildSnapshotText(int maxValueChars = 8000)
+    public string BuildSnapshotText(int maxValueChars = 0)
     {
         if (_entries.Count == 0)
             return "(No proposals in this session.)";
 
         var sb = new StringBuilder();
-        sb.AppendLine("Property proposals for this workflow run (full text; status open/accepted/skipped):");
+        sb.AppendLine("Property proposals for this workflow run.");
+        sb.AppendLine("For each key: status, Collaborator proposed text, and outline value when the run classified the field.");
+        sb.AppendLine("If status is skipped, the writer kept the outline value (use Outline for \"as it is now\").");
+        sb.AppendLine("If status is accepted, the outline should match what was accepted (use Proposed if Outline empty).");
+        sb.AppendLine();
         foreach (var e in _entries.Values.OrderBy(x => x.Update.Key, StringComparer.OrdinalIgnoreCase))
         {
             var status = e.Status switch
@@ -97,15 +105,24 @@ public sealed class SessionProposalSet
                 ProposalSessionStatus.Skipped => "skipped",
                 _ => "?"
             };
-            var val = e.ProposedText ?? string.Empty;
-            if (maxValueChars > 0 && val.Length > maxValueChars)
-                val = val.Substring(0, maxValueChars) + "…";
-            // Keep newlines for long sketches; model needs readable prose
-            sb.AppendLine($"- {e.Update.Key} [{status}]:");
-            sb.AppendLine(val);
+            sb.AppendLine($"### {e.Update.Key} [{status}]");
+            sb.AppendLine("Proposed (Collaborator):");
+            sb.AppendLine(Cap(e.ProposedText, maxValueChars));
+            sb.AppendLine("Outline (value on the story element when classified):");
+            sb.AppendLine(string.IsNullOrEmpty(e.OutlineText)
+                ? "(empty)"
+                : Cap(e.OutlineText, maxValueChars));
             sb.AppendLine();
         }
         return sb.ToString().TrimEnd();
+    }
+
+    private static string Cap(string? text, int maxValueChars)
+    {
+        var val = text ?? string.Empty;
+        if (maxValueChars > 0 && val.Length > maxValueChars)
+            return val.Substring(0, maxValueChars) + "…";
+        return val;
     }
 
     /// <summary>Open count (still need Accept/Skip on the left list).</summary>
@@ -114,15 +131,19 @@ public sealed class SessionProposalSet
 
     public static string BuildSystemInstructions(string workflowTitle) =>
         "You help revise property proposals from the '" + workflowTitle + "' workflow run. " +
-        "This is not general story chat and you do not have the full outline loaded.\n\n" +
+        "This is not general story chat and you do not have the full outline loaded beyond the snapshot.\n\n" +
         "Rules:\n" +
         "- Answer the writer in plain text only (no Markdown).\n" +
+        "- The snapshot gives, for each key: status, Proposed (Collaborator), and Outline (story element when classified).\n" +
+        "- If the writer asks what a field is \"now\" and status is skipped, quote the full Outline text from the snapshot.\n" +
+        "- If status is open, quote Proposed (and Outline if they ask what is already on the element).\n" +
+        "- If status is accepted, prefer Proposed as what was written.\n" +
         "- You may only change keys listed in the property proposals snapshot.\n" +
         "- If the writer wants a field changed, include a JSON block (optionally fenced) of the form: " +
         "{\"patches\":[{\"key\":\"ElementLabel.Property\",\"value\":\"new text\"}]}\n" +
         "- If the request is not about those proposals, say clearly it is out of scope for this chat. " +
         "Do not invent patches. Suggest Accept, Try Again, another workflow, or editing the outline.\n" +
-        "- Do not invent element IDs or properties outside the proposal list.";
+        "- Do not invent element IDs or properties outside the proposal list. Do not claim text is missing if Outline or Proposed is present in the snapshot.";
 
     private static string FormatValue(object? value) =>
         value switch
@@ -135,5 +156,6 @@ public sealed class SessionProposalSet
     public sealed record Entry(
         PendingUpdate Update,
         ProposalSessionStatus Status,
-        string ProposedText);
+        string ProposedText,
+        string OutlineText);
 }

--- a/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
@@ -134,6 +134,23 @@ public partial class WorkflowViewModel : ObservableRecipient
         set => SetProperty(ref _inputText, value);
     }
 
+    private bool _isChatEnabled;
+    /// <summary>
+    /// Collaborator #145: Send enabled only after workflow proposals are seeded into chat.
+    /// </summary>
+    public bool IsChatEnabled
+    {
+        get => _isChatEnabled;
+        set => SetProperty(ref _isChatEnabled, value);
+    }
+
+    private string _chatPlaceholder = "Waiting for proposals…";
+    public string ChatPlaceholder
+    {
+        get => _chatPlaceholder;
+        set => SetProperty(ref _chatPlaceholder, value ?? string.Empty);
+    }
+
     private string _promptOutput;
     public string PromptOutput
     {
@@ -368,6 +385,13 @@ public partial class WorkflowViewModel : ObservableRecipient
     public async Task SendButtonClicked()
     {
         if (string.IsNullOrWhiteSpace(InputText)) return;
+        if (!IsChatEnabled)
+        {
+            ConversationList.Add(ChatMessage.FromCollaborator(
+                "Chat unlocks after the workflow produces property proposals."));
+            InputText = string.Empty;
+            return;
+        }
 
         var userMessage = InputText;
         InputText = string.Empty;

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
@@ -329,6 +329,8 @@
             <AutoSuggestBox x:Name="InputTextBox"
                             Grid.Row="1"
                             HorizontalAlignment="Stretch"
+                            IsEnabled="{x:Bind ViewModel.IsChatEnabled, Mode=OneWay}"
+                            PlaceholderText="{x:Bind ViewModel.ChatPlaceholder, Mode=OneWay}"
                             Text="{x:Bind ViewModel.InputText, Mode=TwoWay}"
                             QuerySubmitted="InputTextBox_QuerySubmitted"
                             AutomationProperties.AutomationId="InputSearchBox"

--- a/StoryCADTests/Collaborator/ChatPatchParserTests.cs
+++ b/StoryCADTests/Collaborator/ChatPatchParserTests.cs
@@ -1,0 +1,58 @@
+using StoryCollaborator.Services;
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>Collaborator #145: parse JSON patches from chat replies.</summary>
+[TestClass]
+public class ChatPatchParserTests
+{
+    [TestMethod]
+    public void TryParse_ExtractsPatches_AndStripsJsonFromDisplay()
+    {
+        var raw =
+            "OK, renamed it.\n\n" +
+            "{\"patches\":[{\"key\":\"Problem.Name\",\"value\":\"Witch Prophecy\"}]}\n";
+
+        var ok = ChatPatchParser.TryParse(raw, out var display, out var patches);
+
+        Assert.IsTrue(ok);
+        Assert.AreEqual(1, patches.Count);
+        Assert.AreEqual("Problem.Name", patches[0].Key);
+        Assert.AreEqual("Witch Prophecy", patches[0].Value);
+        StringAssert.Contains(display, "OK, renamed");
+        Assert.IsFalse(display.Contains("patches", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
+    public void TryParse_MultiplePatches()
+    {
+        var raw = """{"patches":[{"key":"Problem.Name","value":"A"},{"key":"Problem.Premise","value":"B"}]}""";
+
+        Assert.IsTrue(ChatPatchParser.TryParse(raw, out _, out var patches));
+        Assert.AreEqual(2, patches.Count);
+    }
+
+    [TestMethod]
+    public void TryParse_NoJson_ReturnsDisplayOnly_EmptyPatches()
+    {
+        var raw = "That's outside this proposal chat.";
+
+        var ok = ChatPatchParser.TryParse(raw, out var display, out var patches);
+
+        Assert.IsTrue(ok);
+        Assert.AreEqual(0, patches.Count);
+        Assert.AreEqual(raw, display.Trim());
+    }
+
+    [TestMethod]
+    public void TryParse_EmbeddedInFences()
+    {
+        var raw =
+            "Done.\n```json\n{\"patches\":[{\"key\":\"Overview.Concept\",\"value\":\"Shorter\"}]}\n```\n";
+
+        Assert.IsTrue(ChatPatchParser.TryParse(raw, out var display, out var patches));
+        Assert.AreEqual(1, patches.Count);
+        Assert.AreEqual("Overview.Concept", patches[0].Key);
+        Assert.IsFalse(display.Contains("```"));
+    }
+}

--- a/StoryCADTests/Collaborator/SessionProposalSetTests.cs
+++ b/StoryCADTests/Collaborator/SessionProposalSetTests.cs
@@ -7,8 +7,10 @@ namespace StoryCADTests.Collaborator;
 [TestClass]
 public class SessionProposalSetTests
 {
-    private static PendingUpdate Make(string label, string prop, string value, UpdateKind kind = UpdateKind.Fill) =>
-        new(label, Guid.NewGuid(), new PropertySpec(prop), value, kind, "current");
+    private static PendingUpdate Make(
+        string label, string prop, string value,
+        UpdateKind kind = UpdateKind.Fill, string? current = "current") =>
+        new(label, Guid.NewGuid(), new PropertySpec(prop), value, kind, current);
 
     [TestMethod]
     public void LoadFromPending_KeepsAllKeys()
@@ -61,19 +63,25 @@ public class SessionProposalSetTests
     }
 
     [TestMethod]
-    public void BuildSnapshotText_IncludesStatus_AndFullLongText()
+    public void BuildSnapshotText_IncludesProposedAndOutline_FullTextAfterSkip()
     {
         var set = new SessionProposalSet();
-        var longSketch = new string('x', 500) + " END";
-        set.ReplaceFromPending(new[] { Make("Character", "Description", longSketch) });
+        var proposed = "PROPOSED sketch " + new string('p', 400);
+        var outline = "OUTLINE sketch " + new string('o', 400) + " END_OUTLINE";
+        set.ReplaceFromPending(new[]
+        {
+            Make("Character", "Description", proposed, UpdateKind.Protect, outline)
+        });
         set.MarkSkipped("Character.Description");
 
         var snap = set.BuildSnapshotText();
         StringAssert.Contains(snap, "Character.Description");
         StringAssert.Contains(snap, "skipped");
-        StringAssert.Contains(snap, " END");
-        Assert.IsFalse(snap.Contains('…') && !snap.Contains(" END"),
-            "Default snapshot should not truncate a 500-char sketch");
+        StringAssert.Contains(snap, "Proposed (Collaborator):");
+        StringAssert.Contains(snap, "Outline (value on the story element when classified):");
+        StringAssert.Contains(snap, " END_OUTLINE");
+        StringAssert.Contains(snap, proposed.Substring(0, 40));
+        Assert.IsFalse(snap.Contains('…'), "Default snapshot must not truncate outline/proposed");
     }
 
     [TestMethod]

--- a/StoryCADTests/Collaborator/SessionProposalSetTests.cs
+++ b/StoryCADTests/Collaborator/SessionProposalSetTests.cs
@@ -1,0 +1,88 @@
+using StoryCollaborator.Models;
+using StoryCollaborator.Services;
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>Collaborator #145: full session proposal set for chat.</summary>
+[TestClass]
+public class SessionProposalSetTests
+{
+    private static PendingUpdate Make(string label, string prop, string value, UpdateKind kind = UpdateKind.Fill) =>
+        new(label, Guid.NewGuid(), new PropertySpec(prop), value, kind, "current");
+
+    [TestMethod]
+    public void LoadFromPending_KeepsAllKeys()
+    {
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(new[]
+        {
+            Make("Problem", "Name", "Prophecy of the Crown"),
+            Make("Problem", "Premise", "Long premise", UpdateKind.Protect),
+        });
+
+        Assert.AreEqual(2, set.Count);
+        Assert.IsTrue(set.ContainsKey("Problem.Name"));
+        Assert.AreEqual(ProposalSessionStatus.Open, set.Get("Problem.Name")!.Status);
+    }
+
+    [TestMethod]
+    public void MarkAccepted_DoesNotRemove_AllowsPatchAndReopen()
+    {
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(new[] { Make("Overview", "Concept", "Wordy concept") });
+
+        set.MarkAccepted("Overview.Concept");
+        Assert.AreEqual(ProposalSessionStatus.Accepted, set.Get("Overview.Concept")!.Status);
+
+        Assert.IsTrue(set.TryApplyPatch("Overview.Concept", "Three what-ifs only", out var reopened));
+        Assert.IsTrue(reopened);
+        Assert.AreEqual(ProposalSessionStatus.Open, set.Get("Overview.Concept")!.Status);
+        Assert.AreEqual("Three what-ifs only", set.Get("Overview.Concept")!.ProposedText);
+    }
+
+    [TestMethod]
+    public void MarkSkipped_StillPatchable()
+    {
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(new[] { Make("Problem", "Description", "Story Q") });
+        set.MarkSkipped("Problem.Description");
+
+        Assert.IsTrue(set.TryApplyPatch("Problem.Description", "Revised Q", out _));
+        Assert.AreEqual(ProposalSessionStatus.Open, set.Get("Problem.Description")!.Status);
+    }
+
+    [TestMethod]
+    public void TryApplyPatch_UnknownKey_Fails()
+    {
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(new[] { Make("Problem", "Name", "A") });
+
+        Assert.IsFalse(set.TryApplyPatch("Problem.Theme", "No", out _));
+    }
+
+    [TestMethod]
+    public void BuildSnapshotText_IncludesStatus()
+    {
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(new[] { Make("Problem", "Name", "Prophecy") });
+        set.MarkSkipped("Problem.Name");
+
+        var snap = set.BuildSnapshotText();
+        StringAssert.Contains(snap, "Problem.Name");
+        StringAssert.Contains(snap, "skipped");
+    }
+
+    [TestMethod]
+    public void OpenProposals_AsPendingUpdates_ForUi()
+    {
+        var set = new SessionProposalSet();
+        var a = Make("Problem", "Name", "A");
+        var b = Make("Problem", "Premise", "B");
+        set.ReplaceFromPending(new[] { a, b });
+        set.MarkAccepted("Problem.Name");
+
+        var open = set.OpenAsPendingUpdates().ToList();
+        Assert.AreEqual(1, open.Count);
+        Assert.AreEqual("Problem.Premise", open[0].Key);
+    }
+}

--- a/StoryCADTests/Collaborator/SessionProposalSetTests.cs
+++ b/StoryCADTests/Collaborator/SessionProposalSetTests.cs
@@ -61,15 +61,19 @@ public class SessionProposalSetTests
     }
 
     [TestMethod]
-    public void BuildSnapshotText_IncludesStatus()
+    public void BuildSnapshotText_IncludesStatus_AndFullLongText()
     {
         var set = new SessionProposalSet();
-        set.ReplaceFromPending(new[] { Make("Problem", "Name", "Prophecy") });
-        set.MarkSkipped("Problem.Name");
+        var longSketch = new string('x', 500) + " END";
+        set.ReplaceFromPending(new[] { Make("Character", "Description", longSketch) });
+        set.MarkSkipped("Character.Description");
 
         var snap = set.BuildSnapshotText();
-        StringAssert.Contains(snap, "Problem.Name");
+        StringAssert.Contains(snap, "Character.Description");
         StringAssert.Contains(snap, "skipped");
+        StringAssert.Contains(snap, " END");
+        Assert.IsFalse(snap.Contains('…') && !snap.Contains(" END"),
+            "Default snapshot should not truncate a 500-char sketch");
     }
 
     [TestMethod]

--- a/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
@@ -19,6 +19,9 @@ public class WorkflowViewModelTests
     public void Setup()
     {
         _viewModel = new WorkflowViewModel();
+        // #145: production leaves Send locked until proposals seed; unit tests of send
+        // path enable chat explicitly.
+        _viewModel.IsChatEnabled = true;
     }
 
     #region Constructor Tests
@@ -246,6 +249,26 @@ public class WorkflowViewModelTests
     #endregion
 
     #region SendButtonClicked Tests
+
+    [TestMethod]
+    public async Task SendButtonClicked_WhenChatDisabled_DoesNotInvokeCallback()
+    {
+        _viewModel.IsChatEnabled = false;
+        _viewModel.InputText = "Hello";
+        var invoked = false;
+        _viewModel.OnSendMessage = _ =>
+        {
+            invoked = true;
+            return Task.FromResult("x");
+        };
+
+        await _viewModel.SendButtonClicked();
+
+        Assert.IsFalse(invoked);
+        Assert.AreEqual(1, _viewModel.ConversationList.Count);
+        Assert.IsFalse(_viewModel.ConversationList[0].IsUser);
+        StringAssert.Contains(_viewModel.ConversationList[0].Text, "unlocks");
+    }
 
     [TestMethod]
     public async Task SendButtonClicked_WithEmptyInput_DoesNotAddToConversation()


### PR DESCRIPTION
## Summary
Implements [Collaborator #145](https://github.com/storybuilder-org/Collaborator/issues/145) (see \devdocs/chat_vs_workflow_design.md\ on Collaborator).

- After workflow one-shot: clear chat, seed full **session proposal set**, unlock Send
- Chat replies may include JSON \patches\; app updates proposals (re-opens Accepted/Skipped as open)
- Accept still writes outline; Protect rules unchanged
- Mid-chat: refresh proposal snapshot in history; keep conversation turns
- Unit tests: ChatPatchParser + SessionProposalSet (10)

## Test plan
- [x] Unit tests 10/10
- [x] Manual: workflow → chat rename a field → left list updates → Accept
- [x] Manual: out-of-scope ask → model should refuse (prompt-dependent)
- [x] Manual: Accept then chat prune → row re-opens for Accept
