### PR TITLE
feat(collaborator#167): Structure assign problems/scenes; preserve beats

### DIFF
--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -716,37 +716,9 @@ namespace StoryCollaborator
 
                     case WriteVia.BeatSheet:
                     {
+                        // #167: merge proposed beats; never wipe filled assignments.
                         if (update.Value is not List<BeatInfo> beats) break;
-
-                        // Clear existing beats
-                        var structure = _storyApi.GetProblemStructure(uuid);
-                        if (structure.IsSuccess)
-                        {
-                            int beatCount = structure.Payload.Beats.Count();
-                            for (int i = 0; i < beatCount; i++)
-                                _storyApi.DeleteBeat(uuid, 0);
-                        }
-
-                        // Build candidate set for assigned_element validation
-                        var problemGuids = GetCandidateGuids(StoryItemType.Problem);
-                        var sceneGuids = GetCandidateGuids(StoryItemType.Scene);
-                        var validAssignGuids = new System.Collections.Generic.HashSet<Guid>(
-                            problemGuids.Concat(sceneGuids));
-
-                        // Create new beats
-                        for (int i = 0; i < beats.Count; i++)
-                        {
-                            var beat = beats[i];
-                            _storyApi.CreateBeat(uuid, beat.Title, beat.Description);
-                            if (beat.AssignedElement.HasValue)
-                            {
-                                if (validAssignGuids.Contains(beat.AssignedElement.Value))
-                                    _storyApi.AssignElementToBeat(uuid, i, beat.AssignedElement.Value);
-                                else
-                                    result.StatusMessages.Add(
-                                        $"Beat {i} assigned_element {beat.AssignedElement} not in candidate set; left unassigned");
-                            }
-                        }
+                        ApplyBeatSheetMerge(uuid, beats, result);
                         appliedCount++;
                         break;
                     }
@@ -862,6 +834,131 @@ namespace StoryCollaborator
                 beats.Add(new BeatInfo(title, desc, assigned));
             }
             return beats;
