### PR TITLE
feat: DefineStoryWorld workflow client (#201)

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -1831,7 +1831,104 @@ public class Collaborator : ICollaborator
             await InjectSceneSummaryNeighborsAsync(sceneElement, xamlRoot, result);
         }
 
+        // #201: Story Problem + seats when Overview.StoryProblem resolves (thin gather).
+        if (string.Equals(workflow.Label, "DefineStoryWorld", StringComparison.Ordinal)
+            && _storyApi != null)
+        {
+            InjectStoryProblemSeatsForWorld(result);
+        }
+
         return result;
+    }
+
+    /// <summary>
+    /// Collaborator #201: inject Problem / Protagonist / Antagonist when Overview links them.
+    /// Does not create elements. Does not open pickers.
+    /// </summary>
+    private void InjectStoryProblemSeatsForWorld(GatherResult result)
+    {
+        if (!result.Elements.TryGetValue("Overview", out var overviewElement)
+            || overviewElement is not OverviewModel overview)
+            return;
+
+        if (overview.StoryProblem == Guid.Empty)
+            return;
+
+        var problemResult = _storyApi!.GetStoryElement(overview.StoryProblem);
+        if (!problemResult.IsSuccess || problemResult.Payload is not ProblemModel problem)
+            return;
+
+        result.Elements["Problem"] = problem;
+        result.StatusMessages.Add($"Using Problem: {problem.Name}");
+
+        if (problem.Protagonist != Guid.Empty)
+        {
+            var prot = _storyApi.GetStoryElement(problem.Protagonist);
+            if (prot.IsSuccess && prot.Payload != null)
+            {
+                result.Elements["Protagonist"] = prot.Payload;
+                result.StatusMessages.Add($"Using Protagonist: {prot.Payload.Name}");
+            }
+        }
+
+        if (problem.Antagonist != Guid.Empty)
+        {
+            var antag = _storyApi.GetStoryElement(problem.Antagonist);
+            if (antag.IsSuccess && antag.Payload != null)
+            {
+                result.Elements["Antagonist"] = antag.Payload;
+                result.StatusMessages.Add($"Using Antagonist: {antag.Payload.Name}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Collaborator #201: create the StoryWorld singleton under Overview when missing.
+    /// </summary>
+    private StoryElement? TryCreateStoryWorldSingleton(List<string> statusMessages)
+    {
+        if (_storyApi == null || _storyModel == null)
+            return null;
+
+        var existing = _storyApi.GetStoryWorld();
+        if (existing.IsSuccess && existing.Payload != null)
+            return existing.Payload;
+
+        // Parent: Overview (explorer root).
+        Guid overviewGuid = Guid.Empty;
+        if (_storyModel.ExplorerView.Count > 0)
+            overviewGuid = _storyModel.ExplorerView[0].Uuid;
+        if (overviewGuid == Guid.Empty)
+        {
+            var overviewList = _storyApi.GetElementsByType(StoryItemType.StoryOverview);
+            if (overviewList.IsSuccess && overviewList.Payload is { Count: > 0 })
+                overviewGuid = overviewList.Payload[0].Uuid;
+        }
+
+        if (overviewGuid == Guid.Empty)
+        {
+            statusMessages.Add("Cannot create StoryWorld: Overview not found");
+            return null;
+        }
+
+        var add = _storyApi.AddElement(StoryItemType.StoryWorld, overviewGuid.ToString(), "Story World");
+        if (!add.IsSuccess)
+        {
+            statusMessages.Add($"Cannot create StoryWorld: {add.ErrorMessage}");
+            _logger?.LogWarning("AddElement StoryWorld failed: {Error}", add.ErrorMessage);
+            return null;
+        }
+
+        var created = _storyApi.GetStoryElement(add.Payload);
+        if (!created.IsSuccess || created.Payload == null)
+        {
+            statusMessages.Add("StoryWorld was created but could not be reloaded");
+            return null;
+        }
+
+        statusMessages.Add($"Created StoryWorld: {created.Payload.Name}");
+        _logger?.LogInformation("Created StoryWorld {Guid}", created.Payload.Uuid);
+        return created.Payload;
     }
 
     /// <summary>
@@ -1953,6 +2050,24 @@ public class Collaborator : ICollaborator
             _logger?.LogDebug("Auto-resolved {Label} to '{Name}'",
                 requirement.ElementLabel, autoResolved.Name);
             return autoResolved;
+        }
+
+        // #201: StoryWorld is a singleton. Create when missing; never ElementPicker.
+        if (requirement.ElementType == StoryItemType.StoryWorld)
+        {
+            if (requirement.CreateIfMissing && _storyApi != null)
+            {
+                var created = TryCreateStoryWorldSingleton(statusMessages);
+                if (created != null)
+                {
+                    gatheredElements[requirement.ElementLabel] = created;
+                    return created;
+                }
+            }
+
+            statusMessages.Add($"{requirement.ElementLabel}: StoryWorld missing and could not be created");
+            _logger?.LogWarning("StoryWorld gather failed (create={Create})", requirement.CreateIfMissing);
+            return null;
         }
 
         // Try to get referenced element for pre-selection (e.g., "Problem.Protagonist")

--- a/CollaboratorLib/Context/ContextResolver.cs
+++ b/CollaboratorLib/Context/ContextResolver.cs
@@ -34,6 +34,26 @@ public class ContextResolver
     public const string RelatedProblemsRequestName = "RelatedProblems";
 
     /// <summary>
+    /// StoryWorld workflows that receive all Setting elements as RelatedSettings (#201).
+    /// </summary>
+    public static readonly HashSet<string> RelatedSettingsWorkflows = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "DefineStoryWorld"
+    };
+
+    public const string RelatedSettingsRequestName = "RelatedSettings";
+
+    /// <summary>
+    /// StoryWorld workflows that receive Notes + Web under the StoryWorld node (#201).
+    /// </summary>
+    public static readonly HashSet<string> RelatedResearchWorkflows = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "DefineStoryWorld"
+    };
+
+    public const string RelatedResearchRequestName = "RelatedResearch";
+
+    /// <summary>
     /// Get the context specification for a workflow and element type combination.
     /// </summary>
     public ContextSpec GetContextFor(string workflowLabel, StoryItemType elementType)
@@ -67,6 +87,18 @@ public class ContextResolver
         }
 
         if (elementType == StoryItemType.Character)
