### PR TITLE
feat: Character Development in the Guess and Outline gaps (#107)

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -638,10 +638,20 @@ public class Collaborator : ICollaborator
             };
         }).ToList();
 
+        var guess = new StoryContextBuilder(_storyApi).Classify(_storyModel);
+        _logger?.LogDebug(
+            "Outline gaps guess Earliest={Earliest} OpenSteps={OpenSteps}",
+            guess.Earliest,
+            string.Join(",", guess.OpenSteps));
+
         shellViewModel.ContentFrame.Navigate(typeof(GapWorkflowPage));
         if (shellViewModel.ContentFrame.Content is GapWorkflowPage page && page.ViewModel != null)
         {
-            page.ViewModel.Load(new GapWorkflowPayload { Groups = groups });
+            page.ViewModel.Load(new GapWorkflowPayload
+            {
+                Groups = groups,
+                GuessSentence = guess.GapsSentence
+            });
             page.ViewModel.OnOpenElement = guid =>
             {
                 var result = _storyApi.SelectStoryElement(guid);

--- a/CollaboratorLib/Context/DevelopmentGuess.cs
+++ b/CollaboratorLib/Context/DevelopmentGuess.cs
@@ -1,0 +1,15 @@
+namespace CollaboratorLib.Context;
+
+/// <summary>
+/// Outline-progress Guess for StoryContext and Outline gaps (#107).
+/// </summary>
+public sealed class DevelopmentGuess
+{
+    public required StoryContextBuilder.DevelopmentPhase Earliest { get; init; }
+
+    public required IReadOnlyList<StoryContextBuilder.DevelopmentPhase> OpenSteps { get; init; }
+
+    public required string PromptLine { get; init; }
+
+    public required string GapsSentence { get; init; }
+}

--- a/CollaboratorLib/Context/GapWorkflowOwnership.cs
+++ b/CollaboratorLib/Context/GapWorkflowOwnership.cs
@@ -42,10 +42,14 @@ public static class GapWorkflowOwnership
             (StoryItemType.Problem, "Premise") => new[] { "StoryProblem" },
             (StoryItemType.Problem, "Description") => new[] { "StoryProblem" },
 
-            // #182 occupation Role; #183 Story Function + Character Sketch
+            // #182 occupation Role; #183 Story Function + Character Sketch; #107 essentials
             (StoryItemType.Character, "Role") => new[] { "DefineCharacter" },
+            (StoryItemType.Character, "Age") => new[] { "DefineCharacter" },
+            (StoryItemType.Character, "Sex") => new[] { "DefineCharacter" },
+            (StoryItemType.Character, "Appearance") => new[] { "DefineCharacter" },
             (StoryItemType.Character, "StoryRole") => new[] { "StoryFunction" },
             (StoryItemType.Character, "Description") => new[] { "StoryFunction" },
+            (StoryItemType.Character, "BackStory") => new[] { "FlawBackstory" },
             (StoryItemType.Character, "Name") => Array.Empty<string>(),
 
             (StoryItemType.Setting, "Description") => new[] { "SettingTimeSpace" },
@@ -75,6 +79,7 @@ public static class GapWorkflowOwnership
             (StoryItemType.StoryOverview, "StoryGenre") => "Genre",
             (StoryItemType.StoryOverview, "StoryProblem") => "Story Problem",
             (StoryItemType.Character, "StoryRole") => "Story Role",
+            (StoryItemType.Character, "BackStory") => "Backstory",
             (StoryItemType.Problem, "ProblemCategory") => "Problem Category",
             (StoryItemType.Problem, "ProblemType") => "Problem Type",
             (StoryItemType.Problem, "ConflictType") => "Conflict Type",

--- a/CollaboratorLib/Context/RequiredFieldGapScanner.cs
+++ b/CollaboratorLib/Context/RequiredFieldGapScanner.cs
@@ -114,6 +114,10 @@ public static class RequiredFieldGapScanner
             case CharacterModel character:
                 if (IsBlank(character.Role)) missing.Add("Role");
                 if (IsBlank(character.StoryRole)) missing.Add("StoryRole");
+                if (IsBlank(character.Age)) missing.Add("Age");
+                if (IsBlank(character.Sex)) missing.Add("Sex");
+                if (IsBlank(character.Appearance)) missing.Add("Appearance");
+                if (IsBlank(character.BackStory)) missing.Add("BackStory");
                 break;
 
             case SettingModel:

--- a/CollaboratorLib/Context/StoryContextBuilder.cs
+++ b/CollaboratorLib/Context/StoryContextBuilder.cs
@@ -32,9 +32,8 @@ public class StoryContextBuilder
 
         var sb = new StringBuilder();
 
-        // Detect development phase
-        var phase = DetectDevelopmentPhase(model);
-        AppendPhaseContext(sb, phase);
+        var guess = Classify(model);
+        AppendPhaseContext(sb, guess.PromptLine);
 
         // Issue #107: required-field gap GUIDs (outline-wide; no problem craft paste)
         if (spec.IncludeGaps)
@@ -62,50 +61,143 @@ public class StoryContextBuilder
     /// </summary>
     public enum DevelopmentPhase
     {
-        Ideation,           // No overview or empty Type/Genre/Premise
-        ProblemDevelopment, // Overview set, but no Story Problem or no beat sheet
-        StructureBuilding,  // Story Problem has beat sheet, hierarchy being built
-        SceneWork           // Scenes assigned to beats
+        Ideation,              // No overview or empty Type/Genre/Premise
+        ProblemDevelopment,    // Premise present; no Story Problem, or seats empty
+        CharacterDevelopment,  // Essential Character fields empty on seated people
+        StructureBuilding,     // After Character Development; no Scene on any beat
+        SceneWork              // Scenes assigned to beats
     }
 
-    /// <summary>
-    /// Detect the current development phase by examining the StoryModel
-    /// </summary>
-    private DevelopmentPhase DetectDevelopmentPhase(StoryModel model)
+    private static readonly string[] EssentialCharacterProperties =
     {
-        var overview = GetOverview(model);
+        "Name", "Description", "Role", "Age", "Sex", "Appearance", "StoryRole", "BackStory"
+    };
 
-        // No overview or missing basic constraints = Ideation
+    /// <summary>
+    /// Classify the outline for StoryContext and Outline gaps (#107).
+    /// </summary>
+    public DevelopmentGuess Classify(StoryModel model)
+    {
+        if (model == null)
+            return MakeGuess(DevelopmentPhase.Ideation, DevelopmentPhase.Ideation);
+
+        var overview = GetOverview(model);
         if (overview == null ||
             string.IsNullOrWhiteSpace(overview.StoryType) ||
             string.IsNullOrWhiteSpace(overview.StoryGenre) ||
             string.IsNullOrWhiteSpace(overview.Premise))
         {
-            return DevelopmentPhase.Ideation;
+            return MakeGuess(DevelopmentPhase.Ideation, DevelopmentPhase.Ideation);
         }
 
-        // No Story Problem assigned = Problem Development
         if (overview.StoryProblem == Guid.Empty)
-        {
-            return DevelopmentPhase.ProblemDevelopment;
-        }
+            return MakeGuess(DevelopmentPhase.ProblemDevelopment, DevelopmentPhase.ProblemDevelopment);
 
         var storyProblem = ResolveElement(overview.StoryProblem, model) as ProblemModel;
         if (storyProblem == null)
+            return MakeGuess(DevelopmentPhase.ProblemDevelopment, DevelopmentPhase.ProblemDevelopment);
+
+        var seats = ProblemCharacterIndex.Build(_api, model).EdgesForProblem(storyProblem.Uuid);
+        var unseated = seats.Count == 0 ||
+                       seats.Any(s => s.Status != ProblemCharacterLinkStatus.Linked);
+        if (unseated)
         {
-            return DevelopmentPhase.ProblemDevelopment;
+            return MakeGuess(
+                DevelopmentPhase.ProblemDevelopment,
+                DevelopmentPhase.ProblemDevelopment,
+                DevelopmentPhase.CharacterDevelopment);
         }
 
-        // Story Problem exists but no beat sheet = Problem Development
-        if (storyProblem.StructureBeats == null || storyProblem.StructureBeats.Count == 0)
+        var seen = new HashSet<Guid>();
+        foreach (var seat in seats)
         {
-            return DevelopmentPhase.ProblemDevelopment;
+            if (!seen.Add(seat.CharacterGuid))
+                continue;
+
+            var person = ResolveElement(seat.CharacterGuid, model);
+            if (person == null || HasEssentialCharacterGap(person))
+            {
+                return MakeGuess(
+                    DevelopmentPhase.CharacterDevelopment,
+                    DevelopmentPhase.CharacterDevelopment);
+            }
         }
 
-        // Check if any beats have scenes assigned (vs just sub-problems)
-        bool hasSceneAssignments = HasSceneAssignments(storyProblem, model);
+        if (HasSceneAssignments(storyProblem, model))
+            return MakeGuess(DevelopmentPhase.SceneWork, DevelopmentPhase.SceneWork);
 
-        return hasSceneAssignments ? DevelopmentPhase.SceneWork : DevelopmentPhase.StructureBuilding;
+        return MakeGuess(DevelopmentPhase.StructureBuilding, DevelopmentPhase.StructureBuilding);
+    }
+
+    /// <summary>
+    /// Detect the current development phase by examining the StoryModel
+    /// </summary>
+    private DevelopmentPhase DetectDevelopmentPhase(StoryModel model) => Classify(model).Earliest;
+
+    private bool HasEssentialCharacterGap(StoryElement person)
+    {
+        var missing = RequiredFieldGapScanner.GetMissingProperties(_api, person);
+        return missing.Any(p => EssentialCharacterProperties.Contains(p, StringComparer.Ordinal));
+    }
+
+    private static DevelopmentGuess MakeGuess(
+        DevelopmentPhase earliest,
+        params DevelopmentPhase[] openSteps)
+    {
+        var steps = (IReadOnlyList<DevelopmentPhase>)openSteps;
+        return new DevelopmentGuess
+        {
+            Earliest = earliest,
+            OpenSteps = steps,
+            PromptLine = PromptLineFor(earliest),
+            GapsSentence = GapsSentenceFor(steps)
+        };
+    }
+
+    internal static string PromptLineFor(DevelopmentPhase phase) => phase switch
+    {
+        DevelopmentPhase.Ideation =>
+            "Early ideation - establishing basic story parameters",
+        DevelopmentPhase.ProblemDevelopment =>
+            "Problem development - building the Story Problem",
+        DevelopmentPhase.CharacterDevelopment =>
+            "Character development - filling essential Character fields",
+        DevelopmentPhase.StructureBuilding =>
+            "Structure building - organizing problems into beat sheet",
+        DevelopmentPhase.SceneWork =>
+            "Scene work - detailed scene-level development",
+        _ => "Unknown phase"
+    };
+
+    internal static string GapsSentenceFor(IReadOnlyList<DevelopmentPhase> openSteps)
+    {
+        bool problem = openSteps.Contains(DevelopmentPhase.ProblemDevelopment);
+        bool character = openSteps.Contains(DevelopmentPhase.CharacterDevelopment);
+        if (problem && character)
+        {
+            return "Guess: Problem Development and Character Development are both open. " +
+                   "The Story Problem needs protagonist and antagonist seats.";
+        }
+
+        if (openSteps.Count == 1)
+        {
+            return openSteps[0] switch
+            {
+                DevelopmentPhase.Ideation =>
+                    "Guess: the outline is in Ideation.",
+                DevelopmentPhase.ProblemDevelopment =>
+                    "Guess: the outline is in Problem Development.",
+                DevelopmentPhase.CharacterDevelopment =>
+                    "Guess: the outline is in Character Development. Essential Character fields are empty on the Story Problem cast.",
+                DevelopmentPhase.StructureBuilding =>
+                    "Guess: the outline is in Structure Building.",
+                DevelopmentPhase.SceneWork =>
+                    "Guess: the outline is in Scene Work.",
+                _ => "Guess: the outline is in an unknown step."
+            };
+        }
+
+        return "Guess: the outline is in " + PromptLineFor(openSteps.FirstOrDefault()) + ".";
     }
 
     /// <summary>
@@ -136,17 +228,10 @@ public class StoryContextBuilder
         return false;
     }
 
-    private void AppendPhaseContext(StringBuilder sb, DevelopmentPhase phase)
+    private void AppendPhaseContext(StringBuilder sb, string promptLine)
     {
         sb.AppendLine("## Development Phase");
-        sb.AppendLine(phase switch
-        {
-            DevelopmentPhase.Ideation => "Early ideation - establishing basic story parameters",
-            DevelopmentPhase.ProblemDevelopment => "Problem/character development - building story elements",
-            DevelopmentPhase.StructureBuilding => "Structure building - organizing problems into beat sheet",
-            DevelopmentPhase.SceneWork => "Scene work - detailed scene-level development",
-            _ => "Unknown phase"
-        });
+        sb.AppendLine(promptLine);
         sb.AppendLine();
     }
 

--- a/StoryCADLib/Collaborator/Models/GapWorkflowModels.cs
+++ b/StoryCADLib/Collaborator/Models/GapWorkflowModels.cs
@@ -10,6 +10,8 @@ namespace StoryCADLib.Collaborator.Models;
 public sealed class GapWorkflowPayload
 {
     public IReadOnlyList<GapElementGroup> Groups { get; set; } = Array.Empty<GapElementGroup>();
+
+    public string GuessSentence { get; set; } = string.Empty;
 }
 
 public sealed class GapElementGroup

--- a/StoryCADLib/Collaborator/ViewModels/GapWorkflowViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/GapWorkflowViewModel.cs
@@ -32,6 +32,8 @@ public partial class GapWorkflowViewModel : ObservableRecipient
 
     public string EmptyMessage { get; set; } = "No required-field gaps.";
 
+    public string GuessSentence { get; set; } = string.Empty;
+
     /// <summary>Select/focus element in host StoryCAD.</summary>
     public Action<Guid> OnOpenElement { get; set; }
 
@@ -49,7 +51,9 @@ public partial class GapWorkflowViewModel : ObservableRecipient
             foreach (var g in payload.Groups)
                 Groups.Add(g);
         }
