### PR TITLE
feat: StoryFunction workflow; retire RoleAndStoryRole (#183)

### DIFF
--- a/CollaboratorLib/Context/ContextResolver.cs
+++ b/CollaboratorLib/Context/ContextResolver.cs
@@ -25,11 +25,11 @@ public class ContextResolver
     /// </summary>
     public static readonly HashSet<string> RelatedProblemsWorkflows = new(StringComparer.OrdinalIgnoreCase)
     {
-        // #182: DefineCharacter replaces bulk micro-workflows. RoleAndStoryRole stays until #183.
+        // #182 DefineCharacter; #183 StoryFunction. Flaw/Backstory until #184.
         "DefineCharacter",
+        "StoryFunction",
         "Flaw",
-        "Backstory",
-        "RoleAndStoryRole"
+        "Backstory"
     };
 
     public const string RelatedProblemsRequestName = "RelatedProblems";

--- a/CollaboratorLib/Context/GapDetail.cs
+++ b/CollaboratorLib/Context/GapDetail.cs
@@ -19,7 +19,7 @@ public sealed class GapDetail
 
     /// <summary>
     /// Distinct Collaborator workflow labels that help fill these properties
-    /// (e.g. GMC, RoleAndStoryRole). Empty if only host-element edit applies.
+    /// (e.g. GMC, StoryFunction). Empty if only host-element edit applies.
     /// </summary>
     public required IReadOnlyList<string> HelperWorkflowLabels { get; init; }
 }

--- a/CollaboratorLib/Context/GapWorkflowOwnership.cs
+++ b/CollaboratorLib/Context/GapWorkflowOwnership.cs
@@ -42,10 +42,10 @@ public static class GapWorkflowOwnership
             (StoryItemType.Problem, "Premise") => new[] { "StoryProblem" },
             (StoryItemType.Problem, "Description") => new[] { "StoryProblem" },
 
-            (StoryItemType.Character, "Role") => new[] { "RoleAndStoryRole" },
-            (StoryItemType.Character, "StoryRole") => new[] { "RoleAndStoryRole" },
-            // Character Sketch — Role and Story Role (#142)
-            (StoryItemType.Character, "Description") => new[] { "RoleAndStoryRole" },
+            // #182 occupation Role; #183 Story Function + Character Sketch
+            (StoryItemType.Character, "Role") => new[] { "DefineCharacter" },
+            (StoryItemType.Character, "StoryRole") => new[] { "StoryFunction" },
+            (StoryItemType.Character, "Description") => new[] { "StoryFunction" },
             (StoryItemType.Character, "Name") => Array.Empty<string>(),
 
             (StoryItemType.Setting, "Description") => new[] { "SettingTimeSpace" },

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -33,7 +33,7 @@ namespace StoryCollaborator.Workflows
             "StoryProblem",
             "GMC",
             "Structure",
-            "RoleAndStoryRole",
+            "StoryFunction",
             "SceneSummary",
             "SceneConflict"
         };
@@ -520,7 +520,6 @@ namespace StoryCollaborator.Workflows
                     }) { PrimaryElementType = StoryItemType.Problem },
                 // === Character Workflows ===
                 // #182 DefineCharacter: world identity + personality. Occupation Role lives here.
-                // #183 will rename remaining RoleAndStoryRole → StoryFunction (Story Role + Sketch only).
                 new Workflow(
                     "DefineCharacter", "Define Character",
                     "Define who this person is in the world: occupation, body, social background, " +
@@ -572,11 +571,10 @@ namespace StoryCollaborator.Workflows
                         "Creativity", "Dominance", "Enthusiasm", "Assurance", "Sensitivity",
                         "Shrewdness", "Sociability", "Stability"
                     }),
