### PR TITLE
Collab UI QoL changes

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -281,6 +281,9 @@ public class Collaborator : ICollaborator
     /// </summary>
     private void RebuildWorkflowMenu(WorkflowShellViewModel viewModel)
     {
+        // Clearing the menu throws away the selected container, so the pane loses its
+        // highlight on every post-run gap refresh. Re-select the same tag afterwards.
+        var selectedTag = viewModel.CurrentItem?.Tag;
         viewModel.MenuItems.Clear();
 
         if (_storyApi != null && _storyModel != null)
@@ -288,11 +291,9 @@ public class Collaborator : ICollaborator
             var gapDetails = RequiredFieldGapScanner.FindGapDetails(_storyApi, _storyModel);
             if (gapDetails.Count > 0)
             {
-                viewModel.MenuItems.Add(new Microsoft.UI.Xaml.Controls.NavigationViewItem
-                {
-                    Content = $"{GapWorkflowOwnership.OutlineGapsNavTitle} ({gapDetails.Count})",
-                    Tag = GapWorkflowOwnership.OutlineGapsTag
-                });
+                viewModel.MenuItems.Add(WrappingNavItem(
+                    $"{GapWorkflowOwnership.OutlineGapsNavTitle} ({gapDetails.Count})",
+                    GapWorkflowOwnership.OutlineGapsTag));
             }
         }
 
@@ -313,12 +314,32 @@ public class Collaborator : ICollaborator
                 viewModel.MenuItems.Add(group);
             }
 
-            group.MenuItems.Add(new Microsoft.UI.Xaml.Controls.NavigationViewItem
-            {
-                Content = workflow.Title,
-                Tag = workflow
-            });
+            group.MenuItems.Add(WrappingNavItem(workflow.Title, workflow));
         }
+
+        viewModel.RestoreSelection(selectedTag);
+    }
+
+    /// <summary>
+    /// Nav item whose title wraps instead of being trimmed to one line. A string Content is
+    /// rendered by the item template as a single non-wrapping line, so the text has to be a
+    /// TextBlock we control; Height=Auto lets the item grow past the one-line default.
+    /// AutomationProperties.Name keeps the title available to automation and screen readers.
+    /// </summary>
+    private static Microsoft.UI.Xaml.Controls.NavigationViewItem WrappingNavItem(string title, object tag)
+    {
+        var item = new Microsoft.UI.Xaml.Controls.NavigationViewItem
+        {
+            Content = new Microsoft.UI.Xaml.Controls.TextBlock
+            {
+                Text = title,
+                TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap
+            },
+            Tag = tag,
+            Height = double.NaN
+        };
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(item, title);
+        return item;
     }
 
     /// <summary>
@@ -1070,8 +1091,9 @@ public class Collaborator : ICollaborator
                                 RefreshProposalSnapshotInHistory();
                                 _storyModel?.RefreshCurrentView();
                                 await FlushStagedIfQueueDoneAsync();
