### PR TITLE
fix: WorldType Accept default for DefineStoryWorld (#201)

### DIFF
--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -522,6 +522,42 @@ namespace StoryCollaborator
 
             foreach (var update in result.PendingUpdates)
             {
+                // TypedList / SimpleList: empty propose + empty live is NoOp (DefineStoryWorld
+                // re-run returned empty Cultures/PhysicalWorlds as two Accept rows).
+                if (update.Spec.WriteVia is WriteVia.TypedList or WriteVia.SimpleList)
+                {
+                    var proposedCount = CountCollectionValue(update.Value);
+                    var currentCount = ReadCurrentCollectionCount(update.ElementUuid, update.Spec.Property);
+                    if (proposedCount == 0 && currentCount == 0)
+                    {
+                        noOpCount++;
+                        result.StatusMessages.Add($"No-op (empty collection): {update.Key}");
+                        _logger?.LogInformation(
+                            "Classify {Key} kind=NoOp (empty {WriteVia})",
+                            update.Key, update.Spec.WriteVia);
+                        continue;
+                    }
+
+                    // Empty propose against filled live would wipe — do not offer that as Accept.
+                    if (proposedCount == 0 && currentCount > 0)
+                    {
+                        noOpCount++;
+                        result.StatusMessages.Add(
+                            $"No-op (empty {update.Spec.WriteVia} would wipe {currentCount} entries): {update.Key}");
+                        _logger?.LogInformation(
+                            "Classify {Key} kind=NoOp (empty propose vs live count={Count})",
+                            update.Key, currentCount);
+                        continue;
+                    }
+
+                    kept.Add(update);
+                    display[update.Key] = FormatDisplayValue(update);
+                    _logger?.LogInformation(
+                        "Classify {Key} kind=Unclassified (non-scalar WriteVia={WriteVia} count={Count})",
+                        update.Key, update.Spec.WriteVia, proposedCount);
+                    continue;
+                }
+
                 if (update.Spec.WriteVia != WriteVia.Scalar)
                 {
                     kept.Add(update);
@@ -632,6 +668,29 @@ namespace StoryCollaborator
                 text = new RichTextStripper().StripRichTextFormat(text) ?? string.Empty;
 
             return text.Trim();
+        }
+
+        private static int CountCollectionValue(object? value)
+        {
+            if (value is null) return 0;
+            if (value is System.Collections.ICollection c) return c.Count;
+            return 0;
+        }
+
+        private int ReadCurrentCollectionCount(Guid elementUuid, string propertyName)
+        {
+            var got = _storyApi.GetStoryElement(elementUuid);
+            if (!got.IsSuccess || got.Payload == null)
+                return 0;
+
+            var property = got.Payload.GetType().GetProperty(propertyName);
+            if (property == null || !property.CanRead)
+                return 0;
+
+            var value = property.GetValue(got.Payload);
+            if (value is System.Collections.ICollection c)
+                return c.Count;
+            return 0;
         }
 
         private static string NormalizeCompareText(string? text)

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -994,9 +994,10 @@ namespace StoryCollaborator
                             _logger?.LogWarning($"{update.ElementLabel}.{spec.Property}: expected List<JsonElement> for TypedList");
                             break;
                         }
-                        // Clear existing entries by repeatedly removing at index 0,
-                        // then add each entry; the API deserializes the JSON object
-                        // into the collection's typed element (e.g. CultureEntry).
+                        // Snapshot prior entries, then clear-and-add. Merge empty proposed
+                        // fields from prior rows with the same Name so Name-only LLM rows
+                        // do not wipe Values (Cultures Accept smoke).
+                        var priorEntries = SnapshotTypedListEntries(uuid, spec.Property);
                         var existing = _storyApi.GetStoryElement(uuid);
                         if (existing.IsSuccess && existing.Payload != null)
                         {
@@ -1008,7 +1009,8 @@ namespace StoryCollaborator
                         }
                         foreach (var entry in typedEntries)
                         {
-                            var addResult = _storyApi.AddCollectionEntry(uuid, spec.Property, entry);
+                            var toAdd = MergeTypedListJsonWithPrior(entry, priorEntries, spec.ListEntryType);
+                            var addResult = _storyApi.AddCollectionEntry(uuid, spec.Property, toAdd);
                             if (!addResult.IsSuccess)
                                 result.StatusMessages.Add(
                                     $"{spec.Property}: entry rejected: {addResult.ErrorMessage}");
@@ -1295,6 +1297,112 @@ namespace StoryCollaborator
                     entries.Add(entry.Clone());
             }
             return entries;
+        }
+
+        /// <summary>
+        /// Clone current TypedList rows (e.g. CultureEntry) before clear-and-replace.
+        /// </summary>
+        private List<object> SnapshotTypedListEntries(Guid elementUuid, string propertyName)
+        {
+            var list = new List<object>();
+            var existing = _storyApi.GetStoryElement(elementUuid);
+            if (!existing.IsSuccess || existing.Payload == null)
+                return list;
+
+            var prop = existing.Payload.GetType().GetProperty(propertyName);
+            if (prop?.GetValue(existing.Payload) is not System.Collections.IList current)
+                return list;
+
+            foreach (var item in current)
+            {
+                if (item == null) continue;
+                if (item is CultureEntry ce)
+                    list.Add(ce.Clone());
+                else if (item is PhysicalWorldEntry pe)
+                    list.Add(pe.Clone());
+                else
+                    list.Add(item);
+            }
+
+            return list;
+        }
+
+        /// <summary>
+        /// When the model returns Name with blank Values (or camelCase keys already handled
+        /// in API deserialize), keep prior non-empty fields on the same Name.
+        /// </summary>
+        private static object MergeTypedListJsonWithPrior(
+            JsonElement proposedJson,
+            List<object> priorEntries,
+            Type? listEntryType)
+        {
+            if (listEntryType == typeof(CultureEntry))
+            {
+                CultureEntry proposed;
+                try
+                {
+                    proposed = JsonSerializer.Deserialize<CultureEntry>(proposedJson.GetRawText(),
+                        new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                        ?? new CultureEntry();
+                }
+                catch
+                {
+                    return proposedJson;
+                }
+
+                var prior = priorEntries.OfType<CultureEntry>().FirstOrDefault(p =>
+                    string.Equals(
+                        (p.Name ?? string.Empty).Trim(),
+                        (proposed.Name ?? string.Empty).Trim(),
+                        StringComparison.OrdinalIgnoreCase));
+                if (prior != null)
+                {
+                    if (string.IsNullOrWhiteSpace(proposed.Values)) proposed.Values = prior.Values;
+                    if (string.IsNullOrWhiteSpace(proposed.Customs)) proposed.Customs = prior.Customs;
+                    if (string.IsNullOrWhiteSpace(proposed.Taboos)) proposed.Taboos = prior.Taboos;
+                    if (string.IsNullOrWhiteSpace(proposed.Art)) proposed.Art = prior.Art;
+                    if (string.IsNullOrWhiteSpace(proposed.DailyLife)) proposed.DailyLife = prior.DailyLife;
+                    if (string.IsNullOrWhiteSpace(proposed.Entertainment))
+                        proposed.Entertainment = prior.Entertainment;
+                }
+
+                return proposed;
+            }
+
+            if (listEntryType == typeof(PhysicalWorldEntry))
+            {
+                PhysicalWorldEntry proposed;
+                try
+                {
+                    proposed = JsonSerializer.Deserialize<PhysicalWorldEntry>(proposedJson.GetRawText(),
+                        new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                        ?? new PhysicalWorldEntry();
+                }
+                catch
+                {
+                    return proposedJson;
+                }
+
+                var prior = priorEntries.OfType<PhysicalWorldEntry>().FirstOrDefault(p =>
+                    string.Equals(
+                        (p.Name ?? string.Empty).Trim(),
+                        (proposed.Name ?? string.Empty).Trim(),
+                        StringComparison.OrdinalIgnoreCase));
+                if (prior != null)
+                {
+                    if (string.IsNullOrWhiteSpace(proposed.Geography)) proposed.Geography = prior.Geography;
+                    if (string.IsNullOrWhiteSpace(proposed.Climate)) proposed.Climate = prior.Climate;
+                    if (string.IsNullOrWhiteSpace(proposed.NaturalResources))
+                        proposed.NaturalResources = prior.NaturalResources;
+                    if (string.IsNullOrWhiteSpace(proposed.Flora)) proposed.Flora = prior.Flora;
+                    if (string.IsNullOrWhiteSpace(proposed.Fauna)) proposed.Fauna = prior.Fauna;
+                    if (string.IsNullOrWhiteSpace(proposed.Astronomy)) proposed.Astronomy = prior.Astronomy;
+                }
+
+                return proposed;
+            }
+
+            return proposedJson;
         }
 
         private static List<Guid> ExtractGuidList(JsonElement elem)

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -191,6 +191,11 @@ namespace StoryCollaborator
                 if (workflowModel.Label == "InnerOuterProblems")
                     EnrichInnerOuterStructuralFields(result, gatheredElements);
 
+                // #201: empty or omitted WorldType becomes NoOp against empty outline and never
+                // reaches Accept. Propose craft default when still blank.
+                if (string.Equals(workflowModel.Label, "DefineStoryWorld", StringComparison.Ordinal))
+                    EnrichDefineStoryWorldWorldType(result, gatheredElements);
+
                 if (!outputResult.Success)
                 {
                     result.Success = false;
@@ -400,6 +405,52 @@ namespace StoryCollaborator
                 ElementDescription = description,
                 Type = element.ElementType.ToString()
             };
+        }
+
+        /// <summary>
+        /// #201: after extract, ensure a non-empty WorldType is proposed when the outline has none.
+        /// Empty proposed + empty current classifies as NoOp and never reaches Accept (smoke Path A).
+        /// Craft default is Consensus Reality (thin-outline / primary-world default).
+        /// </summary>
+        internal void EnrichDefineStoryWorldWorldType(
+            WorkflowResult result,
+            Dictionary<string, StoryElement> gatheredElements)
+        {
+            const string defaultWorldType = "Consensus Reality";
+            const string label = "StoryWorld";
+
+            if (!gatheredElements.TryGetValue(label, out var world) || world == null)
+            {
+                result.StatusMessages.Add("DefineStoryWorld WorldType enrich skipped: StoryWorld not gathered");
+                return;
+            }
+
+            var current = ReadCurrentScalarDisplay(world.Uuid, "WorldType");
+            if (!string.IsNullOrWhiteSpace(current))
+            {
+                result.StatusMessages.Add(
+                    $"DefineStoryWorld WorldType enrich skipped: already set ({TruncateForLog(current)})");
+                return;
+            }
+
+            var pending = result.PendingUpdates.Find(u =>
+                string.Equals(u.ElementLabel, label, StringComparison.Ordinal)
+                && string.Equals(u.Spec.Property, "WorldType", StringComparison.Ordinal)
+                && u.Spec.WriteVia == WriteVia.Scalar);
+
+            var proposed = pending != null ? NormalizeCompareText(FormatDisplayValue(pending)) : string.Empty;
+            if (!string.IsNullOrEmpty(proposed) && WorldTypeAxisMap.TryGet(proposed, out _))
+            {
+                result.StatusMessages.Add(
+                    $"DefineStoryWorld WorldType enrich skipped: model proposed ({TruncateForLog(proposed)})");
+                return;
+            }
+
+            AddOrReplaceScalarUpdate(result, label, world.Uuid, "WorldType", defaultWorldType);
+            var msg =
+                $"DefineStoryWorld WorldType enrich: proposed default {defaultWorldType} (model empty or invalid)";
+            result.StatusMessages.Add(msg);
+            _logger?.LogInformation("{Message}", msg);
         }
 
         /// <summary>

--- a/StoryCAD/Views/StoryWorldPage.xaml
+++ b/StoryCAD/Views/StoryWorldPage.xaml
@@ -83,7 +83,8 @@
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" MinHeight="80" />
+                            <RowDefinition Height="*" MinHeight="80" />
                         </Grid.RowDefinitions>
 
                         <!-- Question prompt -->
@@ -97,8 +98,28 @@
                                   PlaceholderText="Select the type of world..."
                                   AutomationProperties.AutomationId="WorldTypeCombo"/>
 
-                        <!-- Description panel -->
-                        <Border Grid.Row="2" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        <!-- World tell (StoryElement.Description / ElementDescription) -->
+                        <Expander Grid.Row="2" IsExpanded="True" HorizontalAlignment="Stretch"
+                                  HorizontalContentAlignment="Stretch" Margin="0,16,0,0"
+                                  AutomationProperties.AutomationId="WorldTellExpander">
+                            <Expander.Header>
+                                <TextBlock Text="World tell"
+                                           FontWeight="{x:Bind StoryWorldVm.Description, Converter={StaticResource HasContentToFontWeight}, Mode=OneWay}"/>
+                            </Expander.Header>
+                            <usercontrols:RichEditBoxExtended
+                                RtfText="{x:Bind StoryWorldVm.Description, Mode=TwoWay}"
+                                PlaceholderText="One concrete world fact (the implied-world tell)."
+                                AcceptsReturn="True" IsSpellCheckEnabled="True"
+                                TextWrapping="Wrap"
+                                VerticalAlignment="Stretch"
+                                MinHeight="80"
+                                ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                AutomationProperties.AutomationId="WorldTellRichEdit"
+                                AutomationProperties.Name="World tell"/>
+                        </Expander>
+
+                        <!-- World Type help panel -->
+                        <Border Grid.Row="3" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                                 BorderThickness="1" CornerRadius="4" Margin="0,16,0,0" Padding="16">
                             <StackPanel>

--- a/StoryCADLib/Controls/RichEditBoxExtended.WinAppSDK.cs
+++ b/StoryCADLib/Controls/RichEditBoxExtended.WinAppSDK.cs
@@ -19,8 +19,31 @@ public partial class RichEditBoxExtended : RichEditBox
         TextAlignment = TextAlignment.Left;
         CornerRadius = new CornerRadius(5);
         PointerEntered += (s, e) => UpdateTheme(null, null);
-        Loaded += UpdateTheme;
+        // Expander content is often created after the bound RtfText was set; re-apply on Loaded
+        // so plain-text Collaborator Values etc. appear when the expander opens.
+        Loaded += OnLoadedApplyRtfText;
         UpdateTheme(null, null);
+    }
+
+    private void OnLoadedApplyRtfText(object sender, RoutedEventArgs e)
+    {
+        UpdateTheme(sender, e);
+        if (_lockChangeExecution)
+            return;
+        var text = RtfText ?? "";
+        if (string.IsNullOrEmpty(text))
+            return;
+        _lockChangeExecution = true;
+        var wasReadOnly = IsReadOnly;
+        IsReadOnly = false;
+        var isRtf = text.TrimStart().StartsWith(@"{\rtf", StringComparison.Ordinal);
+        Document.SetText(
+            isRtf
+                ? TextSetOptions.FormatRtf | TextSetOptions.ApplyRtfDocumentDefaults
+                : TextSetOptions.None,
+            text);
+        IsReadOnly = wasReadOnly;
+        _lockChangeExecution = false;
     }
 
     public string RtfText

