### PR TITLE
Track Versions by OS

### DIFF
--- a/StoryCADLib/Models/AppState.cs
+++ b/StoryCADLib/Models/AppState.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using StoryCADLib.Services;
 using StoryCADLib.ViewModels;
 
@@ -150,6 +151,46 @@ public class AppState
             return assembly.Version!.ToString();
         }
     }
+
+    /// <summary>
+    ///     Short code for the operating system this instance is running on,
+    ///     used to break reported versions down per platform (#1428).
+    ///     Detected at runtime rather than with #if, because the desktop head
+    ///     is a single binary that runs on more than one OS.
+    /// </summary>
+    public string Platform
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "Win";
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "Mac";
+            }
+
+            return "Unknown";
+        }
+    }
+
+    /// <summary>
+    ///     The current version tagged with its platform, e.g. "4.2.0.0-Mac".
+    ///     Reported to the backend versions table and to elmah.io. Version
+    ///     itself stays unsuffixed - it is written to .stbx LastVersion and
+    ///     compared against the stored preferences version.
+    /// </summary>
+    public string VersionWithPlatform => WithPlatform(Version);
+
+    /// <summary>
+    ///     Tags an arbitrary version string with the current platform code.
+    ///     An empty or absent version stays empty, so a first-run install
+    ///     reports no previous version rather than a bare "-Win".
+    /// </summary>
+    public string WithPlatform(string? version) =>
+        string.IsNullOrEmpty(version) ? string.Empty : $"{version}-{Platform}";
 
     public StoryDocument? CurrentDocument
     {

--- a/StoryCADLib/Services/Backend/BackendService.cs
+++ b/StoryCADLib/Services/Backend/BackendService.cs
@@ -290,8 +290,11 @@ public class BackendService
             preferences.UserId = id;
             _logService.Log(LogLevel.Info, "User registered, userId: " + id);
 
-            var current = _appState.Version;
-            var previous = preferences.Version ?? "";
+            // Tag both versions with the platform so the versions table can be
+            // broken down per OS (#1428). The previous run was on this same
+            // install, so it carries the same platform code.
+            var current = _appState.VersionWithPlatform;
+            var previous = _appState.WithPlatform(preferences.Version);
             await _sqlIo.AddVersion(id, current, previous);
             _preferenceService.Model.RecordVersionStatus = true;
             PreferencesIo loader = new();

--- a/StoryCADLib/Services/Logging/LogService.cs
+++ b/StoryCADLib/Services/Logging/LogService.cs
@@ -99,8 +99,8 @@ public class LogService : ILogService
 
             elmahIoTarget.OnMessage += msg =>
             {
-                msg.Version = State.Version;
-
+                // Platform-suffixed so exception reports are filterable by OS (#1428).
+                msg.Version = State.VersionWithPlatform;
 
                 try
                 {
@@ -112,7 +112,6 @@ public class LogService : ILogService
                 }
 
                 var baseException = exceptionHelper?.GetBaseException();
-                msg.Version = State.Version;
 
                 msg.Type = baseException?.GetType().FullName;
                 msg.Data = baseException?.ToDataList() ?? new();

--- a/StoryCADTests/Models/AppStateTests.cs
+++ b/StoryCADTests/Models/AppStateTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using StoryCADLib.Models;
 using StoryCADLib.Services;
 using StoryCADLib.ViewModels;
@@ -208,6 +209,95 @@ public class AppStateTests
         bool result = appState.DeveloperBuild;
 
         Assert.IsTrue(result);
+    }
+
+    #endregion
+
+    #region Platform / VersionWithPlatform Tests (Issue #1428)
+
+    [TestMethod]
+    public void Platform_ReturnsCodeFromKnownSet()
+    {
+        // Arrange
+        var appState = new AppState();
+
+        // Act & Assert - only Win, Mac and the Unknown fallback are shipped codes.
+        CollectionAssert.Contains(new[] { "Win", "Mac", "Unknown" }, appState.Platform,
+            $"Platform returned an unexpected code: '{appState.Platform}'");
+    }
+
+    [TestMethod]
+    public void Platform_OnMacOS_ReturnsMac()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            Assert.Inconclusive("macOS-only assertion; this run is on another OS.");
+        }
+
+        Assert.AreEqual("Mac", new AppState().Platform);
+    }
+
+    [TestMethod]
+    public void Platform_OnWindows_ReturnsWin()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Inconclusive("Windows-only assertion; this run is on another OS.");
+        }
+
+        Assert.AreEqual("Win", new AppState().Platform);
+    }
+
+    [TestMethod]
+    public void VersionWithPlatform_AppendsPlatformCodeToVersion()
+    {
+        // Arrange
+        var appState = new AppState();
+
+        // Act & Assert
+        Assert.AreEqual($"{appState.Version}-{appState.Platform}", appState.VersionWithPlatform);
+    }
+
+    [TestMethod]
+    public void Version_StaysUnsuffixed()
+    {
+        // The suffix must not leak into Version itself - that value is written to
+        // .stbx LastVersion and compared against the stored preferences version,
+        // so a suffix there would fire a spurious version change on every upgrade.
+        var appState = new AppState();
+
+        Assert.IsFalse(appState.Version.Contains('-'),
+            $"Version should carry no platform suffix but was '{appState.Version}'");
+    }
+
+    [TestMethod]
+    public void WithPlatform_WhenVersionSupplied_AppendsPlatformCode()
+    {
+        // Arrange
+        var appState = new AppState();
+
+        // Act & Assert
+        Assert.AreEqual($"4.1.0.0-{appState.Platform}", appState.WithPlatform("4.1.0.0"));
+    }
+
+    [TestMethod]
+    public void WithPlatform_WhenVersionEmpty_ReturnsEmpty()
+    {
+        // A first-run install has no previous version; it must stay empty rather
+        // than becoming a bare "-Mac".
+        var appState = new AppState();
+
+        Assert.AreEqual(string.Empty, appState.WithPlatform(""));
+    }
+
+    [TestMethod]
+    public void WithPlatform_WhenVersionNull_ReturnsEmpty()
+    {
+        // Arrange
+        var appState = new AppState();
+
+        // Act & Assert
+        Assert.AreEqual(string.Empty, appState.WithPlatform(null));
     }
 
     #endregion