+        {
+            return new ContextSpec
+            {
+                IncludeStoryConstraints = true,
+                IncludeBeatHierarchy = false,
+                IncludeCharacterContext = false,
+                IncludePrecedingEvents = false,
+                IncludeGaps = true
+            };
+        }
+
+        if (elementType == StoryItemType.StoryWorld)
         {
             return new ContextSpec
             {

--- a/CollaboratorLib/Services/ElementResolver.cs
+++ b/CollaboratorLib/Services/ElementResolver.cs
@@ -140,13 +140,28 @@ namespace StoryCollaborator.Services
                 return null;
             }
 
-            // Only StoryOverview auto-resolves
+            // StoryOverview auto-resolves (always present).
             if (requirement.ElementType == StoryItemType.StoryOverview)
             {
                 var overview = GetMatchingElements(requirement).FirstOrDefault();
                 _logger?.LogDebug("ResolveRequirement: StoryOverview auto-resolve -> {Result}",
                     overview?.Name ?? "(null)");
                 return overview;
+            }
+
+            // StoryWorld singleton: auto-resolve when present (#201). Create path is gather-side.
+            if (requirement.ElementType == StoryItemType.StoryWorld)
+            {
+                var storyWorld = _api.GetStoryWorld();
+                if (storyWorld.IsSuccess && storyWorld.Payload != null)
+                {
+                    _logger?.LogDebug("ResolveRequirement: StoryWorld auto-resolve -> {Result}",
+                        storyWorld.Payload.Name);
+                    return storyWorld.Payload;
+                }
+
+                _logger?.LogDebug("ResolveRequirement: StoryWorld missing (caller may create)");
+                return null;
             }
 
             _logger?.LogDebug("ResolveRequirement: Type {Type} is not singleton - returning null (needs picker)",

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -13,9 +13,11 @@ using CommunityToolkit.Mvvm.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using StoryCADLib.DAL;
 using StoryCADLib.Models;
+using StoryCADLib.Models.StoryWorld;
 using StoryCADLib.Services.API;
 using StoryCADLib.Services.Collaborator.Contracts;
 using StoryCADLib.Services.Reports;
+using StoryCADLib.ViewModels;
 using StoryCollaborator.Models;
 using StoryCollaborator.Workflows;
 
@@ -231,6 +233,7 @@ namespace StoryCollaborator
         /// plus pass-through args and declared collection lists. Does not flatten Label_Property keys
         /// and does not invent lists from WriteVia.
         /// Issue #107: character craft workflows also get RelatedProblems (full Problem models).
+        /// Issue #201: DefineStoryWorld gets RelatedSettings and RelatedResearch.
         /// </summary>
         internal WorkflowProxyBody BuildWorkflowRequestBody(Dictionary<string, StoryElement> gatheredElements)
         {
@@ -255,6 +258,8 @@ namespace StoryCollaborator
             }
 
             AttachRelatedProblemsCollection(body, gatheredElements, serOpts);
+            AttachRelatedSettingsCollection(body);
+            AttachRelatedResearchCollection(body, gatheredElements);
 
             return body;
         }
@@ -286,6 +291,63 @@ namespace StoryCollaborator
             }
 
             body.Args[ContextResolver.RelatedProblemsRequestName] = array.ToJsonString();
