### PR TITLE
feat: FlawBackstory workflow; retire Flaw and Backstory (#184)

### DIFF
--- a/CollaboratorLib/Context/ContextResolver.cs
+++ b/CollaboratorLib/Context/ContextResolver.cs
@@ -25,11 +25,10 @@ public class ContextResolver
     /// </summary>
     public static readonly HashSet<string> RelatedProblemsWorkflows = new(StringComparer.OrdinalIgnoreCase)
     {
-        // #182 DefineCharacter; #183 StoryFunction. Flaw/Backstory until #184.
+        // #182 DefineCharacter; #183 StoryFunction; #184 FlawBackstory.
         "DefineCharacter",
         "StoryFunction",
-        "Flaw",
-        "Backstory"
+        "FlawBackstory"
     };
 
     public const string RelatedProblemsRequestName = "RelatedProblems";

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -589,25 +589,23 @@ namespace StoryCollaborator.Workflows
                         new PropertySpec("Description")
                     },
                     exampleLists: new List<string> { "StoryRole", "Archetype" }),
+                // #184 FlawBackstory: wound + history together. Retires Flaw and Backstory.
                 new Workflow(
-                    "Flaw", "Character Flaw",
-                    "Identify and develop a character's central flaw—the weakness or blind spot tied to their " +
-                    "inner problem and character arc.",
+                    "FlawBackstory", "Flaw and Backstory",
+                    "Identify the character's central flaw and the formative history that grounds it.",
                     StoryItemType.Character,
-                    explanation: "A flaw is often the source of inner conflict and the key to character transformation. " +
-                                "This workflow helps you identify a flaw that matters to your story—one that creates " +
-                                "problems, blocks goals, and must be overcome (or not) for the character's arc to complete.",
-                    outputProperties: new List<PropertySpec> { new PropertySpec("Flaw") }),
-                new Workflow(
-                    "Backstory", "Backstory",
-                    "Develop the character's formative history—the wound, ghost, or defining events that explain " +
-                    "who they are now.",
-                    StoryItemType.Character,
-                    explanation: "Backstory is cause and explanation. Something happened that created your character's " +
-                                "flaw, shaped their worldview, and drives their current behavior. This workflow helps " +
-                                "you identify that wound or defining moment—what the character may not even consciously " +
-                                "remember but which controls them still.",
-                    outputProperties: new List<PropertySpec> { new PropertySpec("BackStory") }),
+                    explanation: "Flaw is the weakness or blind spot that creates internal cost. BackStory is formative " +
+                                "history. When empty, this run fills focused history that grounds the flaw. When already " +
+                                "filled, this run keeps existing facts and weaves Ghost and wound into them. Related " +
+                                "Problems bound stakes. Prefer rows marked Person vs. Self when present. Problem workflow " +
+                                "Inner and Outer Problems may also write Flaw from the problem side; last Accept wins. " +
+                                "Does not set Story Role, Character Sketch, bulk sheet fields, or Relationship.",
+                    outputProperties: new List<PropertySpec>
+                    {
+                        new PropertySpec("Flaw"),
+                        new PropertySpec("BackStory")
+                    },
+                    exampleLists: new List<string> { "Wound", "WoundCategory" }),
                 new Workflow(
                     label: "Relationship",
                     title: "Character Relationship",

--- a/StoryCADTests/Collaborator/WorkflowStarServiceTests.cs
+++ b/StoryCADTests/Collaborator/WorkflowStarServiceTests.cs
@@ -61,11 +61,11 @@ public class WorkflowStarServiceTests
     public async Task GetStarredAsync_AfterUserEdit_ReturnsTheEdit()
     {
         await _service.GetStarredAsync(Defaults);
-        await _service.SetStarredAsync(new[] { "Backstory" });
+        await _service.SetStarredAsync(new[] { "FlawBackstory" });
 
         var starred = await _service.GetStarredAsync(Defaults);
 
-        CollectionAssert.AreEqual(new[] { "Backstory" }, starred.ToArray());
+        CollectionAssert.AreEqual(new[] { "FlawBackstory" }, starred.ToArray());
     }
 
     [TestMethod]
@@ -85,11 +85,11 @@ public class WorkflowStarServiceTests
     public async Task SetStarredAsync_BeforeAnyRead_MarksDefaultsApplied()
     {
         // Otherwise the next read would seed the defaults straight over the user's pick.
-        await _service.SetStarredAsync(new[] { "Backstory" });
+        await _service.SetStarredAsync(new[] { "FlawBackstory" });
 
         var starred = await _service.GetStarredAsync(Defaults);
 
-        CollectionAssert.AreEqual(new[] { "Backstory" }, starred.ToArray());
+        CollectionAssert.AreEqual(new[] { "FlawBackstory" }, starred.ToArray());
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- Registry: `FlawBackstory` (title Flaw and Backstory) owns `Flaw` + `BackStory`; ExampleLists `Wound`, `WoundCategory`
- Retire micro-workflows `Flaw` and `Backstory` (no aliases)
- RelatedProblems set: DefineCharacter, StoryFunction, FlawBackstory
- Star service test samples updated to live label

Implements Character surface 3 from Collaborator epic #180 / issue #184 (design `issue_184_flaw_backstory_design.md`).

## Test plan
- [x] CollaboratorLib build (Debug/x64)
- [x] StoryCADTests: gap non-require Flaw/BackStory; WorkflowStarService suite
- [x] CollaboratorTests (sibling repo, project-ref this lib): registry, RelatedProblems body, ContextResolver
- [ ] Smoke after Collaborator Worker PR: empty + filled BackStory integrate (KD-17)

## Notes
- Accept still Scalar; filled BackStory craft law is on Worker (integrate, do not erase)
- InnerOuterProblems still may write Protagonist.Flaw; last Accept wins
- Pair with Collaborator PR for Worker template