+        GuessSentence = payload?.GuessSentence ?? string.Empty;
         OnPropertyChanged(nameof(HasGroups));
+        OnPropertyChanged(nameof(GuessSentence));
     }
 
     private async Task OpenFieldAsync(GapFieldLink field)

--- a/StoryCADLib/Collaborator/Views/GapWorkflowPage.xaml
+++ b/StoryCADLib/Collaborator/Views/GapWorkflowPage.xaml
@@ -11,6 +11,8 @@
         <StackPanel Spacing="12">
             <TextBlock Text="{x:Bind ViewModel.Title, Mode=OneWay}"
                        FontWeight="Bold" FontSize="16" TextWrapping="Wrap" />
+            <TextBlock Text="{x:Bind ViewModel.GuessSentence, Mode=OneWay}"
+                       TextWrapping="Wrap" FontWeight="SemiBold" />
             <TextBlock Text="{x:Bind ViewModel.Description, Mode=OneWay}"
                        TextWrapping="Wrap" Opacity="0.9" />
 

--- a/StoryCADTests/Collaborator/DevelopmentGuessTests.cs
+++ b/StoryCADTests/Collaborator/DevelopmentGuessTests.cs
@@ -1,0 +1,289 @@
+using CollaboratorLib.Context;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using StoryCADLib.Models;
+using StoryCADLib.Models.Tools;
+using StoryCADLib.Services.API;
+using StoryCADLib.Services.Outline;
+using StoryCADLib.ViewModels;
+using StoryCADLib.ViewModels.Tools;
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>
+/// Collaborator #107: Guess classifier and Problem prompt line.
+/// </summary>
+[TestClass]
+public class DevelopmentGuessTests
+{
+    private static StoryCADApi CreateApi() => new(
+        Ioc.Default.GetRequiredService<OutlineService>(),
+        Ioc.Default.GetRequiredService<ListData>(),
+        Ioc.Default.GetRequiredService<ControlData>(),
+        Ioc.Default.GetRequiredService<ToolsData>());
+
+    [TestMethod]
+    public async Task BlankPremise_IsIdeation_NotCharacterDevelopment()
+    {
+        var api = CreateApi();
+        var create = await api.CreateEmptyOutline("Guess Test", "Author", "0");
+        Assert.IsTrue(create.IsSuccess);
+        var overview = Overview(api);
+        overview.StoryType = "";
+        overview.StoryGenre = "";
+        overview.Premise = "";
+
+        var guess = new StoryContextBuilder(api).Classify(api.CurrentModel!);
+
+        Assert.AreEqual(StoryContextBuilder.DevelopmentPhase.Ideation, guess.Earliest);
+        CollectionAssert.DoesNotContain(guess.OpenSteps.ToList(),
+            StoryContextBuilder.DevelopmentPhase.CharacterDevelopment);
+        StringAssert.Contains(guess.GapsSentence, "Ideation");
+    }
+
+    [TestMethod]
+    public async Task PremiseNoStoryProblem_IsProblemDevelopmentOnly()
+    {
+        var api = await OutlineWithPremise();
+        var overview = Overview(api);
+        overview.StoryProblem = Guid.Empty;
+
+        var guess = new StoryContextBuilder(api).Classify(api.CurrentModel!);
+
+        Assert.AreEqual(StoryContextBuilder.DevelopmentPhase.ProblemDevelopment, guess.Earliest);
+        Assert.AreEqual(1, guess.OpenSteps.Count);
+        Assert.AreEqual(StoryContextBuilder.DevelopmentPhase.ProblemDevelopment, guess.OpenSteps[0]);
+        Assert.IsFalse(guess.PromptLine.Contains("Problem/character"));
+    }
+
+    [TestMethod]
+    public async Task UnseatedStoryProblem_NamesBothSteps()
+    {
+        var api = await OutlineWithPremise();
+        var problem = AddProblem(api, "Crown");
+        Overview(api).StoryProblem = problem.Uuid;
+
+        var guess = new StoryContextBuilder(api).Classify(api.CurrentModel!);
+
+        Assert.AreEqual(StoryContextBuilder.DevelopmentPhase.ProblemDevelopment, guess.Earliest);
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                StoryContextBuilder.DevelopmentPhase.ProblemDevelopment,
+                StoryContextBuilder.DevelopmentPhase.CharacterDevelopment
+            },
+            guess.OpenSteps.ToList());
+        StringAssert.Contains(guess.GapsSentence, "both open");
+        StringAssert.Contains(guess.GapsSentence, "seats");
+    }
+
+    [TestMethod]
+    public async Task OneSeatEmpty_SameAsUnseated()
+    {
+        var api = await OutlineWithPremise();
+        var problem = AddProblem(api, "Crown");
+        var prot = AddCharacter(api, "Macbeth");
+        FillEssentials(prot);
+        problem.Protagonist = prot.Uuid;
+        Overview(api).StoryProblem = problem.Uuid;
+
+        var guess = new StoryContextBuilder(api).Classify(api.CurrentModel!);
+
+        Assert.AreEqual(StoryContextBuilder.DevelopmentPhase.ProblemDevelopment, guess.Earliest);
+        Assert.AreEqual(2, guess.OpenSteps.Count);
+    }
+
+    [TestMethod]
+    public async Task UnresolvedSeat_SameAsUnseated()
+    {
+        var api = await OutlineWithPremise();
+        var problem = AddProblem(api, "Crown");
+        problem.Protagonist = Guid.NewGuid();
+        problem.Antagonist = Guid.NewGuid();
+        Overview(api).StoryProblem = problem.Uuid;
+
+        var guess = new StoryContextBuilder(api).Classify(api.CurrentModel!);
+
+        Assert.AreEqual(StoryContextBuilder.DevelopmentPhase.ProblemDevelopment, guess.Earliest);
+        Assert.AreEqual(2, guess.OpenSteps.Count);
+    }
+
+    [TestMethod]
+    public async Task SeatedMissingBackStory_IsCharacterDevelopment()
+    {
+        var api = await OutlineWithPremise();
+        var problem = AddProblem(api, "Crown");
+        var prot = AddCharacter(api, "Macbeth");
+        var antag = AddCharacter(api, "Macduff");
+        FillEssentials(prot);
+        FillEssentials(antag);
+        antag.BackStory = "";
+        problem.Protagonist = prot.Uuid;
+        problem.Antagonist = antag.Uuid;
+        Overview(api).StoryProblem = problem.Uuid;
+
+        var guess = new StoryContextBuilder(api).Classify(api.CurrentModel!);
+
+        Assert.AreEqual(StoryContextBuilder.DevelopmentPhase.CharacterDevelopment, guess.Earliest);
+        Assert.AreEqual(1, guess.OpenSteps.Count);
+        Assert.AreEqual(
+            "Character development - filling essential Character fields",
+            guess.PromptLine);
+    }
+
+    [TestMethod]
+    public async Task SeatedEssentialsFull_NoBeats_IsStructureBuilding()
+    {
+        var api = await SeatedCompleteCast();
+
+        var guess = new StoryContextBuilder(api).Classify(api.CurrentModel!);
+
+        Assert.AreEqual(StoryContextBuilder.DevelopmentPhase.StructureBuilding, guess.Earliest);
+        Assert.IsFalse(guess.PromptLine.Contains("Problem/character"));
+    }
+
+    [TestMethod]
+    public async Task SeatedEssentialsFull_BeatsNoScene_IsStructureBuilding()
+    {
+        var api = await SeatedCompleteCast();
+        var problem = StoryProblem(api);
+        problem.StructureBeats.Add(new StructureBeat("Catalyst", "Something happens"));
+
+        var guess = new StoryContextBuilder(api).Classify(api.CurrentModel!);
+
+        Assert.AreEqual(StoryContextBuilder.DevelopmentPhase.StructureBuilding, guess.Earliest);
+    }
+
+    [TestMethod]
+    public async Task SeatedEssentialsFull_SceneOnBeat_IsSceneWork()
+    {
+        var api = await SeatedCompleteCast();
+        var problem = StoryProblem(api);
+        var scene = AddScene(api, problem, "Battle");
+        problem.StructureBeats.Add(new StructureBeat("Climax", "They fight") { Guid = scene.Uuid });
+
+        var guess = new StoryContextBuilder(api).Classify(api.CurrentModel!);
+
+        Assert.AreEqual(StoryContextBuilder.DevelopmentPhase.SceneWork, guess.Earliest);
+    }
+
+    [TestMethod]
+    public async Task ExtraCharacterThin_DoesNotHoldGuessInCharacterDevelopment()
+    {
+        var api = await SeatedCompleteCast();
+        AddCharacter(api, "Porter");
+
+        var guess = new StoryContextBuilder(api).Classify(api.CurrentModel!);
+
+        Assert.AreEqual(StoryContextBuilder.DevelopmentPhase.StructureBuilding, guess.Earliest);
+    }
+
+    [TestMethod]
+    public async Task CharacterLinkedOnlyOnNonStoryProblem_DoesNotHoldGuess()
+    {
+        var api = await SeatedCompleteCast();
+        var side = AddProblem(api, "Side conflict");
+        var extra = AddCharacter(api, "Banquo");
+        side.Protagonist = extra.Uuid;
+        side.Antagonist = extra.Uuid;
+
+        var guess = new StoryContextBuilder(api).Classify(api.CurrentModel!);
+
+        Assert.AreEqual(StoryContextBuilder.DevelopmentPhase.StructureBuilding, guess.Earliest);
+    }
+
+    [TestMethod]
+    public async Task SameCharacterOnBothSeats_ScansOnce()
+    {
+        var api = await OutlineWithPremise();
+        var problem = AddProblem(api, "Crown");
+        var only = AddCharacter(api, "Macbeth");
+        FillEssentials(only);
+        problem.Protagonist = only.Uuid;
+        problem.Antagonist = only.Uuid;
+        Overview(api).StoryProblem = problem.Uuid;
+
+        var guess = new StoryContextBuilder(api).Classify(api.CurrentModel!);
+
+        Assert.AreEqual(StoryContextBuilder.DevelopmentPhase.StructureBuilding, guess.Earliest);
+    }
+
+    [TestMethod]
+    public async Task BuildContext_ProblemLine_DoesNotSayProblemCharacter()
+    {
+        var api = await OutlineWithPremise();
+        Overview(api).StoryProblem = Guid.Empty;
+        var context = new StoryContextBuilder(api).BuildContext(
+            null, ContextSpec.Default, api.CurrentModel!);
+
+        StringAssert.Contains(context, "## Development Phase");
+        Assert.IsFalse(context.Contains("Problem/character"));
+        StringAssert.Contains(context, "Problem development - building the Story Problem");
+    }
+
+    private static async Task<StoryCADApi> OutlineWithPremise()
+    {
+        var api = CreateApi();
+        var create = await api.CreateEmptyOutline("Guess Test", "Author", "0");
+        Assert.IsTrue(create.IsSuccess, create.ErrorMessage);
+        var overview = Overview(api);
+        overview.StoryType = "Novel";
+        overview.StoryGenre = "Tragedy";
+        overview.Premise = "Ambition destroys a thane.";
+        return api;
+    }
+
+    private static async Task<StoryCADApi> SeatedCompleteCast()
+    {
+        var api = await OutlineWithPremise();
+        var problem = AddProblem(api, "Crown");
+        var prot = AddCharacter(api, "Macbeth");
+        var antag = AddCharacter(api, "Macduff");
+        FillEssentials(prot);
+        FillEssentials(antag);
+        problem.Protagonist = prot.Uuid;
+        problem.Antagonist = antag.Uuid;
+        Overview(api).StoryProblem = problem.Uuid;
+        return api;
+    }
+
+    private static OverviewModel Overview(StoryCADApi api) =>
+        api.CurrentModel!.StoryElements.OfType<OverviewModel>().First();
+
+    private static ProblemModel StoryProblem(StoryCADApi api)
+    {
+        var guid = Overview(api).StoryProblem;
+        return (ProblemModel)api.GetStoryElement(guid).Payload!;
+    }
+
+    private static ProblemModel AddProblem(StoryCADApi api, string name)
+    {
+        var add = api.AddElement(StoryItemType.Problem, Overview(api).Uuid.ToString(), name);
+        Assert.IsTrue(add.IsSuccess, add.ErrorMessage);
+        return (ProblemModel)api.GetStoryElement(add.Payload).Payload!;
+    }
+
+    private static CharacterModel AddCharacter(StoryCADApi api, string name)
+    {
+        var add = api.AddElement(StoryItemType.Character, Overview(api).Uuid.ToString(), name);
+        Assert.IsTrue(add.IsSuccess, add.ErrorMessage);
+        return (CharacterModel)api.GetStoryElement(add.Payload).Payload!;
+    }
+
+    private static SceneModel AddScene(StoryCADApi api, ProblemModel parent, string name)
+    {
+        var add = api.AddElement(StoryItemType.Scene, parent.Uuid.ToString(), name);
+        Assert.IsTrue(add.IsSuccess, add.ErrorMessage);
+        return (SceneModel)api.GetStoryElement(add.Payload).Payload!;
+    }
+
+    private static void FillEssentials(CharacterModel character)
+    {
+        character.Description = "Sketch";
+        character.Role = "Thane";
+        character.StoryRole = "Protagonist";
+        character.Age = "38";
+        character.Sex = "Male";
+        character.Appearance = "Weathered";
+        character.BackStory = "The witches spoke first";
+    }
+}

