### PR TITLE
feat: Relationship ExampleLists, Accept fields, and delete (#185)

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -925,7 +925,7 @@ public class Collaborator : ICollaborator
 
         EnsureKernelInitialized();
         _sessionProposals = new SessionProposalSet();
-        _sessionProposals.ReplaceFromPending(result.PendingUpdates);
+        _sessionProposals.ReplaceFromPending(result.PendingUpdates, ResolveElementName);
 
         _chatHistory = new ChatHistory();
         _chatHistory.AddSystemMessage(SessionProposalSet.BuildSystemInstructions(workflow.Title));
@@ -1655,12 +1655,14 @@ public class Collaborator : ICollaborator
     /// Readable text for a typed pending-update value; lists render per entry and
     /// element GUIDs resolve to outline names (#129).
     /// </summary>
+    private string? ResolveElementName(Guid guid) =>
+        _storyModel?.StoryElements?.StoryElementGuids != null
+        && _storyModel.StoryElements.StoryElementGuids.TryGetValue(guid, out var element)
+            ? element?.Name
+            : null;
+
     private string FormatValueForDisplay(object? value) =>
-        ValueDisplay.Format(value, guid =>
-            _storyModel?.StoryElements?.StoryElementGuids != null
-            && _storyModel.StoryElements.StoryElementGuids.TryGetValue(guid, out var element)
-                ? element?.Name
-                : null);
+        ValueDisplay.Format(value, ResolveElementName);
 
     private static string TruncateForChat(string? text, int max = 200)
     {

--- a/CollaboratorLib/Models/PropertySpec.cs
+++ b/CollaboratorLib/Models/PropertySpec.cs
@@ -88,6 +88,9 @@ namespace StoryCollaborator.Models
     /// </summary>
     public sealed record RelationshipInfo(
         Guid RecipientGuid,
-        string Description,
-        bool Mirror = false);
+        string RelationType,
+        bool Mirror = false,
+        string Trait = "",
+        string Attitude = "",
+        string Notes = "");
 }

--- a/CollaboratorLib/Models/ValueDisplay.cs
+++ b/CollaboratorLib/Models/ValueDisplay.cs
@@ -67,7 +67,11 @@ internal static class ValueDisplay
                 return Bullets(relationships.Select(rel =>
                 {
                     var name = ResolveName(rel.RecipientGuid, resolveElementName);
-                    return string.IsNullOrWhiteSpace(rel.Description) ? name : $"{name} — {rel.Description}";
+                    var type = rel.RelationType ?? string.Empty;
+                    var notes = rel.Notes ?? string.Empty;
+                    if (!string.IsNullOrWhiteSpace(notes))
+                        return string.IsNullOrWhiteSpace(type) ? $"{name} — {notes}" : $"{name} ({type}) — {notes}";
+                    return string.IsNullOrWhiteSpace(type) ? name : $"{name} — {type}";
                 }));
 
             case List<JsonElement> jsonEntries:

--- a/CollaboratorLib/Services/SessionProposalSet.cs
+++ b/CollaboratorLib/Services/SessionProposalSet.cs
@@ -30,7 +30,9 @@ public sealed class SessionProposalSet
     public IEnumerable<Entry> All => _entries.Values;
 
     /// <summary>Replace session set from a new workflow extract (open rows).</summary>
-    public void ReplaceFromPending(IEnumerable<PendingUpdate> pending)
+    public void ReplaceFromPending(
+        IEnumerable<PendingUpdate> pending,
+        Func<Guid, string?>? resolveElementName = null)
     {
         _entries.Clear();
         foreach (var u in pending)
@@ -39,7 +41,7 @@ public sealed class SessionProposalSet
             // asks "what is this field now?" (outline text, not a truncated proposal).
             var outline = u.CurrentDisplay ?? string.Empty;
             _entries[u.Key] = new Entry(
-                u, ProposalSessionStatus.Open, FormatValue(u.Value), outline);
+                u, ProposalSessionStatus.Open, FormatValue(u.Value, resolveElementName), outline);
         }
     }
 
@@ -154,7 +156,8 @@ public sealed class SessionProposalSet
     /// Human-readable proposal text. Must not use object.ToString() on lists
     /// (leaks "System.Collections.Generic.List`1[System.String]").
     /// </summary>
