### PR TITLE
fix: TraitList proposal display (not CLR type name)

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -974,8 +974,10 @@ public class Collaborator : ICollaborator
 
     private PendingUpdateItem ToSessionPendingUpdateItem(SessionProposalSet.Entry e)
     {
-        var u = e.Update with { Value = e.ProposedText };
-        var proposed = TruncateForChat(FormatValueForDisplay(u.Value), 500);
+        // ProposedText is already ValueDisplay-formatted at capture; do not rebind Value to that string
+        // (List properties must keep typed Values for Accept / SimpleList).
+        var u = e.Update;
+        var proposed = TruncateForChat(e.ProposedText, 500);
         var current = TruncateForChat(u.CurrentDisplay ?? string.Empty, 300);
         var kindLabel = e.Status switch
         {

--- a/CollaboratorLib/Services/SessionProposalSet.cs
+++ b/CollaboratorLib/Services/SessionProposalSet.cs
@@ -76,10 +76,15 @@ public sealed class SessionProposalSet
         return true;
     }
 
+    /// <summary>
+    /// Open rows for Accept. Keep typed <see cref="PendingUpdate.Value"/> (e.g. List&lt;string&gt; for
+    /// SimpleList). Do not replace with ProposedText — that is display/chat only; List.ToString() is garbage.
+    /// Chat patches already store the new text on <see cref="PendingUpdate.Value"/> via TryApplyPatch.
+    /// </summary>
     public IEnumerable<PendingUpdate> OpenAsPendingUpdates() =>
         _entries.Values
             .Where(e => e.Status == ProposalSessionStatus.Open)
-            .Select(e => e.Update with { Value = e.ProposedText });
+            .Select(e => e.Update);
 
     /// <summary>
     /// Snapshot for chat history: full proposed text and full outline value at capture time.
@@ -145,13 +150,11 @@ public sealed class SessionProposalSet
         "Do not invent patches. Suggest Accept, Try Again, another workflow, or editing the outline.\n" +
         "- Do not invent element IDs or properties outside the proposal list. Do not claim text is missing if Outline or Proposed is present in the snapshot.";
 
-    private static string FormatValue(object? value) =>
-        value switch
-        {
-            null => string.Empty,
-            string s => s,
-            _ => value.ToString() ?? string.Empty
-        };
+    /// <summary>
+    /// Human-readable proposal text. Must not use object.ToString() on lists
+    /// (leaks "System.Collections.Generic.List`1[System.String]").
+    /// </summary>
+    private static string FormatValue(object? value) => ValueDisplay.Format(value);
 
     public sealed record Entry(
         PendingUpdate Update,

--- a/StoryCADTests/Collaborator/SessionProposalSetTests.cs
+++ b/StoryCADTests/Collaborator/SessionProposalSetTests.cs
@@ -97,4 +97,27 @@ public class SessionProposalSetTests
         Assert.AreEqual(1, open.Count);
         Assert.AreEqual("Problem.Premise", open[0].Key);
     }
+
+    [TestMethod]
+    public void SimpleList_ProposedText_NotClrTypeName_AndOpenKeepsList()
+    {
+        // DefineCharacter TraitList: List.ToString() used to leak List`1[System.String] in the UI.
+        var traits = new List<string> { "guarded", "precise", "dry humor" };
+        var spec = new PropertySpec("TraitList", WriteVia.SimpleList, ListEntryType: typeof(string));
+        var update = new PendingUpdate("Character", Guid.NewGuid(), spec, traits, UpdateKind.Fill, null);
+
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(new[] { update });
+
+        var entry = set.Get("Character.TraitList");
+        Assert.IsNotNull(entry);
+        Assert.IsFalse(entry!.ProposedText.Contains("System.Collections", StringComparison.Ordinal),
+            entry.ProposedText);
+        StringAssert.Contains(entry.ProposedText, "guarded");
+        StringAssert.Contains(entry.ProposedText, "precise");
+
+        var open = set.OpenAsPendingUpdates().Single();
+        Assert.IsInstanceOfType(open.Value, typeof(List<string>));
+        CollectionAssert.AreEqual(traits, (List<string>)open.Value!);
+    }
 }


### PR DESCRIPTION
## Summary
After Define Character, **TraitList** showed `System.Collections.Generic.List`1[System.String]` instead of the trait strings.

## Cause
`SessionProposalSet.FormatValue` used `value.ToString()` for non-strings. `OpenAsPendingUpdates` also rebound `Value` to that display string, which would break SimpleList Accept.

## Fix
- Format with `ValueDisplay.Format` (bullet list of traits)
- Keep typed `PendingUpdate.Value` for Accept
- Test: list proposed text + open rows keep `List&lt;string&gt;`

## How to test
1. Run Define Character; TraitList row should show traits (bullets), not a CLR type name
2. Accept TraitList; traits write to the character sheet