### PR TITLE
fix: Review Each stuck after Accept on Protect (Has your text)

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -925,6 +925,10 @@ public class Collaborator : ICollaborator
                         }
                         else
                         {
+                            // Writer refused overwrites: session was already MarkAccepted for Review
+                            // Each advance — flip to Skipped so chat/snapshot match the outline.
+                            foreach (var u in staged)
+                                _sessionProposals?.MarkSkipped(u.Key);
                             viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
                                 $"Cancelled: left {staged.Count} existing field(s) unchanged."));
                             _logger?.LogInformation("StagedProtect cancelled: {Count}", staged.Count);
@@ -1047,13 +1051,16 @@ public class Collaborator : ICollaborator
                             if (pending.Kind == UpdateKind.Protect)
                             {
                                 // Stage overwrite; confirm once when the queue is fully decided (#140).
+                                // Mark Accepted in the session set now so Review Each can leave the row
+                                // (IsSettled). Without this, KindLabel stays "Has your text",
+                                // AdvancePastSettledRows never moves, and Accept looks stuck.
                                 stageSession.StageProtect(pending);
                                 RemovePendingKeys(new[] { propertyKey });
+                                _sessionProposals?.MarkAccepted(propertyKey);
                                 viewModel.AddStatusMessage($"Queued overwrite: {propertyKey}");
                                 _logger?.LogInformation("AcceptProperty: Staged Protect {Key}", propertyKey);
                                 PushSessionSetToViewModel(viewModel);
                                 await FlushStagedIfQueueDoneAsync();
-                                // Staged confirm marks accepted when applied
                                 return;
                             }
 
@@ -1131,7 +1138,10 @@ public class Collaborator : ICollaborator
                             RemovePendingKeys(free.Select(u => u.Key));
 
                             foreach (var u in protect)
+                            {
                                 stageSession.StageProtect(u);
+                                _sessionProposals?.MarkAccepted(u.Key);
+                            }
                             RemovePendingKeys(protect.Select(u => u.Key));
 
                             if (freeCount > 0)
@@ -1140,7 +1150,11 @@ public class Collaborator : ICollaborator
                                     $"Applied {freeCount} free update(s)."));
                             }
 
-                            PushPendingToViewModel(viewModel, result);
+                            // Prefer session set so staged Protect show as Accepted for Review Each.
+                            if (_sessionProposals != null && _sessionProposals.Count > 0)
+                                PushSessionSetToViewModel(viewModel);
+                            else
+                                PushPendingToViewModel(viewModel, result);
                             _storyModel?.RefreshCurrentView();
                             await FlushStagedIfQueueDoneAsync();
 

--- a/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
@@ -549,6 +549,56 @@ public class WorkflowViewModelTests
         Assert.AreEqual(0, store.Count, "All three accepts must leave nothing discarded.");
     }
 
+    /// <summary>
+    /// Protect Accept must mark KindLabel Accepted (session set). Leaving
+    /// "Has your text" makes AdvancePastSettledRows stick on the same row.
+    /// </summary>
+    [TestMethod]
+    public void ReviewEach_AcceptProtect_AdvancesWhenMarkedAccepted()
+    {
+        var store = new List<PendingUpdateItem>
+        {
+            Item("Problem.Name", "old name", isProtected: true),
+            Item("Problem.AntagConflict", "old conflict", isProtected: true),
+            Item("Problem.Theme", "old theme", isProtected: true),
+        };
+        _viewModel.SetPendingUpdates(store);
+        WireMarkSettledOnAcceptOrSkip(store);
+        _viewModel.ReviewEachCommand.Execute(null);
+
+        Assert.AreEqual("Problem.Name", _viewModel.CurrentReviewKey);
+
+        _viewModel.SkipCurrentCommand.Execute(null);
+        Assert.AreEqual("Problem.AntagConflict", _viewModel.CurrentReviewKey);
+
+        _viewModel.AcceptCurrentCommand.Execute(null);
+        Assert.AreEqual("Problem.Theme", _viewModel.CurrentReviewKey,
+            "After Accept on Protect AntagConflict, Review Each must advance (not stick).");
+        Assert.IsTrue(_viewModel.IsInReviewMode);
+    }
+
+    /// <summary>
+    /// Documents the stuck-bug shape: Accept that does not settle leaves the index frozen.
+    /// </summary>
+    [TestMethod]
+    public void ReviewEach_AcceptProtect_WithoutMarkingSettled_StaysOnRow()
+    {
+        var store = new List<PendingUpdateItem>
+        {
+            Item("Problem.AntagConflict", "old", isProtected: true),
+            Item("Problem.Theme", "t", isProtected: true),
+        };
+        _viewModel.SetPendingUpdates(store);
+        // Bug shape: stage-only Accept (no KindLabel change)
+        _viewModel.OnAcceptProperty = _ => Task.CompletedTask;
+        _viewModel.ReviewEachCommand.Execute(null);
+
+        Assert.AreEqual("Problem.AntagConflict", _viewModel.CurrentReviewKey);
+        _viewModel.AcceptCurrentCommand.Execute(null);
+        Assert.AreEqual("Problem.AntagConflict", _viewModel.CurrentReviewKey,
+            "Without settling, Review Each must stay (regression detector for production Protect path).");
+    }
+
     [TestMethod]
     public void ReviewEach_SkipCurrent_DoesNotDropRemaining()
     {


### PR DESCRIPTION
## Summary

Review Each did not advance after Accept on a **Protect** row (label \"Has your text\" — field already has content). Skip worked; Accept on overwrites stuck on the same property (e.g. Name skipped, AntagConflict would not advance).

**Cause:** Protect Accept only staged for #140 end confirm and did not ``MarkAccepted`` on the session set. ``IsSettled`` only treats Accepted/Skipped as done.

**Fix:** ``MarkAccepted`` when staging Protect; on overwrite confirm **Cancel**, mark those keys **Skipped**. Accept Remaining free path marks staged Protect the same way.

## Test plan

- [x] ``ReviewEach_AcceptProtect_AdvancesWhenMarkedAccepted``
- [x] ``ReviewEach_AcceptProtect_WithoutMarkingSettled_StaysOnRow`` (documents bug shape)
- [x] Existing skip regression test still passes
- [ ] Manual: Review Each → Skip Name → Accept AntagConflict → next field