--- a/StoryCADTests/Collaborator/GapWorkflowViewModelTests.cs
+++ b/StoryCADTests/Collaborator/GapWorkflowViewModelTests.cs
@@ -1,0 +1,31 @@
+using StoryCADLib.Collaborator.Models;
+using StoryCADLib.Collaborator.ViewModels;
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>
+/// Collaborator #107: Outline gaps page copies the Guess sentence.
+/// </summary>
+[TestClass]
+public class GapWorkflowViewModelTests
+{
+    [TestMethod]
+    public void Load_CopiesGuessSentence_AndRaisesPropertyChanged()
+    {
+        var vm = new GapWorkflowViewModel();
+        var changed = new List<string>();
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != null)
+                changed.Add(e.PropertyName);
+        };
+
+        vm.Load(new GapWorkflowPayload
+        {
+            GuessSentence = "Guess: the outline is in Ideation."
+        });
+
+        Assert.AreEqual("Guess: the outline is in Ideation.", vm.GuessSentence);
+        CollectionAssert.Contains(changed, nameof(GapWorkflowViewModel.GuessSentence));
+    }
+}

--- a/StoryCADTests/Collaborator/RequiredFieldGapScannerTests.cs
+++ b/StoryCADTests/Collaborator/RequiredFieldGapScannerTests.cs
@@ -10,8 +10,8 @@ using StoryCADLib.ViewModels;
 namespace StoryCADTests.Collaborator;
 
 /// <summary>