-                // Temporary until #183 StoryFunction: Story Role + Archetype + Character Sketch only.
-                // Occupation Role stripped (#182) so DefineCharacter is the sole Role writer.
+                // #183 StoryFunction: plot function only. Occupation Role is DefineCharacter.
                 new Workflow(
-                    "RoleAndStoryRole", "Role and Story Role",
-                    "Define a character's story function and a short Character Sketch.",
+                    "StoryFunction", "Character Story Function",
+                    "Define the character's plot function: Story Role, Archetype, and Character Sketch.",
                     StoryItemType.Character,
                     explanation: "Story Role is narrative function (Protagonist, Antagonist, Supporting). " +
                                 "Archetype is the universal pattern (Hero, Mentor, Shadow). " +

--- a/StoryCADTests/Collaborator/StoryFunctionSketchTests.cs
+++ b/StoryCADTests/Collaborator/StoryFunctionSketchTests.cs
@@ -5,27 +5,29 @@ using StoryCollaborator.Workflows;
 namespace StoryCADTests.Collaborator;
 
 /// <summary>
-/// Collaborator #142 / #182: Story function owns Character Sketch (Description).
+/// Collaborator #142 / #183: StoryFunction owns Character Sketch (Description).
 /// Occupation Role is DefineCharacter (#182).
 /// </summary>
 [TestClass]
-public class RoleAndStoryRoleSketchTests
+public class StoryFunctionSketchTests
 {
     [TestMethod]
-    public void RoleAndStoryRole_Outputs_IncludeDescription_NotOccupationRole()
+    public void StoryFunction_Outputs_IncludeDescription_NotOccupationRole()
     {
-        var wf = WorkflowRegistry.Get("RoleAndStoryRole");
+        var wf = WorkflowRegistry.Get("StoryFunction");
         Assert.IsNotNull(wf);
-        var props = wf!.GetIO().Outputs
+        Assert.AreEqual("Character Story Function", wf!.Title);
+        var props = wf.GetIO().Outputs
             .SelectMany(o => o.PropertiesToUpdate)
             .Select(p => p.Property)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        Assert.IsFalse(props.Contains("Role"), "Occupation Role moved to DefineCharacter (#182)");
+        Assert.IsFalse(props.Contains("Role"), "Occupation Role is DefineCharacter (#182)");
         Assert.IsTrue(props.Contains("StoryRole"));
         Assert.IsTrue(props.Contains("Archetype"));
         Assert.IsTrue(props.Contains("Description"),
             "Character Sketch is Description on Character");
+        Assert.IsNull(WorkflowRegistry.Get("RoleAndStoryRole"));
     }
 
     [TestMethod]
@@ -43,13 +45,27 @@ public class RoleAndStoryRoleSketchTests
     }
 
     [TestMethod]
-    public void GapOwnership_CharacterDescription_PointsToRoleAndStoryRole()
+    public void GapOwnership_CharacterSketchAndStoryRole_PointToStoryFunction()
     {
-        var owners = GapWorkflowOwnership.WorkflowsFor(
+        var desc = GapWorkflowOwnership.WorkflowsFor(
             StoryItemType.Character, "Description");
-        Assert.AreEqual(1, owners.Count);
-        Assert.AreEqual("RoleAndStoryRole", owners[0]);
+        Assert.AreEqual(1, desc.Count);
+        Assert.AreEqual("StoryFunction", desc[0]);
         Assert.AreEqual("Character Sketch",
             GapWorkflowOwnership.DisplayLabel(StoryItemType.Character, "Description"));
+
+        var storyRole = GapWorkflowOwnership.WorkflowsFor(
+            StoryItemType.Character, "StoryRole");
+        Assert.AreEqual(1, storyRole.Count);
+        Assert.AreEqual("StoryFunction", storyRole[0]);
+    }
+
+    [TestMethod]
+    public void GapOwnership_CharacterRole_PointsToDefineCharacter()
+    {
+        var owners = GapWorkflowOwnership.WorkflowsFor(
+            StoryItemType.Character, "Role");
+        Assert.AreEqual(1, owners.Count);
+        Assert.AreEqual("DefineCharacter", owners[0]);
     }
 }


### PR DESCRIPTION
## Summary

- Registry: `StoryFunction` / Character Story Function; remove `RoleAndStoryRole`.
- Outputs: StoryRole, Archetype, Description (no occupation Role).
- RelatedProblems membership swaps to StoryFunction; default stars use StoryFunction.
- Gap ownership: Character Role → DefineCharacter; StoryRole and Description → StoryFunction.
- Tests: StoryFunctionSketchTests.

Implements client half of Collaborator **#183** (epic #180 surface 2). Pair with Collaborator Worker PR.

## Test plan

- [x] Build CollaboratorLib + StoryCADTests
- [x] Unit: StoryFunction outputs, gap maps, Role → DefineCharacter
- [x] Human smoke: Character linked as prot/antag; run Character Story Function; Accept writes StoryRole/Archetype/Description; occupation Role unchanged
- [ ] CI green

## Related

- Collaborator #183
- Design: Collaborator `devdocs/issue_183_story_function_design.md`
- Depends on #182 DefineCharacter (shipped)