### PR TITLE
fix(docs): Collaborator section folder URL serves landing page

### DIFF
--- a/docs/StoryCAD Collaborator/StoryCAD_Collaborator.md
+++ b/docs/StoryCAD Collaborator/StoryCAD_Collaborator.md
@@ -1,33 +1,11 @@
 ---
-title: StoryCAD Collaborator
+title: StoryCAD Collaborator (moved)
 layout: default
-nav_enabled: true
-nav_order: 95
-parent: Home
+nav_exclude: true
+search_exclude: true
 has_toc: false
 ---
 
-# StoryCAD Collaborator
+<meta http-equiv="refresh" content="0; url=./">
 
-Writing craft is a collection of skills: certain tools and techniques that can achieve a specific desired result. We divide the craft into language skills (the micro level of words and sentences) and structure skills (the framework of your story, plot, characters, scenes, and so forth). We don't concern ourselves with language skills. There are plenty of excellent books and courses that help with these, including the best teacher: practice, practice, and more practice. Our trade is the structure skills. There are also plenty of excellent books and courses that teach these skills. Our contribution, StoryCAD, is a free desktop app for Windows and macOS that applies computer-aided design to help you create an outline for your story. The outline comprises story elements, which include a story overview, problems, characters, settings, and scenes. Your outline is your blueprint when you write your draft, using your language skills.
-
-Our latest addition to StoryCAD is StoryCAD Collaborator. It's a paid plug-in that helps you develop your outline. A **free trial** is available so you can try it before you buy. If a StoryCAD outline is a map, Collaborator is your GPS, an assistant that helps you navigate your story turn by turn. It's a collection of *workflows*, small AI helpers that can help you with the details of building and assembling story elements into something unique: *your* outline, for *your* story.
-
-From within your outline, when you launch Collaborator, you choose a craft job (a *workflow*). Collaborator works with the story elements that job needs, suggests text for specific fields on those elements, and **you** decide what goes into the outline.
-
-You don't need Collaborator to use StoryCAD. You need StoryCAD to use Collaborator. The plug-in exists for people who want an always-available assistant without leaving the outline they're already working on.
-
-Collaborator is not a replacement for writing craft. It sits beside StoryCAD’s forms and the craft ideas in this manual (especially [Writing with StoryCAD](../Writing%20with%20StoryCAD/Writing_with_StoryCAD.html)) and on [StoryBuilder.org](https://storybuilder.org/resources/).
-
-## In this section
-
-- [Getting Started](Getting_Started.html)
-- [What Collaborator Is](What_Collaborator_Is.html)
-- [Workflows and Writing Craft](Workflows_and_Writing_Craft.html)
-- [Opening Collaborator](Opening_Collaborator.html)
-- [Running a Workflow](Running_a_Workflow.html)
-- [Reviewing Suggestions](Reviewing_Suggestions.html)
-- [A Path to Try](A_Path_to_Try.html)
-- [An Example Session](An_Example_Session.html)
-- [Chat](Chat.html)
-- [Tips and Common Questions](Tips_and_Common_Questions.html)
+This section's landing page is [StoryCAD Collaborator](./).

--- a/docs/StoryCAD Collaborator/index.md
+++ b/docs/StoryCAD Collaborator/index.md
@@ -1,0 +1,33 @@
+---
+title: StoryCAD Collaborator
+layout: default
+nav_enabled: true
+nav_order: 95
+parent: Home
+has_toc: false
+---
+
+# StoryCAD Collaborator
+
+Writing craft is a collection of skills: certain tools and techniques that can achieve a specific desired result. We divide the craft into language skills (the micro level of words and sentences) and structure skills (the framework of your story, plot, characters, scenes, and so forth). We don't concern ourselves with language skills. There are plenty of excellent books and courses that help with these, including the best teacher: practice, practice, and more practice. Our trade is the structure skills. There are also plenty of excellent books and courses that teach these skills. Our contribution, StoryCAD, is a free desktop app for Windows and macOS that applies computer-aided design to help you create an outline for your story. The outline comprises story elements, which include a story overview, problems, characters, settings, and scenes. Your outline is your blueprint when you write your draft, using your language skills.
+
+Our latest addition to StoryCAD is StoryCAD Collaborator. It's a paid plug-in that helps you develop your outline. A **free trial** is available so you can try it before you buy. If a StoryCAD outline is a map, Collaborator is your GPS, an assistant that helps you navigate your story turn by turn. It's a collection of *workflows*, small AI helpers that can help you with the details of building and assembling story elements into something unique: *your* outline, for *your* story.
+
+From within your outline, when you launch Collaborator, you choose a craft job (a *workflow*). Collaborator works with the story elements that job needs, suggests text for specific fields on those elements, and **you** decide what goes into the outline.
+
+You don't need Collaborator to use StoryCAD. You need StoryCAD to use Collaborator. The plug-in exists for people who want an always-available assistant without leaving the outline they're already working on.
+
+Collaborator is not a replacement for writing craft. It sits beside StoryCAD’s forms and the craft ideas in this manual (especially [Writing with StoryCAD](../Writing%20with%20StoryCAD/Writing_with_StoryCAD.html)) and on [StoryBuilder.org](https://storybuilder.org/resources/).
+
+## In this section
+
+- [Getting Started](Getting_Started.html)
+- [What Collaborator Is](What_Collaborator_Is.html)
+- [Workflows and Writing Craft](Workflows_and_Writing_Craft.html)
+- [Opening Collaborator](Opening_Collaborator.html)
+- [Running a Workflow](Running_a_Workflow.html)
+- [Reviewing Suggestions](Reviewing_Suggestions.html)
+- [A Path to Try](A_Path_to_Try.html)
+- [An Example Session](An_Example_Session.html)
+- [Chat](Chat.html)
+- [Tips and Common Questions](Tips_and_Common_Questions.html)


### PR DESCRIPTION
## Summary
- The bare path `/docs/StoryCAD Collaborator/` returned 404 because the section had no `index.html`.
- Landing content now lives in `docs/StoryCAD Collaborator/index.md` so the folder URL and `index.html` resolve.
- `StoryCAD_Collaborator.md` remains as a `nav_exclude` meta-refresh redirect for old `StoryCAD_Collaborator.html` bookmarks.

## Related
Collaborator #170 (user manual status).

## Test plan
- [ ] After merge to `dev`, confirm `sync-beta-manual.yml` runs
- [ ] `https://beta.manual.storybuilder.org/docs/StoryCAD%20Collaborator/` returns 200 with landing content
- [ ] `.../StoryCAD_Collaborator.html` still reaches the landing (redirect)
- [ ] Child pages still load; nav parent **StoryCAD Collaborator** still works