-                                if (result.PendingUpdates.Count == 0 && !stageSession.HasStaged)
-                                    AutoSaveFireAndForget("AcceptProperty");
+                                // Save on each confirmed update, not just the last one in the
+                                // queue: there is no manual Save button to fall back on.
+                                AutoSaveFireAndForget("AcceptProperty");
                             }
                             else
                             {

--- a/StoryCADLib/Collaborator/Models/PendingUpdateItem.cs
+++ b/StoryCADLib/Collaborator/Models/PendingUpdateItem.cs
@@ -22,6 +22,22 @@ public sealed class PendingUpdateItem
     public string ElementAndKind =>
         string.IsNullOrEmpty(ElementName) ? SummaryLine : $"{ElementName} · {SummaryLine}";
 
+    /// <summary>
+    /// True when the pending set spans more than one story element, so the row has to name
+    /// its element to be unambiguous. Set by the ViewModel over the whole set, since a single
+    /// item cannot know. Single-element workflows leave it false and read the same as before.
+    /// </summary>
+    public bool ShowElementName { get; set; }
+
+    /// <summary>
+    /// Faint sub-line under the property name: the kind, prefixed with the element title
+    /// when the set spans several elements (e.g. "Outer Problem · Has your text").
+    /// </summary>
+    public string KindCaption =>
+        ShowElementName && !string.IsNullOrEmpty(ElementName)
+            ? $"{ElementName} · {KindLabel}"
+            : KindLabel;
+
     /// <summary>Proposed value (truncated for display).</summary>
     public string ProposedDisplay { get; set; } = string.Empty;
 

--- a/StoryCADLib/Collaborator/ViewModels/WorkflowShellViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WorkflowShellViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -139,11 +140,66 @@ public partial class WorkflowShellViewModel : ObservableRecipient
     public async void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
     {
         CurrentItem = args.SelectedItem as NavigationViewItem;
-        if (CurrentItem?.Tag != null && OnWorkflowSelected != null)
+        var tag = CurrentItem?.Tag;
+        if (tag == null || OnWorkflowSelected == null)
+            return;
+
+        // Re-selecting the tag we are already on is a restore, not a user request:
+        // RestoreSelection re-highlights the same workflow after the menu is rebuilt,
+        // and running it again there would re-execute the workflow on every rebuild.
+        if (IsSameTag(tag, _selectedTag))
+            return;
+
+        _selectedTag = tag;
+        await OnWorkflowSelected(tag);
+    }
+
+    /// <summary>
+    /// Re-selects the menu item carrying <paramref name="tag"/> after the menu has been
+    /// rebuilt. Rebuilding replaces every NavigationViewItem, so the previously selected
+    /// container is gone and the pane would otherwise show nothing highlighted.
+    /// </summary>
+    public void RestoreSelection(object tag)
+    {
+        if (tag == null)
+            return;
+
+        foreach (var item in MenuItems)
         {
-            await OnWorkflowSelected(CurrentItem.Tag);
+            if (IsSameTag(item.Tag, tag))
+            {
+                CurrentItem = item;
+                return;
+            }
+
+            foreach (var child in item.MenuItems.OfType<NavigationViewItem>())
+            {
+                if (IsSameTag(child.Tag, tag))
+                {
+                    // Group must be open or the selected child is hidden.
+                    item.IsExpanded = true;
+                    CurrentItem = child;
+                    return;
+                }
+            }
         }
     }
+
+    /// <summary>
+    /// Workflow tags are the shared <c>WorkflowRegistry</c> instances (reference equality);
+    /// the outline-gaps tag is a string, so compare by value too.
+    /// </summary>
+    private static bool IsSameTag(object a, object b)
+    {
+        if (ReferenceEquals(a, b))
+            return true;
+        if (a is string sa && b is string sb)
+            return string.Equals(sa, sb, StringComparison.Ordinal);
+        return false;
+    }
+
+    /// <summary>Tag of the workflow last navigated to; guards restore against re-running it.</summary>
+    private object _selectedTag;
 
     public Task LoadWorkflowMenuAsync()
     {
@@ -188,6 +244,7 @@ public partial class WorkflowShellViewModel : ObservableRecipient
         MenuItems.Clear();
         HasPendingUpdates = false;
         ActiveWorkflowName = string.Empty;
+        _selectedTag = null;
         OnAcceptAll = null;
         OnReviewEach = null;
         OnTryAgain = null;

--- a/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
@@ -228,12 +228,12 @@ public partial class WorkflowViewModel : ObservableRecipient
         get
         {
             if (PendingUpdateItems == null || PendingUpdateItems.Count == 0)
-                return "Property Updates";
+                return "Proposed property updates";
 
             var total = PendingUpdateItems.Count;
             var needReview = PendingUpdateItems.Count(i => i.IsProtected);
             var free = total - needReview;
-            return $"Property Updates ({total}: {free} free, {needReview} need review)";
+            return $"Proposed property updates ({total}: {free} free, {needReview} need review)";
         }
     }
 
@@ -589,8 +589,19 @@ public partial class WorkflowViewModel : ObservableRecipient
         PendingUpdateItems.Clear();
         if (items != null)
         {
+            // A property name alone ("Structure Title") does not say which element it belongs
+            // to. Name the element on every row once the set covers more than one of them.
+            var multiElement = items
+                .Select(i => i.ElementName)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Count() > 1;
+
             foreach (var item in items)
+            {
+                item.ShowElementName = multiElement;
                 PendingUpdateItems.Add(item);
+            }
         }
 
         UpdatesApplied = false;

--- a/StoryCADLib/Collaborator/Views/ElementPicker.xaml.cs
+++ b/StoryCADLib/Collaborator/Views/ElementPicker.xaml.cs
@@ -97,7 +97,10 @@ public sealed partial class ElementPicker : Page
             return;
         }
 