+        }
+
+        /// <summary>
+        /// Collaborator #167: install or merge beat proposals without clearing filled assignments.
+        /// Empty sheet: create proposed beats and assign valid candidates.
+        /// Non-empty: fill blank descriptions; assign only empty slots; never reassign.
+        /// </summary>
+        internal void ApplyBeatSheetMerge(Guid problemUuid, List<BeatInfo> proposed, WorkflowResult result)
+        {
+            if (proposed == null || proposed.Count == 0)
+            {
+                result.StatusMessages.Add("BeatSheet: empty proposal; no changes");
+                return;
+            }
+
+            var problemGuids = new HashSet<Guid>(GetCandidateGuids(StoryItemType.Problem));
+            var sceneGuids = new HashSet<Guid>(GetCandidateGuids(StoryItemType.Scene));
+            var validAssignGuids = new HashSet<Guid>(problemGuids.Concat(sceneGuids));
+
+            var existingResult = _storyApi.GetProblemStructure(problemUuid);
+            if (!existingResult.IsSuccess)
+            {
+                result.StatusMessages.Add($"BeatSheet: cannot load structure for {problemUuid}");
+                return;
+            }
+
+            var existingBeats = existingResult.Payload.Beats?.ToList()
+                ?? new List<(string BeatTitle, string BeatDescription, Guid? LinkedElement)>();
+
+            // GUIDs already assigned on this problem (preserve; block multi-problem on same sheet).
+            var usedOnSheet = new HashSet<Guid>(
+                existingBeats
+                    .Where(b => b.LinkedElement.HasValue && b.LinkedElement.Value != Guid.Empty)
+                    .Select(b => b.LinkedElement!.Value));
+
+            if (existingBeats.Count == 0)
+            {
+                for (int i = 0; i < proposed.Count; i++)
+                {
+                    var beat = proposed[i];
+                    var title = string.IsNullOrWhiteSpace(beat.Title) ? $"Beat {i + 1}" : beat.Title.Trim();
+                    var desc = beat.Description?.Trim() ?? string.Empty;
+                    _storyApi.CreateBeat(problemUuid, title, desc);
+                    TryAssignBeat(problemUuid, i, beat.AssignedElement, validAssignGuids, problemGuids, usedOnSheet, result);
+                }
+                return;
+            }
+
+            // Append extra proposed rows when the model grows the sheet (do not delete extras).
+            for (int i = existingBeats.Count; i < proposed.Count; i++)
+            {
+                var beat = proposed[i];
+                var title = string.IsNullOrWhiteSpace(beat.Title) ? $"Beat {i + 1}" : beat.Title.Trim();
+                var desc = beat.Description?.Trim() ?? string.Empty;
+                _storyApi.CreateBeat(problemUuid, title, desc);
+            }
+
+            // Re-read after possible creates.
+            existingResult = _storyApi.GetProblemStructure(problemUuid);
+            existingBeats = existingResult.IsSuccess
+                ? existingResult.Payload.Beats?.ToList()
+                    ?? new List<(string, string, Guid?)>()
+                : existingBeats;
+
+            int pairCount = Math.Min(existingBeats.Count, proposed.Count);
+            for (int i = 0; i < pairCount; i++)
+            {
+                var current = existingBeats[i];
+                var beat = proposed[i];
+
+                var newTitle = string.IsNullOrWhiteSpace(current.BeatTitle) && !string.IsNullOrWhiteSpace(beat.Title)
+                    ? beat.Title.Trim()
+                    : current.BeatTitle;
+                // Prefer keep filled description; fill blank only.
+                var newDesc = string.IsNullOrWhiteSpace(current.BeatDescription) && !string.IsNullOrWhiteSpace(beat.Description)
+                    ? beat.Description.Trim()
+                    : current.BeatDescription;
+
+                if (!string.Equals(newTitle, current.BeatTitle, StringComparison.Ordinal)
+                    || !string.Equals(newDesc, current.BeatDescription, StringComparison.Ordinal))
+                {
+                    _storyApi.UpdateBeat(problemUuid, i, newTitle ?? string.Empty, newDesc ?? string.Empty);
+                }
+
+                var alreadyFilled = current.LinkedElement.HasValue && current.LinkedElement.Value != Guid.Empty;
+                if (alreadyFilled)
+                    continue;
+
+                TryAssignBeat(problemUuid, i, beat.AssignedElement, validAssignGuids, problemGuids, usedOnSheet, result);
+            }
+        }
+
+        private void TryAssignBeat(
+            Guid problemUuid,
+            int beatIndex,
+            Guid? assigned,
+            HashSet<Guid> validAssignGuids,
+            HashSet<Guid> problemGuids,
+            HashSet<Guid> usedOnSheet,
+            WorkflowResult result)
+        {
+            if (!assigned.HasValue || assigned.Value == Guid.Empty)
+                return;
+
+            if (!validAssignGuids.Contains(assigned.Value))
+            {
+                result.StatusMessages.Add(
+                    $"Beat {beatIndex} assigned_element {assigned.Value} not in candidate set; left unassigned");
+                return;
+            }
+
+            // One problem per beat sheet (and prefer one scene): skip if already used on this sheet.
+            if (usedOnSheet.Contains(assigned.Value))
+            {
+                result.StatusMessages.Add(
+                    $"Beat {beatIndex} assigned_element {assigned.Value} already used on this sheet; left unassigned");
+                return;
+            }
+
+            var assignResult = _storyApi.AssignElementToBeat(problemUuid, beatIndex, assigned.Value);
+            if (assignResult.IsSuccess)
+                usedOnSheet.Add(assigned.Value);
+            else
+                result.StatusMessages.Add(
+                    $"Beat {beatIndex} assign failed: {assignResult.ErrorMessage}");
         }
 
         private static List<JsonElement> ExtractTypedEntries(JsonElement elem)

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -370,21 +370,69 @@ namespace StoryCollaborator.Workflows
                             }
                         }
                     }) { PrimaryElementType = StoryItemType.Problem },
