### PR TITLE
feat: Scene Summary Problem and beat-neighbor gather (#174)

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -1528,7 +1528,113 @@ public class Collaborator : ICollaborator
             await GatherElementAsync(requirement, xamlRoot, result.Elements, result.StatusMessages, isRequired: false);
         }
 
+        // #174: Scene Summary injects optional owner Problem + beat-neighbor Scenes
+        // (not OptionalInputs — empty list; derived after Scene is chosen).
+        if (string.Equals(workflow.Label, "SceneSummary", StringComparison.Ordinal)
+            && result.Elements.TryGetValue("Scene", out var sceneElement)
+            && _storyApi != null)
+        {
+            await InjectSceneSummaryNeighborsAsync(sceneElement, xamlRoot, result);
+        }
+
         return result;
+    }
+
+    /// <summary>
+    /// Collaborator #174: resolve and inject Problem / PrecedingScene / NextScene for Scene Summary.
+    /// </summary>
+    private async Task InjectSceneSummaryNeighborsAsync(
+        StoryElement sceneElement,
+        Microsoft.UI.Xaml.XamlRoot xamlRoot,
+        GatherResult result)
+    {
+        var resolver = new Services.SceneStructureNeighborResolver(_storyApi!);
+        var resolved = resolver.ResolveForSceneSummary(sceneElement);
+
+        foreach (var line in resolved.StatusLines)
+            result.StatusMessages.Add(line);
+
+        switch (resolved.OwnerState)
+        {
+            case Services.SceneStructureNeighborResolver.OwnerState.Unique:
+            case Services.SceneStructureNeighborResolver.OwnerState.ExplorerParentOnly:
+                if (resolved.OwnerProblem != null)
+                    result.Elements["Problem"] = resolved.OwnerProblem;
+                if (resolved.PrecedingScene != null)
+                    result.Elements["PrecedingScene"] = resolved.PrecedingScene;
+                if (resolved.NextScene != null)
+                    result.Elements["NextScene"] = resolved.NextScene;
+                break;
+
+            case Services.SceneStructureNeighborResolver.OwnerState.None:
+                // Status already describes omit; no pickers.
+                break;
+
+            case Services.SceneStructureNeighborResolver.OwnerState.Ambiguous:
+                await HandleAmbiguousSceneOwnerAsync(sceneElement, resolver, resolved, xamlRoot, result);
+                break;
+        }
+    }
+
+    private async Task HandleAmbiguousSceneOwnerAsync(
+        StoryElement sceneElement,
+        Services.SceneStructureNeighborResolver resolver,
+        Services.SceneStructureNeighborResolver.ResolveResult resolved,
+        Microsoft.UI.Xaml.XamlRoot xamlRoot,
+        GatherResult result)
+    {
+        var candidates = resolved.OwnerCandidates;
+        if (candidates.Count == 0)
+        {
+            result.StatusMessages.Add("Scene Summary: ambiguous owner list empty; omitting Problem and neighbors.");
+            return;
+        }
+
+        var allowed = candidates.Select(p => p.Uuid).ToList();
+        var preselect = allowed[0];
+        var pickerVM = new ElementPickerVM();
+        // Strict allowlist; Create off (no invent parent).
+        var selectedGuid = await pickerVM.ShowPicker(
+            _storyModel!,
+            xamlRoot,
+            StoryItemType.Problem,
+            "Owner Problem",
+            preselect,
+            storyApi: null,
+            allowedGuids: allowed,
+            allowCreate: false);
+
+        await Task.Delay(100);
+
+        if (string.IsNullOrEmpty(selectedGuid)
+            || !Guid.TryParse(selectedGuid, out var chosen)
+            || !allowed.Contains(chosen))
+        {
+            result.StatusMessages.Add("Scene Summary: owner pick skipped or not a candidate; omitting Problem and neighbors.");
+            return;
+        }
+
+        var problemResult = _storyApi!.GetStoryElement(chosen);
+        if (!problemResult.IsSuccess || problemResult.Payload is not ProblemModel problem)
+        {
+            result.StatusMessages.Add("Scene Summary: chosen owner Problem not found; omitting.");
+            return;
+        }
+
+        result.Elements["Problem"] = problem;
+        var neighbors = resolver.FindNeighbors(problem, sceneElement.Uuid);
+        if (neighbors.PrecedingScene != null)
+            result.Elements["PrecedingScene"] = neighbors.PrecedingScene;
+        if (neighbors.NextScene != null)
+            result.Elements["NextScene"] = neighbors.NextScene;
+
+        result.StatusMessages.Add($"Scene Summary: owner Problem = {problem.Name} (chosen)");
+        result.StatusMessages.Add(neighbors.PrecedingScene != null
+            ? $"Scene Summary: preceding Scene = {neighbors.PrecedingScene.Name}"
+            : "Scene Summary: preceding Scene = (none)");
+        result.StatusMessages.Add(neighbors.NextScene != null
+            ? $"Scene Summary: next Scene = {neighbors.NextScene.Name}"
+            : "Scene Summary: next Scene = (none)");
     }
 
     /// <summary>