-        var elementList = elements.Skip(1).ToList();
+        // Skip(1) drops the "(none)" placeholder; the rest are listed alphabetically.
+        var elementList = elements.Skip(1)
+            .OrderBy(e => e.Name, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
         ElementBox.IsEnabled = true;
         ElementBox.ItemsSource = elementList;
 

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
@@ -106,6 +106,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
             <!-- Brief purpose + topical Explanation (selected elements + what to do next) -->
@@ -142,26 +143,14 @@
                                FontWeight="SemiBold"
                                Margin="0,0,0,8" />
 
-                    <!-- Table column headers; right margin matches the gutter the built-in
-                         scrollbar reserves (ScrollBarSize, 12px) so headers stay over their
-                         columns (#129). Column widths must stay in sync with the row template. -->
-                    <Grid Grid.Row="1"
-                          Margin="0,0,12,0"
-                          Padding="0,0,0,4"
-                          BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                          BorderThickness="0,0,0,1">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="160" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="110" />
-                            <ColumnDefinition Width="64" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="Property" FontWeight="SemiBold"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        <TextBlock Grid.Column="1" Text="Proposed" FontWeight="SemiBold"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        <!-- Status column has no header; rows still render KindLabel there. -->
-                    </Grid>
+                    <!-- No column headers: the panel title names the table and the rows label
+                         themselves. What is left is the rule that separates title from list.
+                         Right margin matches the gutter the built-in scrollbar reserves
+                         (ScrollBarSize, 12px) so the rule ends level with the rows (#129). -->
+                    <Border Grid.Row="1"
+                            Height="1"
+                            Margin="0,0,12,0"
+                            Background="{ThemeResource CardStrokeColorDefaultBrush}" />
                     <!--
                       VerticalScrollBarVisibility must be Visible, never Disabled: per WinUI's
                       ScrollBarVisibility contract, Disabled also turns scrolling off and clamps
@@ -184,30 +173,32 @@
                                               BorderThickness="0,0,0,1"
                                               AutomationProperties.Name="{Binding Key, Mode=OneWay}">
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="160" />
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="110" />
+                                                <ColumnDefinition Width="1*" />
+                                                <ColumnDefinition Width="3*" />
                                                 <ColumnDefinition Width="64" />
                                             </Grid.ColumnDefinitions>
                                             <!-- Tooltip carries the raw key so the element is still discoverable
-                                                 without its own column. -->
-                                            <TextBlock Text="{Binding DisplayName}"
-                                                       FontWeight="SemiBold"
-                                                       VerticalAlignment="Top"
-                                                       TextWrapping="Wrap"
-                                                       ToolTipService.ToolTip="{Binding Key}" />
+                                                 without its own column. KindLabel sits under the property name
+                                                 rather than in a column of its own. -->
+                                            <StackPanel VerticalAlignment="Top"
+                                                        Margin="0,0,8,0">
+                                                <TextBlock Text="{Binding DisplayName}"
+                                                           FontWeight="SemiBold"
+                                                           TextWrapping="Wrap"
+                                                           ToolTipService.ToolTip="{Binding Key}" />
+                                                <TextBlock Text="{Binding KindCaption}"
+                                                           FontSize="11"
+                                                           Opacity="0.6"
+                                                           TextWrapping="Wrap"
+                                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                            </StackPanel>
                                             <TextBlock Grid.Column="1"
                                                        Text="{Binding ProposedDisplay}"
                                                        Opacity="0.9"
                                                        VerticalAlignment="Top"
                                                        TextWrapping="Wrap"
                                                        Margin="0,0,8,0" />
-                                            <TextBlock Grid.Column="2"
-                                                       Text="{Binding KindLabel}"
-                                                       VerticalAlignment="Top"
-                                                       TextTrimming="CharacterEllipsis"
-                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                            <StackPanel Grid.Column="3"
+                                            <StackPanel Grid.Column="2"
                                                         Orientation="Horizontal"
                                                         Spacing="4"
                                                         VerticalAlignment="Top">
@@ -238,7 +229,7 @@
                 </Grid>
             </Border>
 
-            <!-- Review Mode (Accept/Skip); Accept All is on the shell bar -->
+            <!-- Review Mode (Accept/Skip); Accept All sits below the table -->
             <StackPanel Grid.Row="2"
                         Visibility="{x:Bind ViewModel.ReviewModeVisibility, Mode=OneWay}"
                         Margin="0,8,0,0">
@@ -287,6 +278,19 @@
                            Margin="0,8,0,0"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
             </StackPanel>
+
+            <!-- Accept All: primary action for the table, at the foot of the work column.
+                 Accepted updates are written to the outline immediately, so there is no
+                 separate Save button on the shell bar. -->
+            <Button Grid.Row="3"
+                    Content="Accept all changes"
+                    Command="{x:Bind ViewModel.AcceptAllCommand}"
+                    IsEnabled="{x:Bind ViewModel.HasPendingUpdates, Mode=OneWay}"
+                    Style="{ThemeResource AccentButtonStyle}"
+                    HorizontalAlignment="Stretch"
+                    Margin="0,10,0,0"
+                    AutomationProperties.AutomationId="WorkflowAcceptAllButton"
+                    AutomationProperties.Name="Accept all changes" />
         </Grid>
 
         <!-- ========== Chat column (own height; input does not affect work column) ========== -->
@@ -333,6 +337,7 @@
                             PlaceholderText="{x:Bind ViewModel.ChatPlaceholder, Mode=OneWay}"
                             Text="{x:Bind ViewModel.InputText, Mode=TwoWay}"
                             QuerySubmitted="InputTextBox_QuerySubmitted"
+                            Loaded="InputTextBox_Loaded"
                             AutomationProperties.AutomationId="InputSearchBox"
                             AutomationProperties.Name="Message">
                 <AutoSuggestBox.QueryIcon>

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml.cs
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml.cs
@@ -45,17 +45,89 @@ public sealed partial class WorkflowPage : Page
         }
     }
 
-    // Fires on Enter and on the in-box send (query) button alike.
+    /// <summary>
+    /// Guards against the same message being sent twice when both QuerySubmitted and the
+    /// query button's Click fire for one press, and against a second press mid-send.
+    /// </summary>
+    private bool _isSending;
+
+    // Fires on Enter, and on the in-box send (query) button where the platform raises it.
     private async void InputTextBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
     {
-        if (ViewModel == null)
+        // QueryText is the box's current text, but the query button leaves it empty on some
+        // targets; fall back to the box itself so the button sends what the user typed.
+        await SendCurrentAsync(string.IsNullOrWhiteSpace(args.QueryText) ? sender?.Text : args.QueryText);
+    }
+
+    /// <summary>
+    /// The in-box send button does not raise QuerySubmitted on every target, so hook the
+    /// templated query button directly. Both routes funnel through SendCurrentAsync.
+    /// </summary>
+    private void InputTextBox_Loaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is not AutoSuggestBox box)
         {
             return;
         }
 