+        }
+
+        /// <summary>
+        /// All Setting elements as places in the world (#201). Empty array when none.
+        /// </summary>
+        private void AttachRelatedSettingsCollection(WorkflowProxyBody body)
+        {
+            if (!ContextResolver.RelatedSettingsWorkflows.Contains(workflowModel.Label))
+                return;
+
+            var array = new JsonArray();
+            var listResult = _storyApi.GetElementsByType(StoryItemType.Setting);
+            if (listResult.IsSuccess && listResult.Payload != null)
+            {
+                foreach (var setting in listResult.Payload)
+                    array.Add(SerializeElementOutbound(setting));
+            }
+
+            body.Args[ContextResolver.RelatedSettingsRequestName] = array.ToJsonString();
+        }
+
+        /// <summary>
+        /// Notes and Web under the StoryWorld explorer subtree (#201). No live fetch.
+        /// </summary>
+        private void AttachRelatedResearchCollection(
+            WorkflowProxyBody body,
+            Dictionary<string, StoryElement> gatheredElements)
+        {
+            if (!ContextResolver.RelatedResearchWorkflows.Contains(workflowModel.Label))
+                return;
+
+            var array = new JsonArray();
+            if (gatheredElements.TryGetValue("StoryWorld", out var world) && world?.Node != null)
+            {
+                foreach (var research in EnumerateStoryWorldResearch(world.Node))
+                    array.Add(SerializeElementOutbound(research));
+            }
+
+            body.Args[ContextResolver.RelatedResearchRequestName] = array.ToJsonString();
+        }
+
+        private IEnumerable<StoryElement> EnumerateStoryWorldResearch(StoryNodeItem root)
+        {
+            if (root.Children == null || root.Children.Count == 0)
+                yield break;
+
+            foreach (var child in root.Children)
+            {
+                if (storyModel.StoryElements.StoryElementGuids.TryGetValue(child.Uuid, out var element))
+                {
+                    if (element.ElementType is StoryItemType.Notes or StoryItemType.Web)
+                        yield return element;
+                }
+
+                foreach (var nested in EnumerateStoryWorldResearch(child))
+                    yield return nested;
+            }
         }
 
         /// <summary>
@@ -685,6 +747,33 @@ namespace StoryCollaborator
         }
 
         /// <summary>
+        /// Writes the six World Type axis scalars after WorldType Accept (#201).
+        /// </summary>
+        private int ApplyWorldTypeAxes(Guid storyWorldUuid, WorldTypeAxes axes, WorkflowResult result)
+        {
+            int n = 0;
+            void Write(string property, string value)
+            {
+                var r = _storyApi.UpdateElementProperty(storyWorldUuid, property, value);
+                if (r.IsSuccess)
+                {
+                    n++;
+                    result.StatusMessages.Add($"Applied axis {property} from WorldType map");
+                }
+                else
+                    _logger?.LogWarning($"Failed to apply axis {property}: {r.ErrorMessage}");
+            }
+
+            Write("Ontology", axes.Ontology);
+            Write("WorldRelation", axes.WorldRelation);
+            Write("RuleTransparency", axes.RuleTransparency);
+            Write("ScaleOfDifference", axes.ScaleOfDifference);
+            Write("AgencySource", axes.AgencySource);
+            Write("ToneLogic", axes.ToneLogic);
+            return n;
+        }
+
+        /// <summary>
         /// Applies pending updates to story elements via the API.
         /// Dispatches each PendingUpdate by its WriteVia mechanism.
         /// The explicit default: arm throws on any unhandled WriteVia value.