--- a/StoryCADTests/Services/Backend/BackendServiceTests.cs
+++ b/StoryCADTests/Services/Backend/BackendServiceTests.cs
@@ -119,6 +119,87 @@ public class BackendTests
 
     #endregion
 
+    #region PostVersion Platform Suffix Tests (Issue #1428)
+
+    /// <summary>
+    ///     Verifies PostVersion writes the platform-suffixed version to the
+    ///     versions table, so the backend can break usage down per OS (#1428).
+    /// </summary>
+    [TestMethod]
+    public async Task PostVersion_PassesPlatformSuffixedCurrentVersionToSqlIo()
+    {
+        var testLogger = new TestLogService();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var preferenceService = Ioc.Default.GetRequiredService<PreferenceService>();
+        var testSqlIo = new TestMySqlIo();
+        testSqlIo.SetConnectionString("fake");
+        var backendService = new BackendService(testLogger, appState, preferenceService, testSqlIo);
+
+        preferenceService.Model.FirstName = "StoryCAD";
+        preferenceService.Model.LastName = "Tests";
+        preferenceService.Model.Email = "sysadmin@storybuilder.org";
+
+        await backendService.PostVersion();
+
+        Assert.AreEqual(1, testSqlIo.AddVersionCalls.Count);
+        Assert.AreEqual(appState.VersionWithPlatform, testSqlIo.AddVersionCalls[0].current,
+            "PostVersion should send the platform-suffixed version as current_ver");
+    }
+
+    /// <summary>
+    ///     The previous version is suffixed with the same platform code, since a
+    ///     prior run on the same install was necessarily the same OS.
+    /// </summary>
+    [TestMethod]
+    public async Task PostVersion_WhenPreviousVersionStored_SuffixesPreviousVersion()
+    {
+        var testLogger = new TestLogService();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var preferenceService = Ioc.Default.GetRequiredService<PreferenceService>();
+        var testSqlIo = new TestMySqlIo();
+        testSqlIo.SetConnectionString("fake");
+        var backendService = new BackendService(testLogger, appState, preferenceService, testSqlIo);
+
+        preferenceService.Model.FirstName = "StoryCAD";
+        preferenceService.Model.LastName = "Tests";
+        preferenceService.Model.Email = "sysadmin@storybuilder.org";
+        preferenceService.Model.Version = "4.1.0.0";
+
+        await backendService.PostVersion();
+
+        Assert.AreEqual(1, testSqlIo.AddVersionCalls.Count);
+        Assert.AreEqual($"4.1.0.0-{appState.Platform}", testSqlIo.AddVersionCalls[0].previous,
+            "PostVersion should send the platform-suffixed previous version as previous_ver");
+    }
+
+    /// <summary>
+    ///     A first-run install has no stored version; previous_ver must stay empty
+    ///     rather than becoming a bare "-Win".
+    /// </summary>
+    [TestMethod]
+    public async Task PostVersion_WhenNoPreviousVersion_LeavesPreviousEmpty()
+    {
+        var testLogger = new TestLogService();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var preferenceService = Ioc.Default.GetRequiredService<PreferenceService>();
+        var testSqlIo = new TestMySqlIo();
+        testSqlIo.SetConnectionString("fake");
+        var backendService = new BackendService(testLogger, appState, preferenceService, testSqlIo);
+
+        preferenceService.Model.FirstName = "StoryCAD";
+        preferenceService.Model.LastName = "Tests";
+        preferenceService.Model.Email = "sysadmin@storybuilder.org";
+        preferenceService.Model.Version = "";
+
+        await backendService.PostVersion();
+
+        Assert.AreEqual(1, testSqlIo.AddVersionCalls.Count);
+        Assert.AreEqual(string.Empty, testSqlIo.AddVersionCalls[0].previous,
+            "An absent previous version should stay empty, not gain a bare suffix");
+    }
+
+    #endregion
+
     #region DeleteUserData Tests
 
     [TestMethod]


### PR DESCRIPTION
This PR fixes #1428 by appending -mac or -win to Storycad versions, this was already collected in logs, by market place providers and elmah but wasn't collected in the database.