--- a/StoryCADLib/Services/API/StoryCADAPI.cs
+++ b/StoryCADLib/Services/API/StoryCADAPI.cs
@@ -838,6 +838,12 @@ public class StoryCADApi(OutlineService outlineService, ListData listData, Contr
         return new ListTarget(element, property, property.PropertyType.GetGenericArguments()[0]);
     }
 
+    private static readonly JsonSerializerOptions CollectionEntryJsonOptions = new()
+    {
+        // LLM TypedList JSON often uses camelCase; CultureEntry uses Pascal [JsonPropertyName].
+        PropertyNameCaseInsensitive = true
+    };
+
     private static object DeserializeEntry(object entry, Type targetType, out string error)
     {
         error = null;
@@ -848,7 +854,7 @@ public class StoryCADApi(OutlineService outlineService, ListData listData, Contr
         try
         {
             var json = entry is JsonElement je ? je : JsonSerializer.SerializeToElement(entry);
-            var result = json.Deserialize(targetType);
+            var result = json.Deserialize(targetType, CollectionEntryJsonOptions);
             if (result == null)
             {
                 error = $"Conversion of '{entry.GetType().Name}' to '{targetType.Name}' produced null.";

--- a/StoryCADLib/ViewModels/StoryWorldViewModel.cs
+++ b/StoryCADLib/ViewModels/StoryWorldViewModel.cs
@@ -65,6 +65,17 @@ public partial class StoryWorldViewModel : ObservableRecipient, INavigable, ISav
         }
     }
 
+    /// <summary>
+    /// World tell / short classifier prose. StoryElement.Description (ElementDescription in .stbx).
+    /// Collaborator DefineStoryWorld writes this; must load/save and bind on the Structure tab.
+    /// </summary>
+    private string _description = string.Empty;
+    public string Description
+    {
+        get => _description;
+        set => SetProperty(ref _description, value);
+    }
+
     private StoryWorldModel _model;
     public StoryWorldModel Model
     {
@@ -951,6 +962,7 @@ public partial class StoryWorldViewModel : ObservableRecipient, INavigable, ISav
         try
         {
             // Note: Don't save Name - it's derived for display, node keeps "Story World"
+            Model.Description = Description ?? string.Empty;
 
             // Structure tab
             Model.WorldType = WorldType;
@@ -1020,6 +1032,8 @@ public partial class StoryWorldViewModel : ObservableRecipient, INavigable, ISav
         Name = string.IsNullOrEmpty(storyName)
             ? "Story World"
             : storyName + " Story World";
+
+        Description = Model.Description ?? string.Empty;
 
         // Structure tab
         WorldType = Model.WorldType;
@@ -1205,6 +1219,7 @@ public partial class StoryWorldViewModel : ObservableRecipient, INavigable, ISav
 
         // Initialize string properties
         Name = string.Empty;
+        Description = string.Empty;
         WorldType = string.Empty;
 
         // Initialize list tab collections and navigators

--- a/StoryCADTests/ViewModels/StoryWorldViewModelTests.cs
+++ b/StoryCADTests/ViewModels/StoryWorldViewModelTests.cs
@@ -92,6 +92,7 @@ public class StoryWorldViewModelTests
 
         var model = new StoryWorldModel("Ignored Name", storyModel, null);
         model.WorldType = "Hidden World";
+        model.Description = "The door dilated.";
         model.EconomicSystem = "Barter economy";
 
         // Act
@@ -100,6 +101,7 @@ public class StoryWorldViewModelTests
         // Assert - Name is derived from story name + " Story World", not from model
         Assert.AreEqual("Test Story World", viewModel.Name);
         Assert.AreEqual("Hidden World", viewModel.WorldType);
+        Assert.AreEqual("The door dilated.", viewModel.Description);
         Assert.AreEqual("Barter economy", viewModel.EconomicSystem);
     }
 
@@ -117,11 +119,13 @@ public class StoryWorldViewModelTests
 
         // Act - modify ViewModel properties
         viewModel.WorldType = "Broken World";
+        viewModel.Description = "Ash falls every morning.";
         viewModel.Currency = "Bottle caps";
         viewModel.SaveModel();
 
         // Assert - model should have new values
         Assert.AreEqual("Broken World", model.WorldType);
+        Assert.AreEqual("Ash falls every morning.", model.Description);
         Assert.AreEqual("Bottle caps", model.Currency);
     }
 


### PR DESCRIPTION
## Summary

Smoke Path A: model omitted or emptied WorldType. Empty proposed + empty current is NoOp under #116 classify, so WorldType never reached Accept and axes never wrote.

After extract, when StoryWorld WorldType is still blank, propose **Consensus Reality** (thin-outline craft default). Valid model proposals and already-set values are left alone.

## Test plan

- [x] EnrichDefineStoryWorldWorldType_* (3) pass
- [ ] Re-smoke Path A Accept WorldType + axes

Related storybuilder-org/Collaborator#201