+                // Collaborator #167: assign problems/scenes to beats; preserve filled assignments.
                 new Workflow(
-                    "Structure", "Problem Structure",
-                    "Define the structural beats and turning points of a story problem by selecting and applying " +
-                    "a beat sheet template.",
-                    StoryItemType.Problem,
+                    label: "Structure",
+                    title: "Problem Structure",
+                    description: "Choose a beat sheet and match existing problems and scenes to beats " +
+                                "(story problem prefers other problems; other problems prefer scenes).",
                     explanation: "Structure gives your problem shape—a beginning that hooks, a middle that complicates, " +
-                                "and an ending that resolves. This workflow helps you choose a beat sheet (Three Act, " +
-                                "Hero's Journey, Save the Cat, etc.) and maps your problem's key moments to its beats.",
-                    outputProperties: new List<PropertySpec>
+                                "and an ending that resolves. This workflow chooses a beat sheet (full for the story " +
+                                "problem, mini for others) and assigns existing problems and scenes to unfilled beats. " +
+                                "It does not create new elements or wipe filled assignments.",
+                    workflowIO: new WorkflowIO
                     {
-                        new PropertySpec("StructureTitle"),
-                        new PropertySpec("StructureDescription"),
-                        // Beat array: model emits "beats" array; runner clears and rebuilds via the beat API.
-                        new PropertySpec("StructureBeats", WriteVia.BeatSheet, JsonKey: "beats")
-                    }),
+                        RequiredInputs = new List<ElementRequirement>
+                        {
+                            new ElementRequirement
+                            {
+                                ElementType = StoryItemType.Problem,
+                                ElementLabel = "Problem",
+                                RequiredProperties = new List<PropertySpec>(),
+                                CreateIfMissing = false
+                            }
+                        },
+                        OptionalInputs = new List<ElementRequirement>
+                        {
+                            // Overview helps the Worker detect the outline story problem.
+                            new ElementRequirement
+                            {
+                                ElementType = StoryItemType.StoryOverview,
+                                ElementLabel = "Overview",
+                                RequiredProperties = new List<PropertySpec>(),
+                                CreateIfMissing = false
+                            }
+                        },
+                        Outputs = new List<ElementOutput>
+                        {
+                            new ElementOutput
+                            {
+                                ElementType = StoryItemType.Problem,
+                                ElementLabel = "Problem",
+                                PropertiesToUpdate = new List<PropertySpec>
+                                {
+                                    new PropertySpec("StructureTitle"),
+                                    new PropertySpec("StructureDescription"),
+                                    new PropertySpec("StructureBeats", WriteVia.BeatSheet, JsonKey: "beats")
+                                }
+                            }
+                        },
+                        CollectionInputs = new List<CollectionInput>
+                        {
+                            new CollectionInput
+                            {
+                                RequestName = "ProblemChoices",
+                                ElementType = StoryItemType.Problem,
+                                Projection = ElementProjection.BaseStoryElement
+                            },
+                            new CollectionInput
+                            {
+                                RequestName = "SceneChoices",
+                                ElementType = StoryItemType.Scene,
+                                Projection = ElementProjection.BaseStoryElement
+                            }
+                        }
+                    }) { PrimaryElementType = StoryItemType.Problem },
                 // === Character Workflows ===
                 new Workflow(
                     "RoleAndStoryRole", "Role and Story Role",

--- a/StoryCADTests/Collaborator/StructureWorkflowRegistryTests.cs
+++ b/StoryCADTests/Collaborator/StructureWorkflowRegistryTests.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StoryCADLib.Models;
+using StoryCollaborator.Models;
+using StoryCollaborator.Workflows;
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>Collaborator #167: Structure collections and outputs.</summary>
+[TestClass]
+public class StructureWorkflowRegistryTests
+{
+    [TestMethod]
+    public void Structure_Declares_Problem_And_Scene_Collections()
+    {
+        var workflow = WorkflowRegistry.All.First(w => w.Label == "Structure");
+        var io = workflow.GetIO();
+
+        Assert.AreEqual(StoryItemType.Problem, workflow.PrimaryElementType);
+        Assert.IsTrue(io.RequiredInputs.Any(r => r.ElementLabel == "Problem"));
+
+        var problemChoices = io.CollectionInputs.FirstOrDefault(c => c.RequestName == "ProblemChoices");
+        var sceneChoices = io.CollectionInputs.FirstOrDefault(c => c.RequestName == "SceneChoices");
+        Assert.IsNotNull(problemChoices);
+        Assert.IsNotNull(sceneChoices);
+        Assert.AreEqual(StoryItemType.Problem, problemChoices!.ElementType);
+        Assert.AreEqual(StoryItemType.Scene, sceneChoices!.ElementType);
+        Assert.AreEqual(ElementProjection.BaseStoryElement, problemChoices.Projection);
+        Assert.AreEqual(ElementProjection.BaseStoryElement, sceneChoices.Projection);
+    }
+
+    [TestMethod]
+    public void Structure_Outputs_Include_BeatSheet()
+    {
+        var workflow = WorkflowRegistry.All.First(w => w.Label == "Structure");
+        var specs = workflow.GetIO().Outputs
+            .SelectMany(o => o.PropertiesToUpdate)
+            .ToList();
+
+        Assert.IsTrue(specs.Any(s => s.Property == "StructureTitle"));
+        Assert.IsTrue(specs.Any(s => s.Property == "StructureDescription"));
+        var beats = specs.First(s => s.Property == "StructureBeats");
+        Assert.AreEqual(WriteVia.BeatSheet, beats.WriteVia);
+        Assert.AreEqual("beats", beats.JsonKey);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Collaborator **#167** client side:

- Structure registry: Problem gather, optional Overview, **ProblemChoices** + **SceneChoices** (BaseStoryElement).
- **ApplyBeatSheetMerge**: empty sheet creates beats; non-empty fills blank descriptions only and assigns **empty slots only**; never deletes or reassigns filled beats.
- Validates GUIDs against problem/scene candidates; one GUID per sheet.

## Issue

https://github.com/storybuilder-org/Collaborator/issues/167

## Test plan

- [x] StructureWorkflowRegistryTests (2)
- [ ] Manual: Structure on Crown by Blood with Worker template PR (needs Collaborator proxy + deploy)