### PR TITLE
fix: reload host ViewModel after Collaborator Accept

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -7,6 +7,7 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using NLog.Extensions.Logging;
 using StoryCADLib.Models;
+using StoryCADLib.Services;
 using StoryCADLib.Services.Collaborator;
 using StoryCADLib.Services.Collaborator.Contracts;
 using StoryCADLib.Services.Store;
@@ -712,6 +713,32 @@ public class Collaborator : ICollaborator
     }
 
     /// <summary>
+    /// After Collaborator Accept writes the model via API, reload the host page ViewModel
+    /// so the Character (etc.) form and later AutoSave flushes see the new values.
+    /// Close already reloads; Accept did not — empty VM then overwrote applied fields.
+    /// </summary>
+    private void ReloadHostViewModelFromModel()
+    {
+        try
+        {
+            var appState = Ioc.Default.GetService<AppState>();
+            if (appState?.CurrentSaveable is IReloadable reloadable)
+            {
+                reloadable.ReloadFromModel();
+                _logger?.LogInformation("Reloaded host ViewModel from Model after Accept apply");
+            }
+            else
+            {
+                _logger?.LogDebug("No IReloadable CurrentSaveable after Accept apply");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Host ViewModel reload after Accept failed");
+        }
+    }
+
+    /// <summary>
     /// Sets Collaborator settings. Can be called before or after OpenAsync.
     /// </summary>
     public void SetSettings(CollaboratorSettings settings)
@@ -1169,6 +1196,11 @@ public class Collaborator : ICollaborator
                         var applied = runner.ApplyUpdates(slice, gatheredElements);
                         foreach (var u in list)
                             _sessionTouchedFields.Add(u.SessionTouchKey);
+                        // Accept writes the model via API. Host element VMs stay stale until
+                        // reload — AutoSave FlushCurrentEdits then SaveModel's empty VM values
+                        // over the applied text (Character.BackStory wipe after #184 Accept).
+                        if (applied > 0)
+                            ReloadHostViewModelFromModel();
                         return applied;
                     }
 

--- a/StoryCADLib/Controls/RichEditBoxExtended.WinAppSDK.cs
+++ b/StoryCADLib/Controls/RichEditBoxExtended.WinAppSDK.cs
@@ -72,9 +72,15 @@ public partial class RichEditBoxExtended : RichEditBox
         rtb._lockChangeExecution = true;
         var wasReadOnly = rtb.IsReadOnly;
         rtb.IsReadOnly = false;
+        // Collaborator Accept writes plain text. FormatRtf on non-RTF leaves the box blank
+        // and TextChanged can clear the bound property. Use plain set when not RTF.
+        var text = rtb.RtfText ?? "";
+        var isRtf = text.TrimStart().StartsWith(@"{\rtf", StringComparison.Ordinal);
         rtb.Document.SetText(
-            TextSetOptions.FormatRtf | TextSetOptions.ApplyRtfDocumentDefaults,
-            rtb.RtfText ?? "");
+            isRtf
+                ? TextSetOptions.FormatRtf | TextSetOptions.ApplyRtfDocumentDefaults
+                : TextSetOptions.None,
+            text);
         rtb.IsReadOnly = wasReadOnly;
         rtb._lockChangeExecution = false;
     }


### PR DESCRIPTION
## Summary
- After Collaborator **Accept** applies property updates, reload the host page ViewModel (`IReloadable` / `CurrentSaveable`) so Character fields reflect the model immediately
- Stops AutoSave `FlushCurrentEdits` → `SaveModel` from writing empty VM values over API-applied text (reported as empty Backstory after FlawBackstory Accept/patch)
- `RichEditBoxExtended` (WinAppSDK): set plain text with `TextSetOptions.None` when value is not RTF (Collaborator writes plain prose)

## Why
Accept path updated the model and auto-saved via API, but the open Character page still held pre-Accept empty `BackStory`. Host AutoSave flushed that empty VM onto the model and disk. Reload only ran on Collaborator **close**, not on Accept.

## Test plan
- [ ] Open a Character; leave Character page selected
- [ ] Run Flaw and Backstory; Accept (or chat patch then Accept)
- [ ] Without closing Collaborator: Backstory tab shows new text
- [ ] Wait for AutoSave / re-open outline: BackStory still present in file and UI
- [ ] Existing RTF-edited fields still display formatted text

Fixes empty Backstory after #184 Accept (Collaborator issue #184 ship follow-up).