-/// Collaborator #160: Problem spine essentials include ConflictType, ProblemType, Subject.
-/// Flaw/BackStory remain Character input-only (not gap-required).
+/// Collaborator #160 / #107: Problem spine essentials; Character essentials include BackStory.
+/// Flaw is not gap-required.
 /// </summary>
 [TestClass]
 public class RequiredFieldGapScannerTests
@@ -73,7 +73,29 @@ public class RequiredFieldGapScannerTests
     }
 
     [TestMethod]
-    public void Character_DoesNotRequire_Flaw_Or_BackStory()
+    public void Character_Requires_BackStory_Not_Flaw()
+    {
+        var api = CreateApi();
+        var model = new StoryModel();
+        var character = new CharacterModel("Macbeth", model, null)
+        {
+            Description = "Thane",
+            Role = "General",
+            StoryRole = "Protagonist",
+            Age = "38",
+            Sex = "Male",
+            Appearance = "Weathered"
+            // Flaw / BackStory intentionally empty
+        };
+
+        var missing = RequiredFieldGapScanner.GetMissingProperties(api, character);
+
+        CollectionAssert.Contains(missing.ToList(), "BackStory");
+        CollectionAssert.DoesNotContain(missing.ToList(), "Flaw");
+    }
+
+    [TestMethod]
+    public void Character_ThinSheet_Reports_Age_Sex_Appearance_BackStory()
     {
         var api = CreateApi();
         var model = new StoryModel();
@@ -82,14 +104,59 @@ public class RequiredFieldGapScannerTests
             Description = "Thane",
             Role = "General",
             StoryRole = "Protagonist"
-            // Flaw / BackStory intentionally empty
+        };
+
+        var missing = RequiredFieldGapScanner.GetMissingProperties(api, character);
+
+        CollectionAssert.Contains(missing.ToList(), "Age");
+        CollectionAssert.Contains(missing.ToList(), "Sex");
+        CollectionAssert.Contains(missing.ToList(), "Appearance");
+        CollectionAssert.Contains(missing.ToList(), "BackStory");
+        CollectionAssert.DoesNotContain(missing.ToList(), "Flaw");
+        CollectionAssert.DoesNotContain(missing.ToList(), "Archetype");
+        CollectionAssert.DoesNotContain(missing.ToList(), "Enneagram");
+        CollectionAssert.DoesNotContain(missing.ToList(), "Economic");
+    }
+
+    [TestMethod]
+    public void Character_EssentialEightFilled_DoesNotReportCharacterGaps()
+    {
+        var api = CreateApi();
+        var model = new StoryModel();
+        var character = new CharacterModel("Macbeth", model, null)
+        {
+            Description = "Thane",
+            Role = "General",
+            StoryRole = "Protagonist",
+            Age = "38",
+            Sex = "Male",
+            Appearance = "Weathered",
+            BackStory = "The witches spoke first"
         };
 
         var missing = RequiredFieldGapScanner.GetMissingProperties(api, character);
 
         Assert.AreEqual(0, missing.Count, string.Join(", ", missing));
         CollectionAssert.DoesNotContain(missing.ToList(), "Flaw");
-        CollectionAssert.DoesNotContain(missing.ToList(), "BackStory");
+    }
+
+    [TestMethod]
+    public void GapOwnership_NewCharacterFields_PointToSurfaces()
+    {
+        foreach (var prop in new[] { "Age", "Sex", "Appearance" })
+        {
+            var owners = GapWorkflowOwnership.WorkflowsFor(StoryItemType.Character, prop);
+            Assert.AreEqual(1, owners.Count, prop);
+            Assert.AreEqual("DefineCharacter", owners[0], prop);
+        }
+
+        var backStory = GapWorkflowOwnership.WorkflowsFor(StoryItemType.Character, "BackStory");
+        Assert.AreEqual(1, backStory.Count);
+        Assert.AreEqual("FlawBackstory", backStory[0]);
+        Assert.AreEqual("Backstory",
+            GapWorkflowOwnership.DisplayLabel(StoryItemType.Character, "BackStory"));
+        Assert.AreEqual(0,
+            GapWorkflowOwnership.WorkflowsFor(StoryItemType.Character, "Name").Count);
     }
 
     [TestMethod]

