### PR TITLE
fix: Review Each advances past Skipped/Accepted rows (#145 regression)

### DIFF
--- a/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
@@ -442,16 +442,9 @@ public partial class WorkflowViewModel : ObservableRecipient
         if (!HasPendingUpdates) return;
 
         IsInReviewMode = true;
-        // Start on first open row (skip already Accepted/Skipped session rows — #145).
-        var firstOpen = IndexOfNextOpenForReview(fromIndex: 0);
-        if (firstOpen < 0)
-        {
-            IsInReviewMode = false;
-            NotifyReviewProperties();
-            return;
-        }
-
-        CurrentReviewIndex = firstOpen;
+        CurrentReviewIndex = 0;
+        // One forward pass: land on first open row (or exit if none).
+        AdvancePastSettledRows();
         NotifyReviewProperties();
     }
 
@@ -542,68 +535,43 @@ public partial class WorkflowViewModel : ObservableRecipient
     }
 
     /// <summary>
-    /// True when Review Each should still walk this row (not session-settled).
-    /// #145 keeps Accepted/Skipped on the list for chat; they are not review targets.
+    /// Settled rows (Accepted/Skipped) are done for Review Each. One list, one forward pass:
+    /// foreach item → accept or skip → next. No wrap-around.
     /// </summary>