-        // QueryText is the box's current text; push it in case the TwoWay binding hasn't yet.
-        ViewModel.InputText = args.QueryText;
-        await ViewModel.SendButtonClicked();
+        var queryButton = FindQueryButton(box);
+        if (queryButton == null)
+        {
+            return;
+        }
+
+        queryButton.Click -= QueryButton_Click;
+        queryButton.Click += QueryButton_Click;
+    }
+
+    private async void QueryButton_Click(object sender, RoutedEventArgs e)
+    {
+        await SendCurrentAsync(InputTextBox.Text);
+    }
+
+    private async System.Threading.Tasks.Task SendCurrentAsync(string text)
+    {
+        if (ViewModel == null || _isSending || string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        _isSending = true;
+        try
+        {
+            ViewModel.InputText = text;
+            await ViewModel.SendButtonClicked();
+        }
+        finally
+        {
+            _isSending = false;
+        }
+    }
+
+    /// <summary>
+    /// Walks the applied template for the AutoSuggestBox query button ("QueryButton" is the
+    /// documented template part). Matches that name only: the inner TextBox template also
+    /// carries a clear button, and hooking that one would send on clear.
+    /// </summary>
+    private static Button FindQueryButton(DependencyObject root)
+    {
+        var count = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+        {
+            var child = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChild(root, i);
+            if (child is Button button && button.Name == "QueryButton")
+            {
+                return button;
+            }
+
+            var found = FindQueryButton(child);
+            if (found != null)
+            {
+                return found;
+            }
+        }
+
+        return null;
     }
 
     // Per-row accept/skip ticks (#129): row item comes from the button's DataContext.

--- a/StoryCADLib/Collaborator/Views/WorkflowShell.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowShell.xaml
@@ -50,15 +50,7 @@
                            MaxWidth="200"
                            AutomationProperties.Name="Current workflow" />
 
-                <AppBarButton ToolTipService.ToolTip="Accept All"
-                              Command="{x:Bind ShellViewModel.AcceptAllCommand, Mode=OneWay}"
-                              IsEnabled="{x:Bind ShellViewModel.HasPendingUpdates, Mode=OneWay}"
-                              AutomationProperties.AutomationId="WorkflowAcceptAllButton"
-                              AutomationProperties.Name="Accept All">
-                    <AppBarButton.Icon>
-                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE73E;" />
-                    </AppBarButton.Icon>
-                </AppBarButton>
+                <!-- Accept All lives at the foot of the work column on WorkflowPage, not here. -->
                 <AppBarButton ToolTipService.ToolTip="Review Each"
                               Command="{x:Bind ShellViewModel.ReviewEachCommand, Mode=OneWay}"
                               IsEnabled="{x:Bind ShellViewModel.HasPendingUpdates, Mode=OneWay}"
@@ -97,9 +89,9 @@
                                     <TextBlock Text="Story Collaborator Help" FontWeight="Bold" FontSize="16" />
                                     <TextBlock TextWrapping="Wrap" Text="Workflows — The left panel lists available workflows for your story. Each workflow guides you through developing a specific aspect (premise, characters, settings, scenes, etc.). Select one to begin." />
                                     <TextBlock TextWrapping="Wrap" Text="Execute — Runs the selected workflow. Collaborator analyzes your story elements and suggests updates using AI." />
-                                    <TextBlock TextWrapping="Wrap" Text="Review Results — After execution, review each suggested property update. Use Accept to apply individual changes, or Accept All to apply everything at once." />
+                                    <TextBlock TextWrapping="Wrap" Text="Review Results — After execution, review each suggested property update. Use Accept to apply individual changes, or Accept all changes at the foot of the list to apply everything at once." />
                                     <TextBlock TextWrapping="Wrap" Text="Chat — After a workflow runs, use the chat panel to discuss the results, ask for alternatives, or refine suggestions." />
-                                    <TextBlock TextWrapping="Wrap" Text="Save — Saves your outline changes back to StoryCAD." />
+                                    <TextBlock TextWrapping="Wrap" Text="Saving — Updates are written to your outline as soon as you accept them, so there is no Save button." />
                                     <TextBlock TextWrapping="Wrap" Text="Exit — Closes Collaborator and returns to StoryCAD. Any accepted changes are preserved." />
                                 </StackPanel>
                             </ScrollViewer>
@@ -114,14 +106,8 @@
                         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE713;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-                <AppBarButton ToolTipService.ToolTip="Save"
-                              Command="{x:Bind ShellViewModel.SaveCommand, Mode=OneWay}"
-                              AutomationProperties.AutomationId="WorkflowSaveButton"
-                              AutomationProperties.Name="Save">
-                    <AppBarButton.Icon>
-                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE74E;" />
-                    </AppBarButton.Icon>
-                </AppBarButton>
+                <!-- No Save button: accepted updates are written to the outline as they are
+                     confirmed, so there is nothing to save manually. -->
                 <AppBarButton ToolTipService.ToolTip="Exit"
                               Command="{x:Bind ShellViewModel.ExitCommand, Mode=OneWay}"
                               AutomationProperties.AutomationId="WorkflowExitButton"
@@ -147,6 +133,26 @@
                         SelectionChanged="NavView_SelectionChanged"
                         PaneDisplayMode="Left"
                         AutomationProperties.AutomationId="WorkflowNav">
+
+            <!-- The selected workflow must read at a glance: the stock selected state is a
+                 near-invisible tint on Skia. Items in MenuItemsSource are NavigationViewItem
+                 instances, so they are their own containers and MenuItemContainerStyle never
+                 applies; lightweight styling resources are inherited by them, and do. Accent
+                 tint (not a flat accent fill) keeps the default foreground legible in both
+                 light and dark themes. -->
+            <NavigationView.Resources>
+                <SolidColorBrush x:Key="NavigationViewItemBackgroundSelected"
+                                 Color="{ThemeResource SystemAccentColor}"
+                                 Opacity="0.22" />
+                <SolidColorBrush x:Key="NavigationViewItemBackgroundSelectedPointerOver"
+                                 Color="{ThemeResource SystemAccentColor}"
+                                 Opacity="0.30" />
+                <SolidColorBrush x:Key="NavigationViewItemBackgroundSelectedPressed"
+                                 Color="{ThemeResource SystemAccentColor}"
+                                 Opacity="0.36" />
+                <SolidColorBrush x:Key="NavigationViewSelectionIndicatorForeground"
+                                 Color="{ThemeResource SystemAccentColor}" />
+            </NavigationView.Resources>
 
             <Frame x:Name="StepFrame"
                    Navigated="StepFrame_OnNavigated"

--- a/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
@@ -467,10 +467,55 @@ public class WorkflowViewModelTests
             Item("C", isProtected: true)
         });
 