--- a/StoryCADTests/Collaborator/StoryFunctionSketchTests.cs
+++ b/StoryCADTests/Collaborator/StoryFunctionSketchTests.cs
@@ -68,4 +68,14 @@ public class StoryFunctionSketchTests
         Assert.AreEqual(1, owners.Count);
         Assert.AreEqual("DefineCharacter", owners[0]);
     }
+
+    [TestMethod]
+    public void GapOwnership_HasNo_RoleAndStoryRole()
+    {
+        foreach (var prop in new[] { "Role", "StoryRole", "Description", "Age", "Sex", "Appearance", "BackStory" })
+        {
+            var owners = GapWorkflowOwnership.WorkflowsFor(StoryItemType.Character, prop);
+            CollectionAssert.DoesNotContain(owners.ToList(), "RoleAndStoryRole");
+        }
+    }
 }


### PR DESCRIPTION
## What

Adds Character Development to the outline-progress Guess and lengthens the essential Character list used by Outline gaps.

- Scanner now requires Name, Role, Age, Sex, Appearance, Story Role, Description, and BackStory. Flaw is not a gap.
- `Classify` returns earliest step plus `OpenSteps`. An unseated Story Problem names Problem Development and Character Development together.
- Guess uses only people seated on the Story Problem. Outline gaps still lists every Character.
- Outline gaps page shows the Guess sentence.
- Problem prompt line no longer says "Problem/character."

## Why

Collaborator **#107**. The Guess skipped Character Development. Outline gaps only flagged four Character fields.

## How to test

```
vstest.console.exe StoryCADTests\bin\x64\Debug\net10.0-windows10.0.22621\StoryCADTests.dll /TestCaseFilter:"FullyQualifiedName~DevelopmentGuessTests"
vstest.console.exe ... /TestCaseFilter:"FullyQualifiedName~RequiredFieldGapScannerTests"
vstest.console.exe ... /TestCaseFilter:"FullyQualifiedName~StoryFunctionSketchTests"
vstest.console.exe ... /TestCaseFilter:"FullyQualifiedName~GapWorkflowViewModelTests"
```

26 tests passed locally (13 + 7 + 5 + 1).

Interactive smoke was dropped. Dev Worker must be the `main` script (Define Character). Do not deploy Collaborator `issue-119-character-interview` onto that Worker.

## Issue

Implements [Collaborator #107](https://github.com/storybuilder-org/Collaborator/issues/107). Does not close it: Evaluate (wiki + log) is still open.

Design: Collaborator `devdocs/issue_107_character_development_design.md`.