--- a/CollaboratorLib/Services/SceneStructureNeighborResolver.cs
+++ b/CollaboratorLib/Services/SceneStructureNeighborResolver.cs
@@ -1,0 +1,365 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using StoryCADLib.Models;
+using StoryCADLib.Services.Collaborator.Contracts;
+
+namespace StoryCollaborator.Services;
+
+/// <summary>
+/// Collaborator #174: resolve owner Problem and beat-neighbor Scenes for Scene Summary.
+/// Full elements for the gather map; no StoryContext prose.
+/// </summary>
+public sealed class SceneStructureNeighborResolver
+{
+    private readonly IStoryCADAPI _api;
+    private readonly ILogger<SceneStructureNeighborResolver>? _logger;
+
+    public SceneStructureNeighborResolver(IStoryCADAPI api, ILogger<SceneStructureNeighborResolver>? logger = null)
+    {
+        _api = api ?? throw new ArgumentNullException(nameof(api));
+        _logger = logger;
+    }
+
+    public enum OwnerState
+    {
+        None,
+        Unique,
+        Ambiguous,
+        ExplorerParentOnly
+    }
+
+    public sealed class ResolveResult
+    {
+        public ProblemModel? OwnerProblem { get; init; }
+        public SceneModel? PrecedingScene { get; init; }
+        public SceneModel? NextScene { get; init; }
+        public OwnerState OwnerState { get; init; }
+        public IReadOnlyList<ProblemModel> OwnerCandidates { get; init; } = Array.Empty<ProblemModel>();
+        public IReadOnlyList<string> StatusLines { get; init; } = Array.Empty<string>();
+    }
+
+    public sealed class NeighborPair
+    {
+        public SceneModel? PrecedingScene { get; init; }
+        public SceneModel? NextScene { get; init; }
+    }
+
+    /// <summary>
+    /// Full resolve for Scene Summary gather (no UI).
+    /// Calls FindNeighbors only for Unique, or ExplorerParentOnly when Scene is on that sheet.
+    /// </summary>
+    public ResolveResult ResolveForSceneSummary(StoryElement scene)
+    {
+        if (scene == null || scene.ElementType != StoryItemType.Scene)
+        {
+            return new ResolveResult
+            {
+                OwnerState = OwnerState.None,
+                StatusLines = new[] { "Scene Summary: no Scene element; owner omitted." }
+            };
+        }
+
+        var status = new List<string>();
+        var owners = FindStructureOwners(scene.Uuid, status);
+        var explorerParent = GetExplorerParentProblem(scene);
+        var (state, owner, candidates) = ResolveOwner(scene, owners, explorerParent);
+
+        if (state == OwnerState.Ambiguous)
+        {
+            var names = string.Join(", ", candidates.Select(p => p.Name));
+            status.Add($"Scene Summary: owner ambiguous ({candidates.Count}): {names}. Choose one or skip.");
+            return new ResolveResult
+            {
+                OwnerState = OwnerState.Ambiguous,
+                OwnerCandidates = candidates,
+                StatusLines = status
+            };
+        }
+
+        if (state == OwnerState.None)
+        {
+            status.Add("Scene Summary: no owner Problem (not on a structure; explorer parent is not a Problem).");
+            return new ResolveResult
+            {
+                OwnerState = OwnerState.None,
+                StatusLines = status
+            };
+        }
+
+        // Unique or ExplorerParentOnly
+        SceneModel? preceding = null;
+        SceneModel? next = null;
+        if (owner != null)
+        {
+            bool onSheet = owners.Any(o => o.Uuid == owner.Uuid);
+            if (state == OwnerState.Unique || (state == OwnerState.ExplorerParentOnly && onSheet))
+            {
+                var neighbors = FindNeighbors(owner, scene.Uuid);
+                preceding = neighbors.PrecedingScene;
+                next = neighbors.NextScene;
+            }
+
+            status.Add($"Scene Summary: owner Problem = {owner.Name}");
+            status.Add(preceding != null
+                ? $"Scene Summary: preceding Scene = {preceding.Name}"
+                : "Scene Summary: preceding Scene = (none)");
+            status.Add(next != null
+                ? $"Scene Summary: next Scene = {next.Name}"
+                : "Scene Summary: next Scene = (none)");
+        }
+
+        return new ResolveResult
+        {
+            OwnerProblem = owner,
+            PrecedingScene = preceding,
+            NextScene = next,
+            OwnerState = state,
+            OwnerCandidates = candidates,
+            StatusLines = status
+        };
+    }
+
+    /// <summary>
+    /// Problems whose structure assigns <paramref name="sceneGuid"/> on any beat.
+    /// </summary>
+    public IReadOnlyList<ProblemModel> FindStructureOwners(Guid sceneGuid, List<string>? statusLines = null)
+    {
+        var owners = new List<ProblemModel>();
+        var problemsResult = _api.GetElementsByType(StoryItemType.Problem);
+        if (!problemsResult.IsSuccess || problemsResult.Payload == null)
+        {
+            statusLines?.Add("Scene Summary: could not list Problems for structure scan.");
+            _logger?.LogWarning("FindStructureOwners: GetElementsByType(Problem) failed: {Msg}",
+                problemsResult.ErrorMessage);
+            return owners;
+        }
+
+        foreach (var el in problemsResult.Payload)
+        {
+            if (el is not ProblemModel problem)
+                continue;
+
+            var structure = _api.GetProblemStructure(problem.Uuid);
+            if (!structure.IsSuccess || structure.Payload.Beats == null)
+            {
+                _logger?.LogDebug("FindStructureOwners: skip Problem {Name} (structure failed)", problem.Name);
+                continue;
+            }
+
+            foreach (var beat in structure.Payload.Beats)
+            {
+                if (beat.LinkedElement is Guid linked && linked == sceneGuid)
+                {
+                    owners.Add(problem);
+                    break;
+                }
+            }
+        }
+
+        return owners;
+    }
+
+    /// <summary>
+    /// Explorer parent when parent node resolves to a Problem.
+    /// </summary>
+    public ProblemModel? GetExplorerParentProblem(StoryElement scene)
+    {
+        var parentUuid = scene.Node?.Parent?.Uuid ?? Guid.Empty;
+        if (parentUuid == Guid.Empty)
+            return null;
+
+        var result = _api.GetStoryElement(parentUuid);
+        if (result.IsSuccess && result.Payload is ProblemModel problem)
+            return problem;
+
+        return null;
+    }
+
+    /// <summary>
+    /// Apply multi-owner law (design §5.10).
+    /// </summary>
+    public (OwnerState State, ProblemModel? Owner, IReadOnlyList<ProblemModel> Candidates)
+        ResolveOwner(StoryElement scene, IReadOnlyList<ProblemModel> owners, ProblemModel? explorerParent)
+    {
+        var ownerList = owners?.ToList() ?? new List<ProblemModel>();
+
+        if (ownerList.Count == 0)
+        {
+            if (explorerParent != null)
+                return (OwnerState.ExplorerParentOnly, explorerParent, Array.Empty<ProblemModel>());
+            return (OwnerState.None, null, Array.Empty<ProblemModel>());
+        }
+
+        if (ownerList.Count == 1)
+            return (OwnerState.Unique, ownerList[0], Array.Empty<ProblemModel>());
+
+        // Multi-owner: prefer explorer parent when it is among owners
+        if (explorerParent != null)
+        {
+            var match = ownerList.FirstOrDefault(o => o.Uuid == explorerParent.Uuid);
+            if (match != null)
+                return (OwnerState.Unique, match, Array.Empty<ProblemModel>());
+        }
+
+        return (OwnerState.Ambiguous, null, ownerList);
+    }
+
+    /// <summary>
+    /// Immediate previous and next neighbor Scenes on the owner sheet (1+1).
+    /// Prev/next Problem slots expand to last/first nested Scene.
+    /// </summary>
+    public NeighborPair FindNeighbors(ProblemModel owner, Guid sceneGuid)
+    {
+        if (owner == null)
+            return new NeighborPair();
+
+        var structure = _api.GetProblemStructure(owner.Uuid);
+        if (!structure.IsSuccess || structure.Payload.Beats == null)
+            return new NeighborPair();
+
+        var beats = structure.Payload.Beats.ToList();
+        int index = -1;
+        for (int i = 0; i < beats.Count; i++)
+        {
+            if (beats[i].LinkedElement is Guid g && g == sceneGuid)
+            {
+                index = i;
+                break; // first hit if duplicate on one sheet
+            }
+        }
+
+        if (index < 0)
+            return new NeighborPair();
+
+        if (beats.Count(b => b.LinkedElement is Guid g && g == sceneGuid) > 1)
+            _logger?.LogDebug("FindNeighbors: Scene {Guid} appears more than once on {Problem}; using first index",
+                sceneGuid, owner.Name);
+
+        SceneModel? preceding = null;
+        if (index > 0)
+            preceding = ResolvePrecedingFromLinked(beats[index - 1].LinkedElement);
+
+        SceneModel? next = null;
+        if (index < beats.Count - 1)
+            next = ResolveNextFromLinked(beats[index + 1].LinkedElement);
+
+        return new NeighborPair { PrecedingScene = preceding, NextScene = next };
+    }
+
+    /// <summary>
+    /// Resolve previous slot: Scene as-is; Problem → last Scene under that structure.
+    /// </summary>
+    public SceneModel? ResolvePrecedingFromLinked(Guid? linked)
+    {
+        if (linked is not Guid guid || guid == Guid.Empty)
+            return null;
+
+        var elResult = _api.GetStoryElement(guid);
+        if (!elResult.IsSuccess || elResult.Payload == null)
+            return null;
+
+        if (elResult.Payload is SceneModel scene)
+            return scene;
+
+        if (elResult.Payload is ProblemModel problem)
+            return LastSceneInStructure(problem, new HashSet<Guid>());
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolve next slot: Scene as-is; Problem → first Scene under that structure.
+    /// </summary>
+    public SceneModel? ResolveNextFromLinked(Guid? linked)
+    {
+        if (linked is not Guid guid || guid == Guid.Empty)
+            return null;
+
+        var elResult = _api.GetStoryElement(guid);
+        if (!elResult.IsSuccess || elResult.Payload == null)
+            return null;
+
+        if (elResult.Payload is SceneModel scene)
+            return scene;
+
+        if (elResult.Payload is ProblemModel problem)
+            return FirstSceneInStructure(problem, new HashSet<Guid>());
+
+        return null;
+    }
+
+    // Fix FindNeighbors to use ResolvePreceding/NextFromLinked
+    // (rewritten below in patch if needed)
+
+    public SceneModel? LastSceneInStructure(ProblemModel problem, HashSet<Guid> visited)
+    {
+        if (problem == null)
+            return null;
+        if (!visited.Add(problem.Uuid))
+            return null;
+
+        var structure = _api.GetProblemStructure(problem.Uuid);
+        if (!structure.IsSuccess || structure.Payload.Beats == null)
+            return null;
+
+        SceneModel? last = null;
+        foreach (var beat in structure.Payload.Beats)
+        {
+            if (beat.LinkedElement is not Guid guid || guid == Guid.Empty)
+                continue;
+
+            var elResult = _api.GetStoryElement(guid);
+            if (!elResult.IsSuccess || elResult.Payload == null)
+                continue;
+
+            if (elResult.Payload is SceneModel scene)
+            {
+                last = scene;
+            }
+            else if (elResult.Payload is ProblemModel nested)
+            {
+                var nestedLast = LastSceneInStructure(nested, visited);
+                if (nestedLast != null)
+                    last = nestedLast;
+            }
+        }
+
+        return last;
+    }
+
+    public SceneModel? FirstSceneInStructure(ProblemModel problem, HashSet<Guid> visited)
+    {
+        if (problem == null)
+            return null;
+        if (!visited.Add(problem.Uuid))
+            return null;
+
+        var structure = _api.GetProblemStructure(problem.Uuid);
+        if (!structure.IsSuccess || structure.Payload.Beats == null)
+            return null;
+
+        foreach (var beat in structure.Payload.Beats)
+        {
+            if (beat.LinkedElement is not Guid guid || guid == Guid.Empty)
+                continue;
+
+            var elResult = _api.GetStoryElement(guid);
+            if (!elResult.IsSuccess || elResult.Payload == null)
+                continue;
+
+            if (elResult.Payload is SceneModel scene)
+                return scene;
+
+            if (elResult.Payload is ProblemModel nested)
+            {
+                var nestedFirst = FirstSceneInStructure(nested, visited);
+                if (nestedFirst != null)
+                    return nestedFirst;
+            }
+        }
+
+        return null;
+    }
+}

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -686,14 +686,41 @@ namespace StoryCollaborator.Workflows
                 // SettingCreateImage removed; preserved on branch issue-76-image-workflows (issue #76).
 
                 // === Scene Workflows ===
+                // #174: Scene only on RequiredInputs. Problem / PrecedingScene / NextScene are
+                // inject-only after structure resolve (never OptionalInputs).
                 new Workflow(
-                    "SceneSummary", "Scene Summary",
-                    "Create a concise summary of a scene's purpose, content, and role in the larger story.",
-                    StoryItemType.Scene,
+                    label: "SceneSummary",
+                    title: "Scene Summary",
+                    description: "Create a concise summary of a scene's purpose, content, and role in the larger story.",
                     explanation: "Every scene should earn its place. This workflow helps you articulate what happens " +
                                 "in the scene, why it matters, and what would be lost without it—ensuring each scene " +
                                 "advances plot, reveals character, or both.",
-                    outputProperties: new List<PropertySpec> { new PropertySpec("Description") }),
+                    workflowIO: new WorkflowIO
+                    {
+                        RequiredInputs = new List<ElementRequirement>
+                        {
+                            new ElementRequirement
+                            {
+                                ElementType = StoryItemType.Scene,
+                                ElementLabel = "Scene",
+                                RequiredProperties = new List<PropertySpec>(),
+                                CreateIfMissing = false
+                            }
+                        },
+                        OptionalInputs = new List<ElementRequirement>(),
+                        Outputs = new List<ElementOutput>
+                        {
+                            new ElementOutput
+                            {
+                                ElementType = StoryItemType.Scene,
+                                ElementLabel = "Scene",
+                                PropertiesToUpdate = new List<PropertySpec>
+                                {
+                                    new PropertySpec("Description")
+                                }
+                            }
+                        }
+                    }) { PrimaryElementType = StoryItemType.Scene },
                 new Workflow(
                     "CastSceneRoles", "Cast and Scene Roles",
                     "Define which characters appear in a scene and what role each plays—protagonist, antagonist, " +

--- a/StoryCADLib/Collaborator/ViewModels/ElementPickerVM.cs
+++ b/StoryCADLib/Collaborator/ViewModels/ElementPickerVM.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using StoryCADLib.Models;
@@ -22,6 +23,17 @@ public class ElementPickerVM
     public Guid? CurrentSelection { get; set; }
 
     /// <summary>
+    /// When non-null and non-empty, the list shows only these element GUIDs (same ForcedType).
+    /// When null, the list shows all elements of the forced/selected type (default).
+    /// </summary>
+    public IReadOnlyCollection<Guid> AllowedGuids { get; set; }
+
+    /// <summary>
+    /// When false, hide Create UI and do not create elements. Default true.
+    /// </summary>
+    public bool AllowCreate { get; set; } = true;
+
+    /// <summary>
     /// API used to create new elements. Set by <see cref="ShowPicker"/>.
     /// </summary>
     public IStoryCADAPI StoryApi { get; set; }
@@ -34,13 +46,17 @@ public class ElementPickerVM
     /// <summary>
     /// Shows the picker. Returns selected element GUID, or null if cancelled / nothing selected.
     /// </summary>
+    /// <param name="allowedGuids">Optional allowlist. Null = no filter. Non-empty = candidates only.</param>
+    /// <param name="allowCreate">When false, Create control is hidden and Create no-ops.</param>
     public async Task<string> ShowPicker(
         StoryModel Model,
         XamlRoot XAMLRoot,
         StoryItemType? Type = null,
         string label = null,
         Guid? currentSelection = null,
-        IStoryCADAPI storyApi = null)
+        IStoryCADAPI storyApi = null,
+        IReadOnlyCollection<Guid> allowedGuids = null,
+        bool allowCreate = true)
     {
         SelectedType = null;
         SelectedElement = null;
@@ -49,7 +65,10 @@ public class ElementPickerVM
         StoryModel = Model;
         PickerLabel = label;
         CurrentSelection = currentSelection;
-        StoryApi = storyApi;
+        AllowedGuids = allowedGuids;
+        AllowCreate = allowCreate;
+        // Strict filter paths pass null API so Create cannot mutate the outline.
+        StoryApi = allowCreate ? storyApi : null;
 
         var ui = new Views.ElementPicker(this);
 
@@ -112,7 +131,7 @@ public class ElementPickerVM
     /// </summary>
     public void CreateNode()
     {
-        if (StoryApi == null || StoryModel == null)
+        if (!AllowCreate || StoryApi == null || StoryModel == null)
             return;
 
         StoryItemType type;

--- a/StoryCADLib/Collaborator/Views/ElementPicker.xaml.cs
+++ b/StoryCADLib/Collaborator/Views/ElementPicker.xaml.cs
@@ -79,7 +79,9 @@ public sealed partial class ElementPicker : Page
             return;
         }
 
-        NewButton.IsEnabled = true;
+        // Create only when allowed (filtered multi-owner path sets AllowCreate false).
+        NewButton.IsEnabled = PickerVM.AllowCreate;
+        NewButton.Visibility = PickerVM.AllowCreate ? Visibility.Visible : Visibility.Collapsed;
 
         var elements = type switch
         {
@@ -98,10 +100,17 @@ public sealed partial class ElementPicker : Page
         }
 
         // Skip(1) drops the "(none)" placeholder; the rest are listed alphabetically.
-        var elementList = elements.Skip(1)
+        IEnumerable<StoryElement> query = elements.Skip(1);
+        if (PickerVM.AllowedGuids is { Count: > 0 } allowed)
+        {
+            var set = allowed as HashSet<Guid> ?? allowed.ToHashSet();
+            query = query.Where(e => set.Contains(e.Uuid));
+        }
+
+        var elementList = query
             .OrderBy(e => e.Name, StringComparer.CurrentCultureIgnoreCase)
             .ToList();
-        ElementBox.IsEnabled = true;
+        ElementBox.IsEnabled = elementList.Count > 0;
         ElementBox.ItemsSource = elementList;
 
         if (preserve != null)

--- a/StoryCADTests/Collaborator/ViewModels/ElementPickerVMTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/ElementPickerVMTests.cs
@@ -52,6 +52,40 @@ public class ElementPickerVMTests
         Assert.IsNull(vm.ForcedType);
         Assert.IsNull(vm.PickerLabel);
         Assert.IsNull(vm.CurrentSelection);
+        Assert.IsNull(vm.AllowedGuids);
+        Assert.IsTrue(vm.AllowCreate);
+    }
+
+    #endregion
+
+    #region Allowlist / Create filter (#174)
+
+    [TestMethod]
+    public void AllowedGuids_WhenSet_ReturnsSetValue()
+    {
+        var guids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        _viewModel.AllowedGuids = guids;
+        Assert.AreSame(guids, _viewModel.AllowedGuids);
+    }
+
+    [TestMethod]
+    public void AllowCreate_DefaultTrue_CanDisable()
+    {
+        Assert.IsTrue(_viewModel.AllowCreate);
+        _viewModel.AllowCreate = false;
+        Assert.IsFalse(_viewModel.AllowCreate);
+    }
+
+    [TestMethod]
+    public void CreateNode_WhenAllowCreateFalse_DoesNotCreate()
+    {
+        _viewModel.AllowCreate = false;
+        _viewModel.StoryModel = _storyModel;
+        _viewModel.ForcedType = StoryItemType.Problem;
+        _viewModel.NewNodeName = "Should not create";
+        // StoryApi left null and AllowCreate false — CreateNode must no-op
+        _viewModel.CreateNode();
+        Assert.IsNull(_viewModel.SelectedElement);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
Scene Summary gathers optional **owner Problem** and **preceding/next Scenes** as full elements on the gather map (same family as Problem → Protagonist/Antagonist), not StoryContext prose.

## Changes
- `SceneStructureNeighborResolver` — structure owners, explorer parent, multi-owner, 1+1 neighbors, nested Problem last/first Scene, cycle guard
- Registry: `SceneSummary` full WorkflowIO; empty OptionalInputs; Description only
- Gather inject after Scene; ambiguous owner → ElementPicker **allowlist** + Create off
- ElementPicker: optional `allowedGuids` / `allowCreate`
- Unit tests (picker properties); resolver tests live in Collaborator

## Why
Collaborator **#174**. Design: `Collaborator/devdocs/issue_174_scene_summary_neighbors_design.md`.

## How to test
1. Outline with Problem + 3 assigned Scenes; run Scene Summary on middle Scene.
2. Status names owner + neighbors; Accept still Description only.
3. Multi-owner: same Scene on two sheets, explorer parent not owner → picker of candidates only; skip omits.
4. `SceneStructureNeighborResolverTests` (CollaboratorTests) 12/12.

## Pairing
- Collaborator PR: Worker template + design + resolver tests (same issue).

Related: storybuilder-org/Collaborator#174