-        Assert.AreEqual("Property Updates (3: 1 free, 2 need review)", _viewModel.PendingUpdatesHeader);
+        Assert.AreEqual("Proposed property updates (3: 1 free, 2 need review)", _viewModel.PendingUpdatesHeader);
 
         _viewModel.ClearPendingUpdates();
-        Assert.AreEqual("Property Updates", _viewModel.PendingUpdatesHeader);
+        Assert.AreEqual("Proposed property updates", _viewModel.PendingUpdatesHeader);
+    }
+
+    [TestMethod]
+    public void SetPendingUpdates_WithOneElement_DoesNotNameElementOnRows()
+    {
+        var a = Item("A");
+        a.ElementName = "Outer Problem";
+        var b = Item("B");
+        b.ElementName = "Outer Problem";
+
+        _viewModel.SetPendingUpdates(new List<PendingUpdateItem> { a, b });
+
+        Assert.IsFalse(a.ShowElementName);
+        Assert.AreEqual("New", a.KindCaption);
+    }
+
+    [TestMethod]
+    public void SetPendingUpdates_WithMultipleElements_NamesElementOnEveryRow()
+    {
+        var a = Item("A");
+        a.ElementName = "Outer Problem";
+        var b = Item("B", isProtected: true);
+        b.ElementName = "Protagonist";
+
+        _viewModel.SetPendingUpdates(new List<PendingUpdateItem> { a, b });
+
+        Assert.IsTrue(a.ShowElementName);
+        Assert.IsTrue(b.ShowElementName);
+        Assert.AreEqual("Outer Problem · New", a.KindCaption);
+        Assert.AreEqual("Protagonist · Has your text", b.KindCaption);
+    }
+
+    [TestMethod]
+    public void SetPendingUpdates_WithMultipleElementsButNoElementName_FallsBackToKindOnly()
+    {
+        var a = Item("A");
+        a.ElementName = "Outer Problem";
+        var b = Item("B");
+        b.ElementName = "Protagonist";
+        var bare = Item("C");
+
+        _viewModel.SetPendingUpdates(new List<PendingUpdateItem> { a, b, bare });
+
+        Assert.IsTrue(bare.ShowElementName);
+        Assert.AreEqual("New", bare.KindCaption);
     }
 
     [TestMethod]


### PR DESCRIPTION
This PR makes the following QoL tweaks I made during testing:
- Picker is now always A-Z Ordered for easier picking
- Added big accept all changes to bottom
- Removed save button, changes are persisted on acceptance.
- Updated some wording on UI in changes table.