@@ -704,7 +793,17 @@ namespace StoryCollaborator
                     {
                         var applyResult = _storyApi.UpdateElementProperty(uuid, spec.Property, update.Value ?? string.Empty);
                         if (applyResult.IsSuccess)
+                        {
                             appliedCount++;
+                            // #201: WorldType Accept writes six axes from the host map (form auto-fill
+                            // does not run on UpdateElementProperty).
+                            if (string.Equals(spec.Property, "WorldType", StringComparison.Ordinal)
+                                && update.Value is string worldType
+                                && WorldTypeAxisMap.TryGet(worldType, out var axes))
+                            {
+                                appliedCount += ApplyWorldTypeAxes(uuid, axes, result);
+                            }
+                        }
                         else
                             _logger?.LogWarning($"Failed to apply {update.ElementLabel}.{spec.Property}: {applyResult.ErrorMessage}");
                         break;

--- a/CollaboratorLib/Workflows/Workflow.cs
+++ b/CollaboratorLib/Workflows/Workflow.cs
@@ -167,6 +167,7 @@ namespace StoryCollaborator.Workflows
                 StoryItemType.Web => "Web",
                 StoryItemType.Notes => "Notes",
                 StoryItemType.TrashCan => "Trash",
+                StoryItemType.StoryWorld => "StoryWorld",
                 _ => elementType.ToString()
             };
         }

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -657,6 +657,70 @@ namespace StoryCollaborator.Workflows
                         ExampleLists = new List<string> { "Trait", "Attitude" }
                     }) { PrimaryElementType = StoryItemType.Character },
 