-    private static string FormatValue(object? value) => ValueDisplay.Format(value);
+    private static string FormatValue(object? value, Func<Guid, string?>? resolveElementName = null) =>
+        ValueDisplay.Format(value, resolveElementName);
 
     public sealed record Entry(
         PendingUpdate Update,

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -767,7 +767,9 @@ namespace StoryCollaborator
                         foreach (var rel in relationships)
                         {
                             if (validChars.Contains(rel.RecipientGuid))
-                                _storyApi.AddRelationship(uuid, rel.RecipientGuid, rel.Description, rel.Mirror);
+                                _storyApi.AddRelationship(
+                                    uuid, rel.RecipientGuid, rel.RelationType, rel.Mirror,
+                                    rel.Trait, rel.Attitude, rel.Notes);
                             else
                                 result.StatusMessages.Add(
                                     $"Relationships: recipient GUID {rel.RecipientGuid} not in character candidate set; skipped");
@@ -1127,9 +1129,34 @@ namespace StoryCollaborator
             if (entry.TryGetProperty("recipient_guid", out var rg) || entry.TryGetProperty("GUID", out rg))
                 guidStr = rg.GetString();
             if (!Guid.TryParse(guidStr, out var recipientGuid)) return;
-            var desc = entry.TryGetProperty("description", out var d) ? d.GetString() ?? "" : "";
-            var mirror = entry.TryGetProperty("mirror", out var m) && m.GetBoolean();
-            results.Add(new RelationshipInfo(recipientGuid, desc, mirror));
+            var relationType = ReadJsonString(entry, "RelationType", "relation_type");
+            var notes = ReadJsonString(entry, "Notes", "notes");
+            if (string.IsNullOrWhiteSpace(notes))
+                notes = ReadJsonString(entry, "description");
+            var trait = ReadJsonString(entry, "Trait", "trait");
+            var attitude = ReadJsonString(entry, "Attitude", "attitude");
+            var mirror = true;
+            if (entry.TryGetProperty("mirror", out var m))
+            {
+                mirror = m.ValueKind switch
+                {
+                    JsonValueKind.False => false,
+                    JsonValueKind.True => true,
+                    JsonValueKind.String => !string.Equals(m.GetString(), "false", StringComparison.OrdinalIgnoreCase),
+                    _ => true
+                };
+            }
+            results.Add(new RelationshipInfo(recipientGuid, relationType, mirror, trait, attitude, notes));
+        }
+
+        private static string ReadJsonString(JsonElement entry, params string[] names)
+        {
+            foreach (var name in names)
+            {
+                if (!entry.TryGetProperty(name, out var prop)) continue;
+                return prop.ValueKind == JsonValueKind.String ? prop.GetString() ?? "" : prop.ToString();
+            }
+            return "";
         }
 
         /// <summary>

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -610,9 +610,9 @@ namespace StoryCollaborator.Workflows
                     label: "Relationship",
                     title: "Character Relationship",
                     description: "Develop the dynamics, history, and tension between two characters.",
-                    explanation: "Relationships create conflict, reveal character, and drive plot. This workflow " +
-                                "explores how two characters relate—their shared history, what they want from each " +
-                                "other, sources of tension, and how the relationship might change through the story.",
+                    explanation: "Name both people. Prefer some sheet fill from Define Character, Character Story Function, or Flaw and Backstory on each side. " +
+                                "The run still proceeds if sheets are thin. The model uses filled traits when they exist. It does not invent missing bulk fields. " +
+                                "Accept writes the short type, Trait, Attitude, and Relationship Notes on both people.",
                     workflowIO: new WorkflowIO
                     {
                         // Primary + Partner full elements for Partner_* placeholders (#106).
@@ -653,7 +653,8 @@ namespace StoryCollaborator.Workflows
                                 ElementType = StoryItemType.Character,
                                 Projection = ElementProjection.IdAndName
                             }
-                        }
+                        },
+                        ExampleLists = new List<string> { "Trait", "Attitude" }
                     }) { PrimaryElementType = StoryItemType.Character },
 
                 // === Setting Workflows (scene-specific) ===

--- a/StoryCADLib/Controls/RelationshipView.xaml
+++ b/StoryCADLib/Controls/RelationshipView.xaml
@@ -29,8 +29,13 @@
                                         <ColumnDefinition Width="15" />
                                         <ColumnDefinition Width="*" />
                                     </Grid.ColumnDefinitions>