-    private static bool IsOpenForReview(PendingUpdateItem? item)
+    private static bool IsSettled(PendingUpdateItem? item)
     {
-        if (item == null) return false;
+        if (item == null) return true;
         var kind = item.KindLabel ?? string.Empty;
-        if (kind.Equals("Skipped", StringComparison.OrdinalIgnoreCase)) return false;
-        if (kind.Equals("Accepted", StringComparison.OrdinalIgnoreCase)) return false;
-        return true;
+        return kind.Equals("Skipped", StringComparison.OrdinalIgnoreCase)
+            || kind.Equals("Accepted", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
-    /// Next open review index at or after <paramref name="fromIndex"/>, else earlier open, else -1.
+    /// After accept/skip (or on enter review): sit on an open row walking forward only.
+    /// If the current row was removed, the next open item is already at this index (#115) — stay.
+    /// If the current row is settled (#145), move forward until open or past the end.
     /// </summary>
-    private int IndexOfNextOpenForReview(int fromIndex)
+    private void AdvancePastSettledRows()
     {
         if (PendingUpdateItems == null || PendingUpdateItems.Count == 0)
-            return -1;
-
-        fromIndex = Math.Max(0, fromIndex);
-        for (var i = fromIndex; i < PendingUpdateItems.Count; i++)
         {
-            if (IsOpenForReview(PendingUpdateItems[i]))
-                return i;
+            IsInReviewMode = false;
+            return;
         }
 
-        for (var i = 0; i < fromIndex && i < PendingUpdateItems.Count; i++)
+        while (CurrentReviewIndex < PendingUpdateItems.Count
+               && IsSettled(PendingUpdateItems[CurrentReviewIndex]))
         {
-            if (IsOpenForReview(PendingUpdateItems[i]))
-                return i;
+            CurrentReviewIndex++;
         }
 
-        return -1;
+        if (CurrentReviewIndex >= PendingUpdateItems.Count)
+            IsInReviewMode = false;
     }
 
-    /// <summary>
-    /// After accept/skip: if the row was removed, the next open item is at the same index (#115).
-    /// If the row stayed as Accepted/Skipped (#145), move to the next open row.
-    /// Exit review when no open rows remain (settled rows may still show in the list).
-    /// </summary>
     private void AdvanceReview()
     {
-        if (PendingUpdateItems == null || PendingUpdateItems.Count == 0)
-        {
-            IsInReviewMode = false;
-            // Do not ClearPendingUpdates — empty list only; #145 may rebuild settled rows.
-            NotifyReviewProperties();
-            return;
-        }
-
-        // Prefer current index when the row under review is still open (removal case: next slid in).
-        // If current is settled, search from here for the next open.
-        var next = IndexOfNextOpenForReview(CurrentReviewIndex);
-        if (next < 0)
-        {
-            IsInReviewMode = false;
-            NotifyReviewProperties();
-            return;
-        }
-
-        CurrentReviewIndex = next;
+        AdvancePastSettledRows();
         NotifyReviewProperties();
     }
 
@@ -646,20 +614,9 @@ public partial class WorkflowViewModel : ObservableRecipient
 
         UpdatesApplied = false;
 
-        // Review Each + #145: list may keep Skipped/Accepted rows. Stay on an open row.
+        // Review Each: one forward pass; skip settled rows after list rebuild (#145).
         if (IsInReviewMode)
-        {
-            if (PendingUpdateItems.Count == 0)
-                IsInReviewMode = false;
-            else
-            {
-                var open = IndexOfNextOpenForReview(CurrentReviewIndex);
-                if (open < 0)
-                    IsInReviewMode = false;
-                else
-                    CurrentReviewIndex = open;
-            }
-        }
+            AdvancePastSettledRows();
 
         OnPropertyChanged(nameof(PendingUpdateItems));
         OnPropertyChanged(nameof(HasUpdates));

--- a/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
@@ -441,8 +441,17 @@ public partial class WorkflowViewModel : ObservableRecipient
     {
         if (!HasPendingUpdates) return;
 
-        CurrentReviewIndex = 0;
         IsInReviewMode = true;
+        // Start on first open row (skip already Accepted/Skipped session rows — #145).
+        var firstOpen = IndexOfNextOpenForReview(fromIndex: 0);
+        if (firstOpen < 0)
+        {
+            IsInReviewMode = false;
+            NotifyReviewProperties();
+            return;
+        }
+
+        CurrentReviewIndex = firstOpen;
         NotifyReviewProperties();
     }
 
@@ -533,26 +542,68 @@ public partial class WorkflowViewModel : ObservableRecipient
     }
 
     /// <summary>
-    /// After accept/skip, Collaborator removes the current key from the list.
-    /// The next item slides into the same index — do not increment (#115).
+    /// True when Review Each should still walk this row (not session-settled).
+    /// #145 keeps Accepted/Skipped on the list for chat; they are not review targets.
+    /// </summary>
+    private static bool IsOpenForReview(PendingUpdateItem? item)
+    {
+        if (item == null) return false;
+        var kind = item.KindLabel ?? string.Empty;
+        if (kind.Equals("Skipped", StringComparison.OrdinalIgnoreCase)) return false;
+        if (kind.Equals("Accepted", StringComparison.OrdinalIgnoreCase)) return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Next open review index at or after <paramref name="fromIndex"/>, else earlier open, else -1.
+    /// </summary>
+    private int IndexOfNextOpenForReview(int fromIndex)
+    {
+        if (PendingUpdateItems == null || PendingUpdateItems.Count == 0)
+            return -1;
+
+        fromIndex = Math.Max(0, fromIndex);
+        for (var i = fromIndex; i < PendingUpdateItems.Count; i++)
+        {
+            if (IsOpenForReview(PendingUpdateItems[i]))
+                return i;
+        }
+
+        for (var i = 0; i < fromIndex && i < PendingUpdateItems.Count; i++)
+        {
+            if (IsOpenForReview(PendingUpdateItems[i]))
+                return i;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// After accept/skip: if the row was removed, the next open item is at the same index (#115).
+    /// If the row stayed as Accepted/Skipped (#145), move to the next open row.
+    /// Exit review when no open rows remain (settled rows may still show in the list).
     /// </summary>
     private void AdvanceReview()
     {
         if (PendingUpdateItems == null || PendingUpdateItems.Count == 0)
         {
             IsInReviewMode = false;
-            ClearPendingUpdates();
+            // Do not ClearPendingUpdates — empty list only; #145 may rebuild settled rows.
+            NotifyReviewProperties();
             return;
         }
 
-        if (CurrentReviewIndex >= PendingUpdateItems.Count)
+        // Prefer current index when the row under review is still open (removal case: next slid in).
+        // If current is settled, search from here for the next open.
+        var next = IndexOfNextOpenForReview(CurrentReviewIndex);
+        if (next < 0)
         {
             IsInReviewMode = false;
-            if (PendingUpdateItems.Count == 0)
-                ClearPendingUpdates();
+            NotifyReviewProperties();
             return;
         }
 
+        CurrentReviewIndex = next;
         NotifyReviewProperties();
     }
 
@@ -595,14 +646,19 @@ public partial class WorkflowViewModel : ObservableRecipient
 
         UpdatesApplied = false;
 
-        // Inline ticks can shrink the list while Review Each is walking it (#129):
-        // exit review when it empties, clamp the index when it points past the end.
+        // Review Each + #145: list may keep Skipped/Accepted rows. Stay on an open row.
         if (IsInReviewMode)
         {
             if (PendingUpdateItems.Count == 0)
                 IsInReviewMode = false;
-            else if (CurrentReviewIndex >= PendingUpdateItems.Count)
-                CurrentReviewIndex = PendingUpdateItems.Count - 1;
+            else
+            {
+                var open = IndexOfNextOpenForReview(CurrentReviewIndex);
+                if (open < 0)
+                    IsInReviewMode = false;
+                else
+                    CurrentReviewIndex = open;
+            }
         }
 
         OnPropertyChanged(nameof(PendingUpdateItems));

--- a/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
@@ -457,6 +457,33 @@ public class WorkflowViewModelTests
         };
     }
 
+    /// <summary>
+    /// #145: skip/accept keeps the row and marks KindLabel settled (session proposal set).
+    /// </summary>
+    private void WireMarkSettledOnAcceptOrSkip(List<PendingUpdateItem> store)
+    {
+        void Mark(string key, string kind)
+        {
+            var item = store.Find(i => i.Key == key);
+            if (item == null) return;
+            item.KindLabel = kind;
+            item.SummaryLine = kind;
+            item.IsProtected = false;
+            _viewModel.SetPendingUpdates(store);
+        }
+
+        _viewModel.OnAcceptProperty = key =>
+        {
+            Mark(key, "Accepted");
+            return Task.CompletedTask;
+        };
+        _viewModel.OnSkipProperty = key =>
+        {
+            Mark(key, "Skipped");
+            return Task.CompletedTask;
+        };
+    }
+
     [TestMethod]
     public void PendingUpdatesHeader_ReflectsFreeAndProtectedCounts()
     {
@@ -546,6 +573,36 @@ public class WorkflowViewModelTests
         _viewModel.AcceptCurrentCommand.Execute(null);
         Assert.AreEqual(0, store.Count);
         Assert.IsFalse(_viewModel.IsInReviewMode);
+    }
+
+    [TestMethod]
+    public void ReviewEach_SkipWhenRowsStayOnList_AdvancesPastSkipped()
+    {
+        // Regression #145: session set keeps Skipped rows; Review must not stick forever.
+        var store = new List<PendingUpdateItem>
+        {
+            Item("Antagonist.Name", "Ewan"),
+            Item("Problem.Premise", "p"),
+            Item("Problem.Theme", "t")
+        };
+        _viewModel.SetPendingUpdates(store);
+        WireMarkSettledOnAcceptOrSkip(store);
+        _viewModel.ReviewEachCommand.Execute(null);
+
+        Assert.AreEqual("Antagonist.Name", _viewModel.CurrentReviewKey);
+
+        _viewModel.SkipCurrentCommand.Execute(null);
+        Assert.AreEqual("Problem.Premise", _viewModel.CurrentReviewKey,
+            "After skip, review must move to next open row (not stay on Skipped Name).");
+        Assert.AreEqual(3, store.Count, "All rows remain on the session list");
+        Assert.AreEqual("Skipped", store.Find(i => i.Key == "Antagonist.Name")!.KindLabel);
+
+        _viewModel.SkipCurrentCommand.Execute(null);
+        Assert.AreEqual("Problem.Theme", _viewModel.CurrentReviewKey);
+
+        _viewModel.SkipCurrentCommand.Execute(null);
+        Assert.IsFalse(_viewModel.IsInReviewMode, "Review ends when no open rows remain");
+        Assert.AreEqual(3, _viewModel.PendingUpdateItems.Count, "Settled rows stay visible");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
Regression after #145: Skip marks a row **Skipped** but leaves it on the Property Updates list. Review Each still assumed the row was **removed** (#115), so Skip stayed on the same item forever.

## Fix
- Review walks **open** rows only (not KindLabel Skipped/Accepted).
- After accept/skip, advance to the next open row; exit review when none remain.
- Settled rows can stay visible for chat; they are not re-reviewed.

## Test plan
- [x] Existing Review Each remove-on-skip tests
- [x] New: `ReviewEach_SkipWhenRowsStayOnList_AdvancesPastSkipped`
- [ ] Manual: Story Problem Review Each → Skip first row → next open field