+                // === StoryWorld Workflows ===
+                // #201 DefineStoryWorld: one worldbuilding surface (classifier + cultures + live areas).
+                new Workflow(
+                    label: "DefineStoryWorld",
+                    title: "Define Story World",
+                    description: "Classify the story world and fill worldbuilding fields this World Type needs.",
+                    explanation: "Sets World Type, a short world tell (Description), cultures, and only the " +
+                                "Physical / History / Magic-Technology areas that World Type makes live. " +
+                                "May create the StoryWorld element when the outline has none. " +
+                                "Does not fill Setting places, Species, Governments, Religions, or Economy. " +
+                                "Axis fields come from the host World Type map on Accept, not from the model.",
+                    workflowIO: new WorkflowIO
+                    {
+                        RequiredInputs = new List<ElementRequirement>
+                        {
+                            new ElementRequirement
+                            {
+                                ElementType = StoryItemType.StoryWorld,
+                                ElementLabel = "StoryWorld",
+                                RequiredProperties = new List<PropertySpec>(),
+                                CreateIfMissing = true
+                            },
+                            new ElementRequirement
+                            {
+                                ElementType = StoryItemType.StoryOverview,
+                                ElementLabel = "Overview",
+                                RequiredProperties = new List<PropertySpec>(),
+                                CreateIfMissing = false
+                            }
+                        },
+                        OptionalInputs = new List<ElementRequirement>(),
+                        Outputs = new List<ElementOutput>
+                        {
+                            new ElementOutput
+                            {
+                                ElementType = StoryItemType.StoryWorld,
+                                ElementLabel = "StoryWorld",
+                                PropertiesToUpdate = new List<PropertySpec>
+                                {
+                                    new PropertySpec("Name"),
+                                    new PropertySpec("WorldType"),
+                                    new PropertySpec("Description"),
+                                    new PropertySpec("FoundingEvents"),
+                                    new PropertySpec("MajorConflicts"),
+                                    new PropertySpec("Eras"),
+                                    new PropertySpec("TechnologicalShifts"),
+                                    new PropertySpec("LostKnowledge"),
+                                    new PropertySpec("SystemType"),
+                                    new PropertySpec("Source"),
+                                    new PropertySpec("Rules"),
+                                    new PropertySpec("Limitations"),
+                                    new PropertySpec("Cost"),
+                                    new PropertySpec("Practitioners"),
+                                    new PropertySpec("SocialImpact"),
+                                    new PropertySpec("Cultures", WriteVia.TypedList,
+                                        ListEntryType: typeof(CultureEntry)),
+                                    new PropertySpec("PhysicalWorlds", WriteVia.TypedList,
+                                        ListEntryType: typeof(PhysicalWorldEntry))
+                                }
+                            }
+                        },
+                        ExampleLists = new List<string> { "WorldType", "SystemType" }
+                    }) { PrimaryElementType = StoryItemType.StoryWorld },
+
                 // === Setting Workflows (scene-specific) ===
                 new Workflow(
                     "SettingTimeSpace", "Setting in Time and Space",

--- a/StoryCADLib/Models/StoryWorld/WorldTypeAxisMap.cs
+++ b/StoryCADLib/Models/StoryWorld/WorldTypeAxisMap.cs
@@ -1,0 +1,62 @@
+namespace StoryCADLib.Models.StoryWorld;
+
+/// <summary>
+/// Host World Type → six axis fields. Shared by the StoryWorld form and Collaborator Accept
+/// (Collaborator #201). Selecting WorldType does not run through UpdateElementProperty auto-fill.
+/// </summary>
+public sealed record WorldTypeAxes(
+    string Ontology,
+    string WorldRelation,
+    string RuleTransparency,
+    string ScaleOfDifference,
+    string AgencySource,
+    string ToneLogic);
+
+/// <summary>
+/// Gestalt map for the eight Lists.json WorldType values.
+/// </summary>
+public static class WorldTypeAxisMap
+{
+    private static readonly Dictionary<string, WorldTypeAxes> Map =
+        new(StringComparer.Ordinal)
+        {
+            ["Consensus Reality"] = new(
+                "Mundane", "Primary World", "Explicit Rules", "Cosmetic",
+                "Human-Centric", "Rational"),
+            ["Enchanted Reality"] = new(
+                "Supernatural", "Primary World", "Implicit Rules", "Cosmetic",
+                "Systemic Forces", "Symbolic"),
+            ["Hidden World"] = new(
+                "Supernatural", "Layered", "Explicit Rules", "Structural",
+                "Nonhuman Intelligences", "Rational"),
+            ["Divergent World"] = new(
+                "Scientific Speculative", "Divergent Earth", "Explicit Rules", "Structural",
+                "Human-Centric", "Rational"),
+            ["Constructed World"] = new(
+                "Hybrid", "Secondary World", "Explicit Rules", "Cosmological",
+                "Human-Centric", "Rational"),
+            ["Mythic World"] = new(
+                "Symbolic", "Secondary World", "Symbolic Rules", "Cosmological",
+                "Fate / Providence", "Mythic"),
+            ["Estranged World"] = new(
+                "Scientific Speculative", "Secondary World", "Explicit Rules", "Cosmological",
+                "Systemic Forces", "Dark / Entropic"),
+            ["Broken World"] = new(
+                "Scientific Speculative", "Divergent Earth", "Explicit Rules", "Structural",
+                "Human-Centric", "Dark / Entropic"),
+        };
+
+    /// <summary>The eight WorldType keys in map order.</summary>
+    public static IReadOnlyCollection<string> WorldTypes => Map.Keys;
+
+    public static bool TryGet(string worldType, out WorldTypeAxes axes)
+    {
+        if (string.IsNullOrWhiteSpace(worldType))
+        {
+            axes = null!;
+            return false;
+        }
+
+        return Map.TryGetValue(worldType.Trim(), out axes!);
+    }
+}

--- a/StoryCADLib/ViewModels/StoryWorldViewModel.cs
+++ b/StoryCADLib/ViewModels/StoryWorldViewModel.cs
@@ -1115,12 +1115,11 @@ public partial class StoryWorldViewModel : ObservableRecipient, INavigable, ISav
 
     /// <summary>
     /// Auto-populates axis values based on the selected World Type.
-    /// Uses the gestalt-to-axis mapping from design documents.
+    /// Uses <see cref="WorldTypeAxisMap"/> (shared with Collaborator Accept).
     /// </summary>
     private void AutoPopulateAxisValues()
     {
-        var axes = GetAxisValuesForWorldType(WorldType);
-        if (axes == null) return;
+        if (!WorldTypeAxisMap.TryGet(WorldType, out var axes)) return;
 
         Ontology = axes.Ontology;
         WorldRelation = axes.WorldRelation;
@@ -1187,102 +1186,6 @@ public partial class StoryWorldViewModel : ObservableRecipient, INavigable, ISav
 
             _ => ("Select a World Type to see its description.", "")
         };
-    }
-
-    /// <summary>
-    /// Returns axis values for a World Type based on the gestalt-to-axis mapping.
-    /// </summary>
-    private static AxisValues GetAxisValuesForWorldType(string worldType)
-    {
-        return worldType switch
-        {
-            "Consensus Reality" => new AxisValues
-            {
-                Ontology = "Mundane",
-                WorldRelation = "Primary World",
-                RuleTransparency = "Explicit Rules",
-                ScaleOfDifference = "Cosmetic",
-                AgencySource = "Human-Centric",
-                ToneLogic = "Rational"
-            },
-            "Enchanted Reality" => new AxisValues
-            {
-                Ontology = "Supernatural",
-                WorldRelation = "Primary World",
-                RuleTransparency = "Implicit Rules",
-                ScaleOfDifference = "Cosmetic",
-                AgencySource = "Systemic Forces",
-                ToneLogic = "Symbolic"
-            },
-            "Hidden World" => new AxisValues
-            {
-                Ontology = "Supernatural",
-                WorldRelation = "Layered",
-                RuleTransparency = "Explicit Rules",
-                ScaleOfDifference = "Structural",
-                AgencySource = "Nonhuman Intelligences",
-                ToneLogic = "Rational"
-            },
-            "Divergent World" => new AxisValues
-            {
-                Ontology = "Scientific Speculative",
-                WorldRelation = "Divergent Earth",
-                RuleTransparency = "Explicit Rules",
-                ScaleOfDifference = "Structural",
-                AgencySource = "Human-Centric",
-                ToneLogic = "Rational"
-            },
-            "Constructed World" => new AxisValues
-            {
-                Ontology = "Hybrid",
-                WorldRelation = "Secondary World",
-                RuleTransparency = "Explicit Rules",
-                ScaleOfDifference = "Cosmological",
-                AgencySource = "Human-Centric",  // Variable in spec, default to Human-Centric
-                ToneLogic = "Rational"           // Variable in spec, default to Rational
-            },
-            "Mythic World" => new AxisValues
-            {
-                Ontology = "Symbolic",
-                WorldRelation = "Secondary World",
-                RuleTransparency = "Symbolic Rules",
-                ScaleOfDifference = "Cosmological",
-                AgencySource = "Fate / Providence",
-                ToneLogic = "Mythic"
-            },
-            "Estranged World" => new AxisValues
-            {
-                Ontology = "Scientific Speculative",
-                WorldRelation = "Secondary World",  // Variable in spec
-                RuleTransparency = "Explicit Rules",
-                ScaleOfDifference = "Cosmological",
-                AgencySource = "Systemic Forces",
-                ToneLogic = "Dark / Entropic"
-            },
-            "Broken World" => new AxisValues
-            {
-                Ontology = "Scientific Speculative",
-                WorldRelation = "Divergent Earth",
-                RuleTransparency = "Explicit Rules",
-                ScaleOfDifference = "Structural",
-                AgencySource = "Human-Centric",
-                ToneLogic = "Dark / Entropic"
-            },
-            _ => null
-        };
-    }
-
-    /// <summary>
-    /// Helper class to hold axis values for mapping.
-    /// </summary>
-    private class AxisValues
-    {
-        public string Ontology { get; init; }
-        public string WorldRelation { get; init; }
-        public string RuleTransparency { get; init; }
-        public string ScaleOfDifference { get; init; }
-        public string AgencySource { get; init; }
-        public string ToneLogic { get; init; }
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Implements the client half of Collaborator **#201** — one StoryWorld-primary workflow **Define Story World** (`DefineStoryWorld`).

- Registry entry with StoryWorld + Overview required inputs; TypedList Cultures / PhysicalWorlds
- Singleton resolve via `GetStoryWorld()`; create under Overview when missing (no ElementPicker)
- Inject Story Problem + seats when Overview links them
- `RelatedSettings` and `RelatedResearch` request args
- Shared `WorldTypeAxisMap` (form + Accept); Accept of WorldType writes six axes
- Host form auto-fill now uses the shared map

Does not implement Guess / Outline gaps (**#198**).

## Test plan

- [x] CollaboratorTests `DefineStoryWorldWorkflowTests` (8) pass against this client
- [ ] Manual smoke after Collaborator Worker PR deploys: empty outline creates StoryWorld; re-run with existing world
- [ ] Accept WorldType fills Ontology and the other five axes
- [ ] Cultures / PhysicalWorlds Accept via TypedList

Tracks storybuilder-org/Collaborator#201