-                                    <SymbolIcon Symbol="Cancel" HorizontalAlignment="Left" Grid.Column="0"
-                                                PointerPressed="RemoveRelationship" />
+                                    <Button Grid.Column="0" Padding="4" Background="Transparent"
+                                            BorderThickness="0" HorizontalAlignment="Left"
+                                            Click="RemoveRelationship" Tag="{x:Bind}"
+                                            ToolTipService.ToolTip="Delete relationship"
+                                            AutomationProperties.Name="Delete relationship">
+                                        <SymbolIcon Symbol="Cancel" />
+                                    </Button>
                                     <Grid Grid.Row="0" Margin="0,10" HorizontalAlignment="Center" Grid.Column="2">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />

--- a/StoryCADLib/Controls/RelationshipView.xaml.cs
+++ b/StoryCADLib/Controls/RelationshipView.xaml.cs
@@ -17,29 +17,32 @@ public sealed partial class RelationshipView : UserControl
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    private async void RemoveRelationship(object sender, PointerRoutedEventArgs e)
+    private async void RemoveRelationship(object sender, RoutedEventArgs e)
     {
         try
         {
             Logger.Log(LogLevel.Info, "Starting to remove relationship");
 
-            // Get the RelationshipModel directly from DataContext
-            var characterToDelete = (sender as FrameworkElement)?.DataContext as RelationshipModel;
+            // x:Bind templates do not set DataContext. The row is on Tag ({x:Bind}).
+            var characterToDelete = (sender as FrameworkElement)?.Tag as RelationshipModel;
             if (characterToDelete == null)
             {
-                Logger.Log(LogLevel.Warn, "Could not get RelationshipModel from DataContext");
+                Logger.Log(LogLevel.Warn, "Could not get RelationshipModel from Button.Tag");
                 return;
             }
 
+            var partnerName = characterToDelete.Partner?.Name
+                ?? StoryElement.GetByGuid(characterToDelete.PartnerUuid)?.Name
+                ?? "this partner";
             Logger.Log(LogLevel.Info,
-                $"Character to delete: {characterToDelete.Partner.Name}({characterToDelete.Partner.Uuid})");
+                $"Character to delete: {partnerName}({characterToDelete.PartnerUuid})");
 
             //Show confirmation dialog and gets result.
             ContentDialog cd = new()
             {
                 Title = "Are you sure?",
                 Content =
-                    $"Are you sure you want to delete the relationship between {CharVm.Name} and {characterToDelete.Partner.Name}?",
+                    $"Are you sure you want to delete the relationship between {CharVm.Name} and {partnerName}?",
                 PrimaryButtonText = "Yes",
                 SecondaryButtonText = "No"
             };
@@ -48,7 +51,7 @@ public sealed partial class RelationshipView : UserControl
 
             if (result == ContentDialogResult.Primary) //If positive, then delete.
             {
-                Logger.Log(LogLevel.Info, $"Deleting Relationship to {characterToDelete.Partner.Name}");
+                Logger.Log(LogLevel.Info, $"Deleting Relationship to {partnerName}");
                 Ioc.Default.GetRequiredService<CharacterViewModel>().CharacterRelationships.Remove(characterToDelete);
                 Logger.Log(LogLevel.Info, "Deleted");
                 CharVm.SaveRelationships();

--- a/StoryCADLib/Services/API/StoryCADAPI.cs
+++ b/StoryCADLib/Services/API/StoryCADAPI.cs
@@ -1035,11 +1035,13 @@ public class StoryCADApi(OutlineService outlineService, ListData listData, Contr
     [Description("""
                  Adds a relationship between characters.
                  Both Source and Recipient must be GUIDs of elements that are characters.
-                 Description is the relationship between the two characters.
-                 mirror is a boolean that specifies if the relationship
-                 should be created on both characters.
+                 Description is the short RelationType (the "is a ___ to" slot).
+                 Trait, Attitude, and Notes fill the relationship row.
+                 mirror creates the same row on the partner.
                  """)]
-    public OperationResult<bool> AddRelationship(Guid source, Guid recipient, string desc, bool mirror = false)
+    public OperationResult<bool> AddRelationship(
+        Guid source, Guid recipient, string desc, bool mirror = false,
+        string trait = "", string attitude = "", string notes = "")
     {
         if (CurrentModel == null)
         {
@@ -1058,7 +1060,7 @@ public class StoryCADApi(OutlineService outlineService, ListData listData, Contr
 
         try
         {
-            outlineService.AddRelationship(CurrentModel, source, recipient, desc, mirror);
+            outlineService.AddRelationship(CurrentModel, source, recipient, desc, mirror, trait, attitude, notes);
             return OperationResult<bool>.Success(true);
         }
         catch (Exception ex)

--- a/StoryCADLib/Services/Collaborator/Contracts/IStoryCADAPI.cs
+++ b/StoryCADLib/Services/Collaborator/Contracts/IStoryCADAPI.cs
@@ -98,7 +98,9 @@ public interface IStoryCADAPI
 
     OperationResult<bool> UpdateImageCaption(Guid element, Guid imageId, string caption);
 
-    OperationResult<bool> AddRelationship(Guid source, Guid recipient, string desc, bool mirror = false);
+    OperationResult<bool> AddRelationship(
+        Guid source, Guid recipient, string desc, bool mirror = false,
+        string trait = "", string attitude = "", string notes = "");
 
     OperationResult<bool> MoveElement(Guid elementGuid, Guid newParentGuid, int? index = null);
 

--- a/StoryCADLib/Services/Outline/OutlineService.cs
+++ b/StoryCADLib/Services/Outline/OutlineService.cs
@@ -417,10 +417,15 @@ public class OutlineService
     /// <param name="Model">StoryModel</param>
     /// <param name="source">Character you want to add relationship to.</param>
     /// <param name="recipient">Relationship character is with</param>
-    /// <param name="desc">Relationship description</param>
+    /// <param name="desc">Short RelationType (the "is a ___ to" slot)</param>
     /// <param name="mirror">Create same relationship on recipient</param>
+    /// <param name="trait">Dyad Trait</param>
+    /// <param name="attitude">Dyad Attitude</param>
+    /// <param name="notes">Relationship Notes (plain text)</param>
     /// <returns></returns>
-    internal bool AddRelationship(StoryModel Model, Guid source, Guid recipient, string desc, bool mirror = false)
+    internal bool AddRelationship(
+        StoryModel Model, Guid source, Guid recipient, string desc, bool mirror = false,
+        string trait = "", string attitude = "", string notes = "")
     {
         _log.Log(LogLevel.Info, $"AddRelationship called from {source} to {recipient}.");
         if (source == Guid.Empty)
@@ -460,7 +465,7 @@ public class OutlineService
             }
         }
 
-        RelationshipModel relationship = new(recipient, desc);
+        RelationshipModel relationship = BuildRelationship(recipient, recipientElement, desc, trait, attitude, notes);
         sourceCharacter.RelationshipList.Add(relationship);
         Model.Changed = true;
 
@@ -483,7 +488,8 @@ public class OutlineService
 
             if (!mirrorExists)
             {
-                RelationshipModel mirrorRelationship = new(source, desc);
+                RelationshipModel mirrorRelationship = BuildRelationship(
+                    source, sourceElement, desc, trait, attitude, notes);
                 recipientCharacter.RelationshipList.Add(mirrorRelationship);
             }
         }
@@ -491,6 +497,17 @@ public class OutlineService
         _log.Log(LogLevel.Info, $"AddRelationship completed from {source} to {recipient}.");
         return true;
     }
+
+    private static RelationshipModel BuildRelationship(
+        Guid partnerUuid, StoryElement partner, string relationType,
+        string trait, string attitude, string notes) =>
+        new(partnerUuid, relationType ?? string.Empty)
+        {
+            Partner = partner,
+            Trait = trait ?? string.Empty,
+            Attitude = attitude ?? string.Empty,
+            Notes = notes ?? string.Empty
+        };
 
     /// <summary>
     ///     Adds a new cast member to a scene.

--- a/StoryCADTests/Collaborator/SessionProposalSetTests.cs
+++ b/StoryCADTests/Collaborator/SessionProposalSetTests.cs
@@ -120,4 +120,26 @@ public class SessionProposalSetTests
         Assert.IsInstanceOfType(open.Value, typeof(List<string>));
         CollectionAssert.AreEqual(traits, (List<string>)open.Value!);
     }
+
+    [TestMethod]
+    public void ReplaceFromPending_Relationship_ShowsPartnerNameNotGuid()
+    {
+        var partnerGuid = Guid.Parse("6ede4860-411b-43f5-829d-47b3a6b1aa21");
+        var spec = new PropertySpec("RelationshipList", WriteVia.Relationships, JsonKey: "relationship");
+        var update = new PendingUpdate(
+            "Character",
+            Guid.Parse("e2ab5b51-1f5e-4067-b4d4-7e99ba4e642f"),
+            spec,
+            new List<RelationshipInfo> { new(partnerGuid, "Rival", Notes: "A tries to impose order") },
+            UpdateKind.Fill,
+            null);
+
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(new[] { update }, guid => guid == partnerGuid ? "B" : null);
+
+        var text = set.Get("Character.RelationshipList")!.ProposedText;
+        StringAssert.Contains(text, "B");
+        StringAssert.Contains(text, "A tries to impose order");
+        Assert.IsFalse(text.Contains(partnerGuid.ToString("D"), StringComparison.Ordinal), text);
+    }
 }

--- a/StoryCADTests/Collaborator/ValueDisplayTests.cs
+++ b/StoryCADTests/Collaborator/ValueDisplayTests.cs
@@ -102,11 +102,11 @@ public class ValueDisplayTests
     public void Format_WithRelationshipList_ResolvesNameAndDescription()
     {
         var guid = Guid.NewGuid();
-        var relationships = new List<RelationshipInfo> { new(guid, "rival") };
+        var relationships = new List<RelationshipInfo> { new(guid, "rival", Notes: "keeps score") };
 
         var result = ValueDisplay.Format(relationships, _ => "Herold");
 
-        Assert.AreEqual("• Herold — rival", result);
+        Assert.AreEqual("• Herold (rival) — keeps score", result);
     }
 
     [TestMethod]

--- a/StoryCADTests/Services/Outline/OutlineServiceTests.cs
+++ b/StoryCADTests/Services/Outline/OutlineServiceTests.cs
@@ -1858,6 +1858,33 @@ public class OutlineServiceTests
         Assert.IsFalse(model.Changed, "A no-op duplicate add must not mark the model changed.");
     }
 
+    [TestMethod]
+    public async Task AddRelationship_WritesTraitAttitudeNotesAndMirrors()
+    {
+        var model = await _outlineService.CreateModel("Test Story", "Test Author", 0);
+        var overview = model.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var character1 = _outlineService.AddStoryElement(model, StoryItemType.Character, overview.Node);
+        var character2 = _outlineService.AddStoryElement(model, StoryItemType.Character, overview.Node);
+
+        var result = _outlineService.AddRelationship(
+            model, character1.Uuid, character2.Uuid, "Rival",
+            mirror: true, trait: "Protective", attitude: "Wary", notes: "They keep score");
+
+        Assert.IsTrue(result);
+        var source = (CharacterModel)character1;
+        var partner = (CharacterModel)character2;
+        Assert.AreEqual(1, source.RelationshipList.Count);
+        Assert.AreEqual(1, partner.RelationshipList.Count);
+        Assert.AreEqual("Rival", source.RelationshipList[0].RelationType);
+        Assert.AreEqual("Protective", source.RelationshipList[0].Trait);
+        Assert.AreEqual("Wary", source.RelationshipList[0].Attitude);
+        Assert.AreEqual("They keep score", source.RelationshipList[0].Notes);
+        Assert.AreEqual(character2.Uuid, source.RelationshipList[0].PartnerUuid);
+        Assert.AreEqual(character2.Name, source.RelationshipList[0].Partner.Name);
+        Assert.AreEqual(character1.Uuid, partner.RelationshipList[0].PartnerUuid);
+        Assert.AreEqual("They keep score", partner.RelationshipList[0].Notes);
+    }
+
     #endregion
 
     #region AddCastMember Tests


### PR DESCRIPTION
## Summary
- Registry: Character Relationship Explanation states thin sheets and filled traits. ExampleLists `Trait` and `Attitude`.
- Accept writes short RelationType, Trait, Attitude, and Relationship Notes. Mirror creates the same row on the partner.
- `AddRelationship` (API + OutlineService) takes optional trait, attitude, notes. Existing four-argument callers keep the empty-row behavior.
- Proposal list shows the partner name, not a GUID.
- Delete relationship is a real button (`Tag` carries the row). The old X read empty DataContext and did nothing.

Implements Character surface 4 from Collaborator epic #180 / issue #185.

## Test plan
- [x] CollaboratorLib + StoryCADLib build (Debug/x64)
- [x] StoryCADTests: AddRelationship writes Trait/Attitude/Notes and mirrors; ValueDisplay name; SessionProposalSet name not GUID
- [x] CollaboratorTests (sibling): extract/apply writes all four fields; registry Explanation
- [x] Smoke: thin A/B run; Accept; name display; B row; delete leftover

## Notes
- Pair with Collaborator PR **#195** against `main`
- Related: storybuilder-org/Collaborator#185