### PR TITLE
feat: SceneBuilder gather, Story Problem bail, and merged Scene outputs (#208)

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -225,6 +225,15 @@ public class Collaborator : ICollaborator
                             return;
                         }
 
+                        if (gatherResult.Failed)
+                        {
+                            viewModel.StatusText = string.IsNullOrWhiteSpace(gatherResult.BailReason)
+                                ? FormatGatherStatusForShell(gatherResult.StatusMessages)
+                                : gatherResult.BailReason;
+                            _logger?.LogInformation("SceneBuilder bail: {BailReason}", gatherResult.BailReason);
+                            return;
+                        }
+
                         viewModel.StatusText = string.Empty;
 
                         // Navigate to WorkflowPage
@@ -1197,15 +1206,28 @@ public class Collaborator : ICollaborator
                     // #140 / #116 rev: Protect accepts are staged until end-of-queue confirm.
                     var stageSession = new OverwriteAcceptanceSession();
 
+                    var sceneBuilderOrphanBindDone = false;
+
                     int ApplyPendingList(IReadOnlyList<PendingUpdate> list)
                     {
-                        if (list.Count == 0) return 0;
-                        var slice = WorkflowResult.Succeeded();
-                        foreach (var u in list)
-                            slice.PendingUpdates.Add(u);
-                        var applied = runner.ApplyUpdates(slice, gatheredElements);
-                        foreach (var u in list)
-                            _sessionTouchedFields.Add(u.SessionTouchKey);
+                        int applied = 0;
+                        if (list.Count > 0)
+                        {
+                            var slice = WorkflowResult.Succeeded();
+                            foreach (var u in list)
+                                slice.PendingUpdates.Add(u);
+                            applied = runner.ApplyUpdates(slice, gatheredElements);
+                            foreach (var u in list)
+                                _sessionTouchedFields.Add(u.SessionTouchKey);
+                        }
+                        if (!sceneBuilderOrphanBindDone
+                            && string.Equals(workflow.Label, "SceneBuilder", StringComparison.Ordinal))
+                        {
+                            var bindMsg = runner.TryApplySceneBuilderOrphanBind(result, gatheredElements);
+                            sceneBuilderOrphanBindDone = true;
+                            if (!string.IsNullOrEmpty(bindMsg))
+                                viewModel.AddStatusMessage(bindMsg);
+                        }
                         // Accept writes the model via API. Host element VMs stay stale until
                         // reload — AutoSave FlushCurrentEdits then SaveModel's empty VM values
                         // over the applied text (Character.BackStory wipe after #184 Accept).
@@ -1717,6 +1739,8 @@ public class Collaborator : ICollaborator
         public Dictionary<string, StoryElement> Elements { get; set; } = new();
         public List<string> StatusMessages { get; set; } = new();
         public bool Cancelled { get; set; }
+        public bool Failed { get; set; }
+        public string? BailReason { get; set; }
     }
 
     /// <summary>
@@ -1831,6 +1855,13 @@ public class Collaborator : ICollaborator
             await InjectSceneSummaryNeighborsAsync(sceneElement, xamlRoot, result);
         }
 
+        if (string.Equals(workflow.Label, "SceneBuilder", StringComparison.Ordinal)
+            && result.Elements.TryGetValue("Scene", out var sceneBuilderScene)
+            && _storyApi != null)
+        {
+            InjectSceneBuilder(sceneBuilderScene, result);
+        }
+
         // #201: Story Problem + seats when Overview.StoryProblem resolves (thin gather).
         if (string.Equals(workflow.Label, "DefineStoryWorld", StringComparison.Ordinal)
             && _storyApi != null)
@@ -1929,6 +1960,164 @@ public class Collaborator : ICollaborator
         statusMessages.Add($"Created StoryWorld: {created.Payload.Name}");
         _logger?.LogInformation("Created StoryWorld {Guid}", created.Payload.Uuid);
         return created.Payload;
+    }
+
+    /// <summary>
+    /// Collaborator #208: inject Overview, owner, contributing Problems, neighbors, seats, Setting.
+    /// Sets Failed on Story Problem / empty-category bail. Does not open pickers.
+    /// </summary>
+    private void InjectSceneBuilder(StoryElement sceneElement, GatherResult result)
+    {
+        InjectOverviewIfMissing(result);
+
+        var resolver = new Services.SceneStructureNeighborResolver(_storyApi!);
+        var resolved = resolver.ResolveForSceneBuilder(sceneElement);
+
+        foreach (var line in resolved.StatusLines)
+            result.StatusMessages.Add(line);
+
+        if (resolved.OwnerState is Services.SceneStructureNeighborResolver.SceneBuilderOwnerState.StoryProblemBail
+            or Services.SceneStructureNeighborResolver.SceneBuilderOwnerState.EmptyCategoryBail)
+        {
+            result.Failed = true;
+            result.BailReason = resolved.BailReason;
+            return;
+        }
+
+        if (resolved.OwnerProblem != null)
+            result.Elements["Problem"] = resolved.OwnerProblem;
+        if (resolved.PrecedingScene != null)
+            result.Elements["PrecedingScene"] = resolved.PrecedingScene;
+        if (resolved.NextScene != null)
+            result.Elements["NextScene"] = resolved.NextScene;
+
+        InjectSceneBuilderSeatsAndCast(sceneElement, result);
+        InjectSceneBuilderContributingLabels(sceneElement, resolver, resolved, result);
+        InjectStoryProblemAncestor(result);
+    }
+
+    private void InjectOverviewIfMissing(GatherResult result)
+    {
+        if (result.Elements.ContainsKey("Overview") || _storyApi == null)
+            return;
+
+        var overviews = _storyApi.GetElementsByType(StoryItemType.StoryOverview);
+        if (!overviews.IsSuccess || overviews.Payload == null || overviews.Payload.Count == 0)
+            return;
+
+        result.Elements["Overview"] = overviews.Payload[0];
+        result.StatusMessages.Add($"Using Overview: {overviews.Payload[0].Name}");
+    }
+
+    private void InjectStoryProblemAncestor(GatherResult result)
+    {
+        if (_storyApi == null)
+            return;
+        if (!result.Elements.TryGetValue("Overview", out var overviewEl)
+            || overviewEl is not OverviewModel overview
+            || overview.StoryProblem == Guid.Empty)
+            return;
+        if (result.Elements.TryGetValue("Problem", out var owner)
+            && owner.Uuid == overview.StoryProblem)
+            return;
+
+        var sp = _storyApi.GetStoryElement(overview.StoryProblem);
+        if (!sp.IsSuccess || sp.Payload is not ProblemModel problem)
+            return;
+
+        result.Elements["StoryProblem"] = problem;
+        result.StatusMessages.Add($"Using StoryProblem (ancestor): {problem.Name}");
+    }
+
+    private void InjectSceneBuilderSeatsAndCast(StoryElement sceneElement, GatherResult result)
+    {
+        if (_storyApi == null || sceneElement is not SceneModel scene)
+            return;
+
+        if (scene.Setting != Guid.Empty)
+        {
+            var settingResult = _storyApi.GetStoryElement(scene.Setting);
+            if (settingResult.IsSuccess && settingResult.Payload is SettingModel setting)
+            {
+                result.Elements["Setting"] = setting;
+                result.StatusMessages.Add($"Using Setting: {setting.Name}");
+            }
+        }
+
+        var used = new HashSet<Guid>();
+        TryInjectCharacterSeat(scene.Protagonist, "Protagonist", result, used);
+        TryInjectCharacterSeat(scene.Antagonist, "Antagonist", result, used);
+        TryInjectCharacterSeat(scene.ViewpointCharacter, "ViewpointCharacter", result, used);
+
+        int n = 1;
+        foreach (var guid in scene.CastMembers ?? new List<Guid>())
+        {
+            if (guid == Guid.Empty || used.Contains(guid))
+                continue;
+            var member = _storyApi.GetStoryElement(guid);
+            if (!member.IsSuccess || member.Payload == null)
+                continue;
+            result.Elements[$"CastMember{n}"] = member.Payload;
+            result.StatusMessages.Add($"Using CastMember{n}: {member.Payload.Name}");
+            used.Add(guid);
+            n++;
+        }
+    }
+
+    private void TryInjectCharacterSeat(
+        Guid guid,
+        string label,
+        GatherResult result,
+        HashSet<Guid> used)
+    {
+        if (guid == Guid.Empty || _storyApi == null)
+            return;
+        var got = _storyApi.GetStoryElement(guid);
+        if (!got.IsSuccess || got.Payload is not CharacterModel character)
+            return;
+        result.Elements[label] = character;
+        result.StatusMessages.Add($"Using {label}: {character.Name}");
+        used.Add(guid);
+    }
+
+    private void InjectSceneBuilderContributingLabels(
+        StoryElement sceneElement,
+        Services.SceneStructureNeighborResolver resolver,
+        Services.SceneStructureNeighborResolver.SceneBuilderResolveResult resolved,
+        GatherResult result)
+    {
+        var owners = resolved.ContributingProblems.ToList();
+        if (owners.Count == 0)
+            return;
+
+        var ordered = new List<ProblemModel>();
+        void AddIfOwner(ProblemModel? problem)
+        {
+            if (problem == null)
+                return;
+            var match = owners.FirstOrDefault(o => o.Uuid == problem.Uuid);
+            if (match != null && ordered.All(o => o.Uuid != match.Uuid))
+                ordered.Add(match);
+        }
+
+        AddIfOwner(resolved.OwnerProblem);
+        AddIfOwner(resolver.GetExplorerParentProblem(sceneElement));
+        foreach (var owner in owners)
+            AddIfOwner(owner);
+
+        const int cap = 8;
+        int k = Math.Min(cap, ordered.Count);
+        for (int i = 0; i < k; i++)
+        {
+            result.Elements[$"ContributingProblem{i + 1}"] = ordered[i];
+            result.StatusMessages.Add($"Using ContributingProblem{i + 1}: {ordered[i].Name}");
+        }
+
+        if (ordered.Count > cap)
+        {
+            result.StatusMessages.Add(
+                $"Scene Builder: {ordered.Count} contributing Problems; labeled first {cap}.");
+        }
     }
 
     /// <summary>

--- a/CollaboratorLib/Context/GapWorkflowOwnership.cs
+++ b/CollaboratorLib/Context/GapWorkflowOwnership.cs
@@ -55,9 +55,9 @@ public static class GapWorkflowOwnership
             (StoryItemType.Setting, "Description") => new[] { "SettingTimeSpace" },
             (StoryItemType.Setting, "Name") => Array.Empty<string>(),
 
-            (StoryItemType.Scene, "Description") => new[] { "SceneSummary" },
-            (StoryItemType.Scene, "CastMembers") => new[] { "CastSceneRoles" },
-            (StoryItemType.Scene, "Setting") => new[] { "SceneSummary", "CastSceneRoles" },
+            (StoryItemType.Scene, "Description") => new[] { "SceneBuilder", "SceneSummary" },
+            (StoryItemType.Scene, "CastMembers") => new[] { "SceneBuilder", "CastSceneRoles" },
+            (StoryItemType.Scene, "Setting") => new[] { "SceneBuilder", "SceneSummary", "CastSceneRoles" },
             (StoryItemType.Scene, "Name") => Array.Empty<string>(),
 
             (_, "Name") => Array.Empty<string>(),

--- a/CollaboratorLib/Models/ValueDisplay.cs
+++ b/CollaboratorLib/Models/ValueDisplay.cs
@@ -48,7 +48,12 @@ internal static class ValueDisplay
             case null:
                 return string.Empty;
 
+            case Guid g:
+                return g == Guid.Empty ? string.Empty : ResolveName(g, resolveElementName);
+
             case string s:
+                if (Guid.TryParse(s, out var parsed) && parsed != Guid.Empty)
+                    return ResolveName(parsed, resolveElementName);
                 return s;
 
             case List<string> entries:

--- a/CollaboratorLib/Models/WorkflowResult.cs
+++ b/CollaboratorLib/Models/WorkflowResult.cs
@@ -56,6 +56,17 @@ public class WorkflowResult
     public ProxyCostInfo? Cost { get; set; }
 
     /// <summary>
+    /// Collaborator #208: analysis-only orphan bind GUID from SceneBuilder JSON.
+    /// Not a SceneModel property. Accept uses this when the Scene is an orphan.
+    /// </summary>
+    public Guid? ProposedOwnerGuid { get; set; }
+
+    /// <summary>
+    /// Collaborator #208: display name for the proposed orphan owner (Notes fallback).
+    /// </summary>
+    public string? ProposedOwnerName { get; set; }
+
+    /// <summary>
     /// Creates a successful result.
     /// </summary>
     public static WorkflowResult Succeeded()

--- a/CollaboratorLib/Services/SceneStructureNeighborResolver.cs
+++ b/CollaboratorLib/Services/SceneStructureNeighborResolver.cs
@@ -30,6 +30,20 @@ public sealed class SceneStructureNeighborResolver
         ExplorerParentOnly
     }
 
+    /// <summary>
+    /// Collaborator #208: owner state for SceneBuilder. Separate from Scene Summary
+    /// <see cref="OwnerState"/> so ResolveForSceneSummary is unchanged.
+    /// </summary>
+    public enum SceneBuilderOwnerState
+    {
+        None,
+        UniqueSubproblem,
+        ExplorerParentSubproblem,
+        AmbiguousSubproblems,
+        StoryProblemBail,
+        EmptyCategoryBail
+    }
+
     public sealed class ResolveResult
     {
         public ProblemModel? OwnerProblem { get; init; }
@@ -44,6 +58,17 @@ public sealed class SceneStructureNeighborResolver
     {
         public SceneModel? PrecedingScene { get; init; }
         public SceneModel? NextScene { get; init; }
+    }
+
+    public sealed class SceneBuilderResolveResult
+    {
+        public IReadOnlyList<ProblemModel> ContributingProblems { get; init; } = Array.Empty<ProblemModel>();
+        public ProblemModel? OwnerProblem { get; init; }
+        public SceneModel? PrecedingScene { get; init; }
+        public SceneModel? NextScene { get; init; }
+        public SceneBuilderOwnerState OwnerState { get; init; }
+        public string? BailReason { get; init; }
+        public IReadOnlyList<string> StatusLines { get; init; } = Array.Empty<string>();
     }
 
     /// <summary>
@@ -62,7 +87,7 @@ public sealed class SceneStructureNeighborResolver
         }
 
         var status = new List<string>();
-        var owners = FindStructureOwners(scene.Uuid, status);
+        var owners = FindStructureOwners(scene.Uuid, status, "Scene Summary");
         var explorerParent = GetExplorerParentProblem(scene);
         var (state, owner, candidates) = ResolveOwner(scene, owners, explorerParent);
 
@@ -124,13 +149,16 @@ public sealed class SceneStructureNeighborResolver
     /// <summary>
     /// Problems whose structure assigns <paramref name="sceneGuid"/> on any beat.
     /// </summary>
-    public IReadOnlyList<ProblemModel> FindStructureOwners(Guid sceneGuid, List<string>? statusLines = null)
+    public IReadOnlyList<ProblemModel> FindStructureOwners(
+        Guid sceneGuid,
+        List<string>? statusLines = null,
+        string scanLabel = "Scene Summary")
     {
         var owners = new List<ProblemModel>();
         var problemsResult = _api.GetElementsByType(StoryItemType.Problem);
         if (!problemsResult.IsSuccess || problemsResult.Payload == null)
         {
-            statusLines?.Add("Scene Summary: could not list Problems for structure scan.");
+            statusLines?.Add($"{scanLabel}: could not list Problems for structure scan.");
             _logger?.LogWarning("FindStructureOwners: GetElementsByType(Problem) failed: {Msg}",
                 problemsResult.ErrorMessage);
             return owners;
@@ -361,5 +389,162 @@ public sealed class SceneStructureNeighborResolver
         }
 
         return null;
+    }
+
+    public const string SceneBuilderStoryProblemBailMessage =
+        "Scene Builder does not run on a Story Problem. Use Problem Builder or Structure for story-problem beats.";
+
+    public const string SceneBuilderEmptyCategoryBailMessage =
+        "Set Problem Category on the owning problem before Scene Builder.";
+
+    /// <summary>
+    /// Collaborator #208: contributing Problems, owning problem, Story Problem / empty-category bail,
+    /// and 1+1 neighbors from OwnerProblem when the Scene GUID is on that sheet.
+    /// </summary>
+    public SceneBuilderResolveResult ResolveForSceneBuilder(StoryElement scene)
+    {
+        if (scene == null || scene.ElementType != StoryItemType.Scene)
+        {
+            return new SceneBuilderResolveResult
+            {
+                OwnerState = SceneBuilderOwnerState.None,
+                StatusLines = new[] { "Scene Builder: no Scene element; owner omitted." }
+            };
+        }
+
+        var status = new List<string>();
+        var owners = FindStructureOwners(scene.Uuid, status, "Scene Builder");
+        var explorerParent = GetExplorerParentProblem(scene);
+        var overviewStoryProblem = GetOverviewStoryProblemUuid();
+        var (state, owner, bail) = ResolveSceneBuilderOwner(owners, explorerParent, overviewStoryProblem);
+
+        if (state is SceneBuilderOwnerState.StoryProblemBail or SceneBuilderOwnerState.EmptyCategoryBail)
+        {
+            if (owner != null)
+                status.Add($"Scene Builder: owner Problem = {owner.Name}");
+            if (!string.IsNullOrEmpty(bail))
+                status.Add(bail);
+            return new SceneBuilderResolveResult
+            {
+                ContributingProblems = owners,
+                OwnerProblem = owner,
+                OwnerState = state,
+                BailReason = bail,
+                StatusLines = status
+            };
+        }
+
+        SceneModel? preceding = null;
+        SceneModel? next = null;
+        if (owner != null)
+        {
+            bool onSheet = owners.Any(o => o.Uuid == owner.Uuid);
+            if (onSheet)
+            {
+                var neighbors = FindNeighbors(owner, scene.Uuid);
+                preceding = neighbors.PrecedingScene;
+                next = neighbors.NextScene;
+            }
+
+            status.Add($"Scene Builder: owner Problem = {owner.Name}");
+            status.Add(preceding != null
+                ? $"Scene Builder: preceding Scene = {preceding.Name}"
+                : "Scene Builder: preceding Scene = (none)");
+            status.Add(next != null
+                ? $"Scene Builder: next Scene = {next.Name}"
+                : "Scene Builder: next Scene = (none)");
+        }
+        else if (state == SceneBuilderOwnerState.AmbiguousSubproblems)
+        {
+            var names = string.Join(", ", owners.Where(o => !IsStoryProblem(o, overviewStoryProblem)).Select(p => p.Name));
+            status.Add($"Scene Builder: ambiguous subproblems ({owners.Count} contributing): {names}. Neighbors omitted.");
+        }
+        else
+        {
+            status.Add("Scene Builder: no owner Problem (orphan); neighbors omitted.");
+        }
+
+        status.Add($"Scene Builder: contributing Problems = {owners.Count}");
+
+        return new SceneBuilderResolveResult
+        {
+            ContributingProblems = owners,
+            OwnerProblem = owner,
+            PrecedingScene = preceding,
+            NextScene = next,
+            OwnerState = state,
+            StatusLines = status
+        };
+    }
+
+    internal Guid GetOverviewStoryProblemUuid()
+    {
+        var result = _api.GetElementsByType(StoryItemType.StoryOverview);
+        if (!result.IsSuccess || result.Payload == null || result.Payload.Count == 0)
+            return Guid.Empty;
+        if (result.Payload[0] is OverviewModel overview)
+            return overview.StoryProblem;
+        return Guid.Empty;
+    }
+
+    internal bool IsStoryProblem(ProblemModel problem, Guid overviewStoryProblem)
+    {
+        if (overviewStoryProblem != Guid.Empty && problem.Uuid == overviewStoryProblem)
+            return true;
+        return string.Equals(
+            (problem.ProblemCategory ?? string.Empty).Trim(),
+            Collaborator.StoryProblemCategoryListValue,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal (SceneBuilderOwnerState State, ProblemModel? Owner, string? BailReason)
+        ResolveSceneBuilderOwner(
+            IReadOnlyList<ProblemModel> owners,
+            ProblemModel? explorerParent,
+            Guid overviewStoryProblem)
+    {
+        bool IsSp(ProblemModel p) => IsStoryProblem(p, overviewStoryProblem);
+        bool IsCategorizedSubproblem(ProblemModel p) =>
+            !IsSp(p) && !string.IsNullOrWhiteSpace(p.ProblemCategory);
+
+        var ownerList = owners?.ToList() ?? new List<ProblemModel>();
+
+        // 5.4 step 1
+        if (explorerParent != null && IsSp(explorerParent))
+            return (SceneBuilderOwnerState.StoryProblemBail, explorerParent, SceneBuilderStoryProblemBailMessage);
+
+        // 5.4 step 2
+        if (explorerParent != null && string.IsNullOrWhiteSpace(explorerParent.ProblemCategory))
+        {
+            var categorized = ownerList.Where(IsCategorizedSubproblem).ToList();
+            if (categorized.Count == 1)
+                return (SceneBuilderOwnerState.UniqueSubproblem, categorized[0], null);
+            return (SceneBuilderOwnerState.EmptyCategoryBail, explorerParent, SceneBuilderEmptyCategoryBailMessage);
+        }
+
+        // 5.4 step 3
+        if (explorerParent != null)
+            return (SceneBuilderOwnerState.ExplorerParentSubproblem, explorerParent, null);
+
+        // 5.4 step 4
+        var nonStory = ownerList.Where(o => !IsSp(o)).ToList();
+        if (nonStory.Count == 1)
+        {
+            var only = nonStory[0];
+            if (string.IsNullOrWhiteSpace(only.ProblemCategory))
+                return (SceneBuilderOwnerState.EmptyCategoryBail, only, SceneBuilderEmptyCategoryBailMessage);
+            return (SceneBuilderOwnerState.UniqueSubproblem, only, null);
+        }
+
+        // 5.4 step 5
+        if (ownerList.Count > 0 && ownerList.All(IsSp))
+            return (SceneBuilderOwnerState.StoryProblemBail, ownerList[0], SceneBuilderStoryProblemBailMessage);
+
+        // 5.4 step 6
+        if (nonStory.Count >= 2)
+            return (SceneBuilderOwnerState.AmbiguousSubproblems, null, null);
+
+        // 5.4 step 7
+        return (SceneBuilderOwnerState.None, null, null);
     }
 }

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -19,6 +19,7 @@ using StoryCADLib.Services.Collaborator.Contracts;
 using StoryCADLib.Services.Reports;
 using StoryCADLib.ViewModels;
 using StoryCollaborator.Models;
+using StoryCollaborator.Services;
 using StoryCollaborator.Workflows;
 
 namespace StoryCollaborator
@@ -124,6 +125,15 @@ namespace StoryCollaborator
                     return WorkflowResult.Failed(gateMessage);
             }
 
+            // Collaborator #208: SceneBuilder Story Problem / empty-category bail.
+            // Do not copy BeatScenes: a missing Problem map entry is not empty category.
+            if (string.Equals(workflowModel.Label, "SceneBuilder", StringComparison.Ordinal))
+            {
+                var sceneBuilderGate = ValidateSceneBuilderOwner(gatheredElements);
+                if (sceneBuilderGate != null)
+                    return WorkflowResult.Failed(sceneBuilderGate);
+            }
+
             // Without a subscriber's (or allowlisted dev/tester's) activation JWT, the workflow
             // degrades to the stub rather than calling out bare (issue #90 step 8 item 5: the
             // OPENAI_API_KEY direct-to-OpenAI path retired, so a held JWT is the only credential).
@@ -185,6 +195,9 @@ namespace StoryCollaborator
                     result.UpdatedProperties[kvp.Key] = kvp.Value;
                 foreach (var pending in outputResult.PendingUpdates)
                     result.PendingUpdates.Add(pending);
+
+                if (string.Equals(workflowModel.Label, "SceneBuilder", StringComparison.Ordinal))
+                    CaptureSceneBuilderProposal(planResult, result);
 
                 // #120: structural fields the model must not invent (list value + GUIDs).
                 // Proposes into pending only; #116 classify decides Fill vs Protect (never silent force).
@@ -265,8 +278,47 @@ namespace StoryCollaborator
             AttachRelatedProblemsCollection(body, gatheredElements, serOpts);
             AttachRelatedSettingsCollection(body);
             AttachRelatedResearchCollection(body, gatheredElements);
+            AttachContributingProblemsCollection(body, gatheredElements);
 
             return body;
+        }
+
+        /// <summary>
+        /// Collaborator #208: all structure owners as full Problem models.
+        /// Orphan (no owners, explorer parent is not a Problem) also attaches ProblemChoices.
+        /// </summary>
+        private void AttachContributingProblemsCollection(
+            WorkflowProxyBody body,
+            Dictionary<string, StoryElement> gatheredElements)
+        {
+            if (!string.Equals(workflowModel.Label, "SceneBuilder", StringComparison.Ordinal))
+                return;
+            if (!gatheredElements.TryGetValue("Scene", out var scene) || scene == null)
+                return;
+
+            var resolver = new SceneStructureNeighborResolver(_storyApi);
+            var owners = resolver.FindStructureOwners(scene.Uuid);
+            var array = new JsonArray();
+            foreach (var owner in owners)
+                array.Add(SerializeElementOutbound(owner));
+            body.Args["ContributingProblems"] = array.ToJsonString();
+
+            var explorerParent = resolver.GetExplorerParentProblem(scene);
+            bool orphan = owners.Count == 0 && explorerParent == null;
+            if (!orphan)
+                return;
+
+            var choices = new JsonArray();
+            var problems = _storyApi.GetElementsByType(StoryItemType.Problem);
+            if (problems.IsSuccess && problems.Payload != null)
+            {
+                foreach (var el in problems.Payload)
+                {
+                    if (el is ProblemModel problem)
+                        choices.Add(SerializeElementOutbound(problem));
+                }
+            }
+            body.Args["ProblemChoices"] = choices.ToJsonString();
         }
 
         /// <summary>
@@ -522,6 +574,12 @@ namespace StoryCollaborator
 
             foreach (var update in result.PendingUpdates)
             {
+                if (TryDropInvalidSceneBuilderGuid(update, result))
+                {
+                    noOpCount++;
+                    continue;
+                }
+
                 // TypedList / SimpleList: empty propose + empty live is NoOp (DefineStoryWorld
                 // re-run returned empty Cultures/PhysicalWorlds as two Accept rows).
                 if (update.Spec.WriteVia is WriteVia.TypedList or WriteVia.SimpleList)
@@ -550,6 +608,13 @@ namespace StoryCollaborator
                         continue;
                     }
 
+                    // #208: SceneBuilder ScenePurpose uses Fill/Protect. Other SimpleList stays Unclassified.
+                    if (TryClassifySceneBuilderScenePurpose(update, sessionTouched, workflowId, result, kept, display,
+                            ref fillCount, ref refreshCount, ref protectCount, ref noOpCount))
+                    {
+                        continue;
+                    }
+
                     kept.Add(update);
                     display[update.Key] = FormatDisplayValue(update);
                     _logger?.LogInformation(
@@ -574,6 +639,8 @@ namespace StoryCollaborator
 
                 UpdateKind kind;
                 if (string.Equals(current, proposed, StringComparison.OrdinalIgnoreCase))
+                    kind = UpdateKind.NoOp;
+                else if (string.IsNullOrEmpty(proposed) && !string.IsNullOrEmpty(current))
                     kind = UpdateKind.NoOp;
                 else if (string.IsNullOrEmpty(current))
                     kind = UpdateKind.Fill;
@@ -693,12 +760,34 @@ namespace StoryCollaborator
             return 0;
         }
 
-        private static string NormalizeCompareText(string? text)
+        /// <summary>
+        /// Compare as the writer sees the field: strip RTF, fold quotes/dashes/whitespace.
+        /// A→A (same visible words) is NoOp. Do not treat curly apostrophe vs ASCII as a change.
+        /// </summary>
+        internal static string NormalizeCompareText(string? text)
         {
             if (string.IsNullOrWhiteSpace(text))
                 return string.Empty;
-            return text.Trim();
+
+            var s = text.Trim();
+            if (s.StartsWith(@"{\rtf", StringComparison.Ordinal))
+                s = new RichTextStripper().StripRichTextFormat(s) ?? string.Empty;
+
+            s = s
+                .Replace('\u2018', '\'')
+                .Replace('\u2019', '\'')
+                .Replace('\u201C', '"')
+                .Replace('\u201D', '"')
+                .Replace('\u2013', '-')
+                .Replace('\u2014', '-')
+                .Replace('\u00A0', ' ');
+
+            s = WhitespaceRuns.Replace(s, " ");
+            return s.Trim();
         }
+
+        private static readonly System.Text.RegularExpressions.Regex WhitespaceRuns =
+            new(@"\s+", System.Text.RegularExpressions.RegexOptions.Compiled);
 
         private static string FormatDisplayValue(PendingUpdate update)
         {
@@ -901,6 +990,18 @@ namespace StoryCollaborator
                 {
                     case WriteVia.Scalar:
                     {
+                        if (TryDropInvalidSceneBuilderGuid(update, result))
+                            break;
+                        var live = ReadCurrentScalarDisplay(uuid, spec.Property);
+                        var proposed = FormatDisplayValue(update);
+                        var liveN = NormalizeCompareText(live);
+                        var proposedN = NormalizeCompareText(proposed);
+                        if (string.IsNullOrEmpty(proposedN) ||
+                            string.Equals(liveN, proposedN, StringComparison.OrdinalIgnoreCase))
+                        {
+                            result.StatusMessages.Add($"No-op (unchanged on apply): {update.Key}");
+                            break;
+                        }
                         var applyResult = _storyApi.UpdateElementProperty(uuid, spec.Property, update.Value ?? string.Empty);
                         if (applyResult.IsSuccess)
                         {
@@ -1024,8 +1125,44 @@ namespace StoryCollaborator
                 }
             }
 
+            if (string.Equals(workflowModel.Label, "SceneBuilder", StringComparison.Ordinal)
+                && gatheredElements.TryGetValue("Scene", out var sceneEl)
+                && sceneEl != null)
+            {
+                appliedCount += EnsureSceneBuilderSeatsOnCast(sceneEl.Uuid, result);
+            }
+
             _logger?.LogInformation($"Applied {appliedCount} pending updates");
             return appliedCount;
+        }
+
+        /// <summary>
+        /// Collaborator #208: Cast includes Protagonist, Antagonist, and ViewpointCharacter at minimum.
+        /// </summary>
+        internal int EnsureSceneBuilderSeatsOnCast(Guid sceneUuid, WorkflowResult result)
+        {
+            var got = _storyApi.GetStoryElement(sceneUuid);
+            if (!got.IsSuccess || got.Payload is not SceneModel scene)
+                return 0;
+
+            var validChars = new HashSet<Guid>(GetCandidateGuids(StoryItemType.Character));
+            int n = 0;
+            foreach (var seat in new[] { scene.Protagonist, scene.Antagonist, scene.ViewpointCharacter })
+            {
+                if (seat == Guid.Empty || !validChars.Contains(seat))
+                    continue;
+                if (scene.CastMembers != null && scene.CastMembers.Contains(seat))
+                    continue;
+                var add = _storyApi.AddCastMember(sceneUuid, seat);
+                if (add.IsSuccess)
+                    n++;
+                else
+                    result.StatusMessages.Add($"Scene Builder: could not add seat {seat} to Cast.");
+            }
+
+            if (n > 0)
+                result.StatusMessages.Add($"Scene Builder: added {n} seat(s) to Cast.");
+            return n;
         }
 
         private IEnumerable<Guid> GetCandidateGuids(StoryItemType type)
@@ -1085,6 +1222,267 @@ namespace StoryCollaborator
                 return "Set Problem Category before Scenes from Beats.";
             if (string.Equals(problemCategory.Trim(), "Story Problem", StringComparison.Ordinal))
                 return "Use Structure on the story problem; run Scenes from Beats on a complication or other category.";
+            return null;
+        }
+
+        /// <summary>
+        /// Collaborator #208: refuse POST when OwnerState is StoryProblemBail or EmptyCategoryBail.
+        /// Missing Problem map entry is not empty category.
+        /// </summary>
+        internal string? ValidateSceneBuilderOwner(Dictionary<string, StoryElement> gatheredElements)
+        {
+            if (!gatheredElements.TryGetValue("Scene", out var scene) || scene == null)
+                return null;
+
+            var resolved = new SceneStructureNeighborResolver(_storyApi).ResolveForSceneBuilder(scene);
+            if (resolved.OwnerState is SceneStructureNeighborResolver.SceneBuilderOwnerState.StoryProblemBail
+                or SceneStructureNeighborResolver.SceneBuilderOwnerState.EmptyCategoryBail)
+                return resolved.BailReason;
+            return null;
+        }
+
+        private static void CaptureSceneBuilderProposal(string planResult, WorkflowResult result)
+        {
+            var json = ExtractJson(planResult);
+            if (string.IsNullOrEmpty(json))
+                return;
+            try
+            {
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("proposed_owner_guid", out var guidEl)
+                    && guidEl.ValueKind == JsonValueKind.String
+                    && Guid.TryParse(guidEl.GetString(), out var guid)
+                    && guid != Guid.Empty)
+                {
+                    result.ProposedOwnerGuid = guid;
+                }
+                if (root.TryGetProperty("proposed_owner_name", out var nameEl)
+                    && nameEl.ValueKind == JsonValueKind.String)
+                {
+                    result.ProposedOwnerName = nameEl.GetString();
+                }
+            }
+            catch (JsonException)
+            {
+                // analysis-only keys are optional
+            }
+        }
+
+        /// <summary>
+        /// Collaborator #208: on Accept of an orphan, bind the first empty beat when section 5.6 holds.
+        /// Otherwise Fill Notes with a propose line when Notes is empty.
+        /// </summary>
+        internal string? TryApplySceneBuilderOrphanBind(
+            WorkflowResult result,
+            Dictionary<string, StoryElement> gatheredElements)
+        {
+            if (!string.Equals(workflowModel.Label, "SceneBuilder", StringComparison.Ordinal))
+                return null;
+            if (!gatheredElements.TryGetValue("Scene", out var scene) || scene == null)
+                return null;
+
+            var resolver = new SceneStructureNeighborResolver(_storyApi);
+            var owners = resolver.FindStructureOwners(scene.Uuid);
+            var explorerParent = resolver.GetExplorerParentProblem(scene);
+            if (owners.Count > 0 || explorerParent != null)
+                return null;
+
+            var proposed = result.ProposedOwnerGuid;
+            var displayName = string.IsNullOrWhiteSpace(result.ProposedOwnerName)
+                ? proposed?.ToString() ?? string.Empty
+                : result.ProposedOwnerName;
+
+            if (proposed is null || proposed == Guid.Empty)
+                return WriteOrphanProposeNotes(scene, result, "empty GUID", displayName);
+
+            var problems = _storyApi.GetElementsByType(StoryItemType.Problem);
+            ProblemModel? match = null;
+            if (problems.IsSuccess && problems.Payload != null)
+                match = problems.Payload.OfType<ProblemModel>().FirstOrDefault(p => p.Uuid == proposed.Value);
+            if (match == null)
+                return WriteOrphanProposeNotes(scene, result, "GUID not in ProblemChoices", displayName);
+
+            var overviewSp = resolver.GetOverviewStoryProblemUuid();
+            if (resolver.IsStoryProblem(match, overviewSp))
+                return WriteOrphanProposeNotes(scene, result, "proposed owner is Story Problem", displayName);
+
+            var structure = _storyApi.GetProblemStructure(match.Uuid);
+            if (!structure.IsSuccess || structure.Payload.Beats == null)
+                return WriteOrphanProposeNotes(scene, result, "could not read beat sheet", displayName);
+
+            int emptyIndex = -1;
+            int i = 0;
+            foreach (var beat in structure.Payload.Beats)
+            {
+                if (beat.LinkedElement is not Guid linked || linked == Guid.Empty)
+                {
+                    emptyIndex = i;
+                    break;
+                }
+                i++;
+            }
+
+            if (emptyIndex < 0)
+                return WriteOrphanProposeNotes(scene, result, "no empty beat", displayName);
+
+            var assign = _storyApi.AssignElementToBeat(match.Uuid, emptyIndex, scene.Uuid);
+            if (!assign.IsSuccess)
+                return WriteOrphanProposeNotes(scene, result,
+                    assign.ErrorMessage ?? "AssignElementToBeat failed", displayName);
+
+            var msg = $"Scene Builder: assigned Scene to beat {emptyIndex} on {match.Name}.";
+            result.StatusMessages.Add(msg);
+            return msg;
+        }
+
+        private string WriteOrphanProposeNotes(
+            StoryElement scene,
+            WorkflowResult result,
+            string reason,
+            string displayName)
+        {
+            var live = ReadCurrentScalarDisplay(scene.Uuid, "Notes");
+            var line = string.IsNullOrWhiteSpace(displayName)
+                ? $"Proposed owner could not be bound ({reason})."
+                : $"Proposed owner: {displayName} ({reason}).";
+            if (string.IsNullOrEmpty(live))
+            {
+                var write = _storyApi.UpdateElementProperty(scene.Uuid, "Notes", line);
+                var msg = write.IsSuccess
+                    ? $"Scene Builder: could not bind ({reason}); wrote propose line to Notes."
+                    : $"Scene Builder: could not bind ({reason}); Notes write failed.";
+                result.StatusMessages.Add(msg);
+                return msg;
+            }
+
+            var protectedMsg = $"Scene Builder: could not bind ({reason}); Notes unchanged.";
+            result.StatusMessages.Add(protectedMsg);
+            return protectedMsg;
+        }
+
+        private static readonly HashSet<string> SceneBuilderCharacterGuidProperties = new(StringComparer.Ordinal)
+        {
+            "Protagonist", "Antagonist", "ViewpointCharacter"
+        };
+
+        /// <summary>
+        /// Drop seat/Setting GUID updates that do not resolve to Character or Setting.
+        /// Empty GUID is not dropped (Fill vs empty live).
+        /// </summary>
+        private bool TryDropInvalidSceneBuilderGuid(PendingUpdate update, WorkflowResult result)
+        {
+            if (!string.Equals(workflowModel.Label, "SceneBuilder", StringComparison.Ordinal))
+                return false;
+            if (update.Spec.WriteVia != WriteVia.Scalar)
+                return false;
+
+            var property = update.Spec.Property;
+            bool isCharacterSeat = SceneBuilderCharacterGuidProperties.Contains(property);
+            bool isSetting = string.Equals(property, "Setting", StringComparison.Ordinal);
+            if (!isCharacterSeat && !isSetting)
+                return false;
+
+            var text = update.Value?.ToString();
+            if (string.IsNullOrWhiteSpace(text) || !Guid.TryParse(text, out var guid) || guid == Guid.Empty)
+                return false;
+
+            var got = _storyApi.GetStoryElement(guid);
+            if (!got.IsSuccess || got.Payload == null)
+            {
+                result.StatusMessages.Add($"Scene Builder: {property} GUID {guid} not found; dropped.");
+                return true;
+            }
+
+            if (isCharacterSeat && got.Payload is not CharacterModel)
+            {
+                result.StatusMessages.Add($"Scene Builder: {property} is not a Character; dropped.");
+                return true;
+            }
+
+            if (isSetting && got.Payload is not SettingModel)
+            {
+                result.StatusMessages.Add("Scene Builder: Setting is not a Setting; dropped.");
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool TryClassifySceneBuilderScenePurpose(
+            PendingUpdate update,
+            ISet<string> sessionTouched,
+            string workflowId,
+            WorkflowResult result,
+            List<PendingUpdate> kept,
+            Dictionary<string, object> display,
+            ref int fillCount,
+            ref int refreshCount,
+            ref int protectCount,
+            ref int noOpCount)
+        {
+            if (!string.Equals(workflowId, "SceneBuilder", StringComparison.Ordinal))
+                return false;
+            if (update.Spec.WriteVia != WriteVia.SimpleList)
+                return false;
+            if (!string.Equals(update.Spec.Property, "ScenePurpose", StringComparison.Ordinal))
+                return false;
+            if (update.Value is not List<string> proposed)
+                return false;
+
+            var live = ReadCurrentStringList(update.ElementUuid, update.Spec.Property) ?? new List<string>();
+            UpdateKind kind;
+            if (live.Count == 0 && proposed.Count > 0)
+                kind = UpdateKind.Fill;
+            else if (live.SequenceEqual(proposed, StringComparer.Ordinal))
+                kind = UpdateKind.NoOp;
+            else if (sessionTouched.Contains(update.SessionTouchKey))
+                kind = UpdateKind.Refresh;
+            else
+                kind = UpdateKind.Protect;
+
+            _logger?.LogInformation(
+                "Classify {Key} kind={Kind} (SceneBuilder ScenePurpose ordinal)",
+                update.Key, kind);
+
+            if (kind == UpdateKind.NoOp)
+            {
+                noOpCount++;
+                result.StatusMessages.Add($"No-op (unchanged): {update.Key}");
+                return true;
+            }
+
+            switch (kind)
+            {
+                case UpdateKind.Fill: fillCount++; break;
+                case UpdateKind.Refresh: refreshCount++; break;
+                case UpdateKind.Protect: protectCount++; break;
+            }
+
+            var classified = update with
+            {
+                Kind = kind,
+                CurrentDisplay = live.Count == 0 ? string.Empty : $"{live.Count} items"
+            };
+            kept.Add(classified);
+            display[classified.Key] = FormatDisplayValue(classified);
+            result.StatusMessages.Add($"Classified {classified.Key} as {kind}");
+            return true;
+        }
+
+        private List<string>? ReadCurrentStringList(Guid elementUuid, string propertyName)
+        {
+            var got = _storyApi.GetStoryElement(elementUuid);
+            if (!got.IsSuccess || got.Payload == null)
+                return null;
+            var property = got.Payload.GetType().GetProperty(propertyName);
+            if (property == null || !property.CanRead)
+                return null;
+            var value = property.GetValue(got.Payload);
+            if (value is List<string> list)
+                return list;
+            if (value is IEnumerable<string> enumerable)
+                return enumerable.ToList();
             return null;
         }
 

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -23,9 +23,8 @@ namespace StoryCollaborator.Workflows
         /// problem gets a shape, cast has function, scenes happen and scenes have conflict — so
         /// the top band reads as a next action rather than a catalog. Seeded once by
         /// WorkflowStarService; after that the user's choices win.
-        /// Both scene workflows are starred because the user manual's A Path to Try tells writers
-        /// to prefer Scene Summary when running only one; starring Scene Conflict alone would put
-        /// the product at odds with its own craft guidance.
+        /// Scene Summary and Scene Conflict stay starred for A:B. SceneBuilder is also starred
+        /// (#208) after the Worker table entry exists. Cleanup drops the two micro-workflow stars.
         /// </summary>
         public static readonly IReadOnlyList<string> DefaultStarredLabels = new List<string>
         {
@@ -35,7 +34,8 @@ namespace StoryCollaborator.Workflows
             "Structure",
             "StoryFunction",
             "SceneSummary",
-            "SceneConflict"
+            "SceneConflict",
+            "SceneBuilder"
         };
 
         /// <summary>
@@ -756,6 +756,77 @@ namespace StoryCollaborator.Workflows
                 // SettingCreateImage removed; preserved on branch issue-76-image-workflows (issue #76).
 
                 // === Scene Workflows ===
+                // #208: one Scene-primary surface. Five micro-workflows stay registered for A:B.
+                // Required Scene only. Problem / neighbors / contributing Problems are inject-only.
+                new Workflow(
+                    label: "SceneBuilder",
+                    title: "Scene Builder",
+                    description: "Fill an existing Scene: sketch, type, cast, development, conflict, and sequel.",
+                    explanation: "Scene Builder does not create a Scene. Select a Scene first. The run reads contributing Problems and writes Scene fields the model can infer. It does not run on a Story Problem.",
+                    workflowIO: new WorkflowIO
+                    {
+                        RequiredInputs = new List<ElementRequirement>
+                        {
+                            new ElementRequirement
+                            {
+                                ElementType = StoryItemType.Scene,
+                                ElementLabel = "Scene",
+                                RequiredProperties = new List<PropertySpec>(),
+                                CreateIfMissing = false
+                            }
+                        },
+                        OptionalInputs = new List<ElementRequirement>(),
+                        Outputs = new List<ElementOutput>
+                        {
+                            new ElementOutput
+                            {
+                                ElementType = StoryItemType.Scene,
+                                ElementLabel = "Scene",
+                                PropertiesToUpdate = new List<PropertySpec>
+                                {
+                                    new PropertySpec("Description"),
+                                    new PropertySpec("SceneType"),
+                                    new PropertySpec("CastMembers", WriteVia.CastMembers, JsonKey: "cast"),
+                                    new PropertySpec("Protagonist"),
+                                    new PropertySpec("Antagonist"),
+                                    new PropertySpec("ScenePurpose", WriteVia.SimpleList, ListEntryType: typeof(string)),
+                                    new PropertySpec("ValueExchange"),
+                                    new PropertySpec("Events"),
+                                    new PropertySpec("Consequences"),
+                                    new PropertySpec("Significance"),
+                                    new PropertySpec("Realization"),
+                                    new PropertySpec("ProtagGoal"),
+                                    new PropertySpec("Opposition"),
+                                    new PropertySpec("Outcome"),
+                                    new PropertySpec("AntagGoal"),
+                                    new PropertySpec("ProtagEmotion"),
+                                    new PropertySpec("AntagEmotion"),
+                                    new PropertySpec("Emotion"),
+                                    new PropertySpec("Review"),
+                                    new PropertySpec("NewGoal"),
+                                    new PropertySpec("ViewpointCharacter"),
+                                    new PropertySpec("Setting"),
+                                    new PropertySpec("Date"),
+                                    new PropertySpec("Time"),
+                                    new PropertySpec("Notes")
+                                }
+                            }
+                        },
+                        CollectionInputs = new List<CollectionInput>
+                        {
+                            new CollectionInput
+                            {
+                                RequestName = "CharacterChoices",
+                                ElementType = StoryItemType.Character,
+                                Projection = ElementProjection.IdAndName
+                            }
+                        },
+                        ExampleLists = new List<string>
+                        {
+                            "SceneType", "ScenePurpose", "ValueExchange", "Emotion",
+                            "Goal", "Opposition", "Outcome"
+                        }
+                    }) { PrimaryElementType = StoryItemType.Scene },
                 // #174: Scene only on RequiredInputs. Problem / PrecedingScene / NextScene are
                 // inject-only after structure resolve (never OptionalInputs).
                 new Workflow(

--- a/StoryCADTests/Collaborator/SceneBuilderResolverTests.cs
+++ b/StoryCADTests/Collaborator/SceneBuilderResolverTests.cs
@@ -1,0 +1,558 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StoryCADLib.Models;
+using StoryCADLib.Models.Tools;
+using StoryCADLib.Services.API;
+using StoryCADLib.Services.Outline;
+using StoryCADLib.Services.Reports;
+using StoryCADLib.ViewModels;
+using StoryCollaborator;
+using StoryCollaborator.Models;
+using StoryCollaborator.Services;
+using StoryCollaborator.Workflows;
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>Collaborator #208: SceneBuilder owner resolve, bail, and Protect. Real StoryCADApi.</summary>
+[TestClass]
+public class SceneBuilderResolverTests
+{
+    private static StoryCADApi CreateApi() => new(
+        Ioc.Default.GetRequiredService<OutlineService>(),
+        Ioc.Default.GetRequiredService<ListData>(),
+        Ioc.Default.GetRequiredService<ControlData>(),
+        Ioc.Default.GetRequiredService<ToolsData>());
+
+    [TestMethod]
+    public async Task ExplorerParentSubproblem_MiddleScene_HasBothNeighbors()
+    {
+        var api = CreateApi();
+        var fx = await BuildThreeSceneComplication(api);
+        var resolver = new SceneStructureNeighborResolver(api);
+
+        var resolved = resolver.ResolveForSceneBuilder(fx.Middle);
+
+        Assert.AreEqual(
+            SceneStructureNeighborResolver.SceneBuilderOwnerState.ExplorerParentSubproblem,
+            resolved.OwnerState);
+        Assert.AreEqual(fx.Complication.Uuid, resolved.OwnerProblem!.Uuid);
+        Assert.AreEqual(1, resolved.ContributingProblems.Count);
+        Assert.AreEqual(fx.First.Uuid, resolved.PrecedingScene!.Uuid);
+        Assert.AreEqual(fx.Last.Uuid, resolved.NextScene!.Uuid);
+        Assert.IsNull(resolved.BailReason);
+    }
+
+    [TestMethod]
+    public async Task ExplorerParentStoryProblem_BailsEvenWhenComplicationAlsoOwns()
+    {
+        var api = CreateApi();
+        var fx = await BuildThreeSceneComplication(api);
+        // Reparent middle Scene under the Story Problem while leaving it on the Complication sheet.
+        var add = api.AddElement(StoryItemType.Scene, fx.StoryProblem.Uuid.ToString(), "Under Story Problem");
+        Assert.IsTrue(add.IsSuccess);
+        var underSp = (SceneModel)api.GetStoryElement(add.Payload).Payload!;
+        api.AssignElementToBeat(fx.Complication.Uuid, 1, underSp.Uuid);
+
+        var resolved = new SceneStructureNeighborResolver(api).ResolveForSceneBuilder(underSp);
+
+        Assert.AreEqual(SceneStructureNeighborResolver.SceneBuilderOwnerState.StoryProblemBail, resolved.OwnerState);
+        Assert.AreEqual(fx.StoryProblem.Uuid, resolved.OwnerProblem!.Uuid);
+        StringAssert.Contains(resolved.BailReason, "does not run on a Story Problem");
+    }
+
+    [TestMethod]
+    public async Task OnlyStructureOwnerIsStoryProblem_Bails()
+    {
+        var api = CreateApi();
+        await api.CreateEmptyOutline("SP only", "Author", "0");
+        var overview = api.CurrentModel!.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var spAdd = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "Story Problem");
+        var sp = (ProblemModel)api.GetStoryElement(spAdd.Payload).Payload!;
+        api.UpdateElementProperty(sp.Uuid, "ProblemCategory", "Story problem");
+        api.UpdateElementProperty(overview.Uuid, "StoryProblem", sp.Uuid);
+        api.CreateBeat(sp.Uuid, "Beat", "d");
+        var sceneAdd = api.AddElement(StoryItemType.Folder, overview.Uuid.ToString(), "Folder");
+        var folder = api.GetStoryElement(sceneAdd.Payload).Payload!;
+        var scAdd = api.AddElement(StoryItemType.Scene, folder.Uuid.ToString(), "On SP sheet");
+        var scene = api.GetStoryElement(scAdd.Payload).Payload!;
+        api.AssignElementToBeat(sp.Uuid, 0, scene.Uuid);
+
+        var resolved = new SceneStructureNeighborResolver(api).ResolveForSceneBuilder(scene);
+
+        Assert.AreEqual(SceneStructureNeighborResolver.SceneBuilderOwnerState.StoryProblemBail, resolved.OwnerState);
+        Assert.IsNull(resolved.PrecedingScene);
+        Assert.IsNull(resolved.NextScene);
+    }
+
+    [TestMethod]
+    public async Task EmptyCategoryOnChosenOwner_Bails()
+    {
+        var api = CreateApi();
+        await api.CreateEmptyOutline("Empty cat", "Author", "0");
+        var overview = api.CurrentModel!.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var pAdd = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "Uncategorized");
+        var problem = (ProblemModel)api.GetStoryElement(pAdd.Payload).Payload!;
+        api.CreateBeat(problem.Uuid, "Beat", "d");
+        var scAdd = api.AddElement(StoryItemType.Scene, problem.Uuid.ToString(), "Child");
+        var scene = api.GetStoryElement(scAdd.Payload).Payload!;
+        api.AssignElementToBeat(problem.Uuid, 0, scene.Uuid);
+
+        var resolved = new SceneStructureNeighborResolver(api).ResolveForSceneBuilder(scene);
+
+        Assert.AreEqual(SceneStructureNeighborResolver.SceneBuilderOwnerState.EmptyCategoryBail, resolved.OwnerState);
+        Assert.AreEqual(problem.Uuid, resolved.OwnerProblem!.Uuid);
+        StringAssert.Contains(resolved.BailReason, "Problem Category");
+    }
+
+    [TestMethod]
+    public async Task EmptyExplorerParent_UniqueCategorizedContributor_Runs()
+    {
+        var api = CreateApi();
+        await api.CreateEmptyOutline("Fall-through", "Author", "0");
+        var overview = api.CurrentModel!.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var parentAdd = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "Empty parent");
+        var parent = (ProblemModel)api.GetStoryElement(parentAdd.Payload).Payload!;
+        var cAdd = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "Complication");
+        var complication = (ProblemModel)api.GetStoryElement(cAdd.Payload).Payload!;
+        api.UpdateElementProperty(complication.Uuid, "ProblemCategory", "Complication");
+        api.CreateBeat(complication.Uuid, "B1", "d");
+        api.CreateBeat(complication.Uuid, "B2", "d");
+        api.CreateBeat(complication.Uuid, "B3", "d");
+        var firstAdd = api.AddElement(StoryItemType.Scene, parent.Uuid.ToString(), "First");
+        var midAdd = api.AddElement(StoryItemType.Scene, parent.Uuid.ToString(), "Middle");
+        var lastAdd = api.AddElement(StoryItemType.Scene, parent.Uuid.ToString(), "Last");
+        var first = api.GetStoryElement(firstAdd.Payload).Payload!;
+        var middle = api.GetStoryElement(midAdd.Payload).Payload!;
+        var last = api.GetStoryElement(lastAdd.Payload).Payload!;
+        api.AssignElementToBeat(complication.Uuid, 0, first.Uuid);
+        api.AssignElementToBeat(complication.Uuid, 1, middle.Uuid);
+        api.AssignElementToBeat(complication.Uuid, 2, last.Uuid);
+
+        var resolved = new SceneStructureNeighborResolver(api).ResolveForSceneBuilder(middle);
+
+        Assert.AreEqual(SceneStructureNeighborResolver.SceneBuilderOwnerState.UniqueSubproblem, resolved.OwnerState);
+        Assert.AreEqual(complication.Uuid, resolved.OwnerProblem!.Uuid);
+        Assert.AreEqual(first.Uuid, resolved.PrecedingScene!.Uuid);
+        Assert.AreEqual(last.Uuid, resolved.NextScene!.Uuid);
+        Assert.IsNull(resolved.BailReason);
+    }
+
+    [TestMethod]
+    public async Task EmptyExplorerParent_TwoComplications_EmptyCategoryBail()
+    {
+        var api = CreateApi();
+        await api.CreateEmptyOutline("Two comps", "Author", "0");
+        var overview = api.CurrentModel!.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var parentAdd = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "Empty parent");
+        var parent = api.GetStoryElement(parentAdd.Payload).Payload!;
+        var c1Add = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "C1");
+        var c2Add = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "C2");
+        var c1 = (ProblemModel)api.GetStoryElement(c1Add.Payload).Payload!;
+        var c2 = (ProblemModel)api.GetStoryElement(c2Add.Payload).Payload!;
+        api.UpdateElementProperty(c1.Uuid, "ProblemCategory", "Complication");
+        api.UpdateElementProperty(c2.Uuid, "ProblemCategory", "Complication");
+        api.CreateBeat(c1.Uuid, "B", "d");
+        api.CreateBeat(c2.Uuid, "B", "d");
+        var scAdd = api.AddElement(StoryItemType.Scene, parent.Uuid.ToString(), "Shared");
+        var scene = api.GetStoryElement(scAdd.Payload).Payload!;
+        api.AssignElementToBeat(c1.Uuid, 0, scene.Uuid);
+        api.AssignElementToBeat(c2.Uuid, 0, scene.Uuid);
+
+        var resolved = new SceneStructureNeighborResolver(api).ResolveForSceneBuilder(scene);
+
+        Assert.AreEqual(SceneStructureNeighborResolver.SceneBuilderOwnerState.EmptyCategoryBail, resolved.OwnerState);
+        Assert.AreEqual(parent.Uuid, resolved.OwnerProblem!.Uuid);
+        Assert.IsNull(resolved.PrecedingScene);
+    }
+
+    [TestMethod]
+    public async Task MixedCaseStoryProblemCategory_Bails()
+    {
+        var api = CreateApi();
+        await api.CreateEmptyOutline("Mixed case", "Author", "0");
+        var overview = api.CurrentModel!.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var pAdd = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "SP mixed");
+        var problem = (ProblemModel)api.GetStoryElement(pAdd.Payload).Payload!;
+        api.UpdateElementProperty(problem.Uuid, "ProblemCategory", "Story Problem");
+        var scAdd = api.AddElement(StoryItemType.Scene, problem.Uuid.ToString(), "Child");
+        var scene = api.GetStoryElement(scAdd.Payload).Payload!;
+
+        var resolved = new SceneStructureNeighborResolver(api).ResolveForSceneBuilder(scene);
+
+        Assert.AreEqual(SceneStructureNeighborResolver.SceneBuilderOwnerState.StoryProblemBail, resolved.OwnerState);
+    }
+
+    [TestMethod]
+    public async Task FolderParent_TwoComplications_Ambiguous_NoBail()
+    {
+        var api = CreateApi();
+        await api.CreateEmptyOutline("Ambiguous", "Author", "0");
+        var overview = api.CurrentModel!.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var folderAdd = api.AddElement(StoryItemType.Folder, overview.Uuid.ToString(), "Folder");
+        var folder = api.GetStoryElement(folderAdd.Payload).Payload!;
+        var c1Add = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "C1");
+        var c2Add = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "C2");
+        var c1 = (ProblemModel)api.GetStoryElement(c1Add.Payload).Payload!;
+        var c2 = (ProblemModel)api.GetStoryElement(c2Add.Payload).Payload!;
+        api.UpdateElementProperty(c1.Uuid, "ProblemCategory", "Complication");
+        api.UpdateElementProperty(c2.Uuid, "ProblemCategory", "Complication");
+        api.CreateBeat(c1.Uuid, "B", "d");
+        api.CreateBeat(c2.Uuid, "B", "d");
+        var scAdd = api.AddElement(StoryItemType.Scene, folder.Uuid.ToString(), "Shared");
+        var scene = api.GetStoryElement(scAdd.Payload).Payload!;
+        api.AssignElementToBeat(c1.Uuid, 0, scene.Uuid);
+        api.AssignElementToBeat(c2.Uuid, 0, scene.Uuid);
+
+        var resolved = new SceneStructureNeighborResolver(api).ResolveForSceneBuilder(scene);
+
+        Assert.AreEqual(SceneStructureNeighborResolver.SceneBuilderOwnerState.AmbiguousSubproblems, resolved.OwnerState);
+        Assert.IsNull(resolved.OwnerProblem);
+        Assert.AreEqual(2, resolved.ContributingProblems.Count);
+        Assert.IsNull(resolved.PrecedingScene);
+        Assert.IsNull(resolved.BailReason);
+    }
+
+    [TestMethod]
+    public async Task OrphanUnderFolder_OwnerStateNone_NoBail()
+    {
+        var api = CreateApi();
+        await api.CreateEmptyOutline("Orphan", "Author", "0");
+        var overview = api.CurrentModel!.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var folderAdd = api.AddElement(StoryItemType.Folder, overview.Uuid.ToString(), "Folder");
+        var folder = api.GetStoryElement(folderAdd.Payload).Payload!;
+        var scAdd = api.AddElement(StoryItemType.Scene, folder.Uuid.ToString(), "Orphan");
+        var scene = api.GetStoryElement(scAdd.Payload).Payload!;
+
+        var resolved = new SceneStructureNeighborResolver(api).ResolveForSceneBuilder(scene);
+
+        Assert.AreEqual(SceneStructureNeighborResolver.SceneBuilderOwnerState.None, resolved.OwnerState);
+        Assert.IsNull(resolved.OwnerProblem);
+        Assert.AreEqual(0, resolved.ContributingProblems.Count);
+        Assert.IsNull(resolved.BailReason);
+    }
+
+    [TestMethod]
+    public async Task ValidateSceneBuilderOwner_OrphanDoesNotUseBeatScenesEmptyCategoryMessage()
+    {
+        var api = CreateApi();
+        await api.CreateEmptyOutline("Orphan run", "Author", "0");
+        var overview = api.CurrentModel!.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var folderAdd = api.AddElement(StoryItemType.Folder, overview.Uuid.ToString(), "Folder");
+        var folder = api.GetStoryElement(folderAdd.Payload).Payload!;
+        var scAdd = api.AddElement(StoryItemType.Scene, folder.Uuid.ToString(), "Orphan");
+        var scene = api.GetStoryElement(scAdd.Payload).Payload!;
+
+        var runner = new WorkflowRunner(api.CurrentModel!, WorkflowRegistry.Get("SceneBuilder")!, api);
+        var gathered = new Dictionary<string, StoryElement> { ["Scene"] = scene };
+        var gate = runner.ValidateSceneBuilderOwner(gathered);
+
+        Assert.IsNull(gate);
+        Assert.AreNotEqual("Set Problem Category before Scenes from Beats.", gate);
+    }
+
+    [TestMethod]
+    public async Task OrphanAccept_ValidComplication_BindsFirstEmptyBeat()
+    {
+        var api = CreateApi();
+        await api.CreateEmptyOutline("Bind", "Author", "0");
+        var overview = api.CurrentModel!.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var folderAdd = api.AddElement(StoryItemType.Folder, overview.Uuid.ToString(), "Folder");
+        var folder = api.GetStoryElement(folderAdd.Payload).Payload!;
+        var scAdd = api.AddElement(StoryItemType.Scene, folder.Uuid.ToString(), "Orphan");
+        var scene = api.GetStoryElement(scAdd.Payload).Payload!;
+        var cAdd = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "Home");
+        var complication = (ProblemModel)api.GetStoryElement(cAdd.Payload).Payload!;
+        api.UpdateElementProperty(complication.Uuid, "ProblemCategory", "Complication");
+        api.CreateBeat(complication.Uuid, "B1", "d");
+        api.CreateBeat(complication.Uuid, "B2", "d");
+
+        var runner = new WorkflowRunner(api.CurrentModel!, WorkflowRegistry.Get("SceneBuilder")!, api);
+        var result = WorkflowResult.Succeeded();
+        result.ProposedOwnerGuid = complication.Uuid;
+        result.ProposedOwnerName = complication.Name;
+        var gathered = new Dictionary<string, StoryElement> { ["Scene"] = scene };
+
+        var msg = runner.TryApplySceneBuilderOrphanBind(result, gathered);
+
+        Assert.IsNotNull(msg);
+        StringAssert.Contains(msg, "assigned Scene");
+        var structure = api.GetProblemStructure(complication.Uuid);
+        Assert.AreEqual(scene.Uuid, structure.Payload.Beats.First().LinkedElement);
+        Assert.AreEqual(folder.Uuid, scene.Node!.Parent!.Uuid);
+    }
+
+    [TestMethod]
+    public async Task OrphanAccept_StoryProblemGuid_WritesNotesWhenEmpty()
+    {
+        var api = CreateApi();
+        await api.CreateEmptyOutline("SP bind", "Author", "0");
+        var overview = api.CurrentModel!.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var folderAdd = api.AddElement(StoryItemType.Folder, overview.Uuid.ToString(), "Folder");
+        var folder = api.GetStoryElement(folderAdd.Payload).Payload!;
+        var scAdd = api.AddElement(StoryItemType.Scene, folder.Uuid.ToString(), "Orphan");
+        var scene = (SceneModel)api.GetStoryElement(scAdd.Payload).Payload!;
+        var spAdd = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "SP");
+        var sp = (ProblemModel)api.GetStoryElement(spAdd.Payload).Payload!;
+        api.UpdateElementProperty(sp.Uuid, "ProblemCategory", "Story problem");
+        api.UpdateElementProperty(overview.Uuid, "StoryProblem", sp.Uuid);
+        api.CreateBeat(sp.Uuid, "B1", "d");
+
+        var runner = new WorkflowRunner(api.CurrentModel!, WorkflowRegistry.Get("SceneBuilder")!, api);
+        var result = WorkflowResult.Succeeded();
+        result.ProposedOwnerGuid = sp.Uuid;
+        var gathered = new Dictionary<string, StoryElement> { ["Scene"] = scene };
+
+        var msg = runner.TryApplySceneBuilderOrphanBind(result, gathered);
+
+        StringAssert.Contains(msg, "could not bind");
+        var structure = api.GetProblemStructure(sp.Uuid);
+        var linked = structure.Payload.Beats.First().LinkedElement;
+        Assert.IsTrue(linked is not Guid assigned || assigned == Guid.Empty);
+        Assert.IsFalse(string.IsNullOrEmpty(((SceneModel)api.GetStoryElement(scene.Uuid).Payload!).Notes));
+    }
+
+    [TestMethod]
+    public async Task ScenePurpose_LiveListNotTouched_Protect()
+    {
+        var api = CreateApi();
+        var fx = await BuildThreeSceneComplication(api);
+        fx.Middle.ScenePurpose.Add("Reveal");
+        var runner = new WorkflowRunner(api.CurrentModel!, WorkflowRegistry.Get("SceneBuilder")!, api);
+        var pending = new PendingUpdate(
+            "Scene",
+            fx.Middle.Uuid,
+            new PropertySpec("ScenePurpose", WriteVia.SimpleList, ListEntryType: typeof(string)),
+            new List<string> { "Turn" });
+        var result = WorkflowResult.Succeeded();
+        result.PendingUpdates.Add(pending);
+
+        runner.ClassifyScalarUpdates(result, new HashSet<string>(), "SceneBuilder");
+
+        Assert.AreEqual(1, result.PendingUpdates.Count);
+        Assert.AreEqual(UpdateKind.Protect, result.PendingUpdates[0].Kind);
+    }
+
+    [TestMethod]
+    public async Task ScenePurpose_EmptyLive_Fill()
+    {
+        var api = CreateApi();
+        var fx = await BuildThreeSceneComplication(api);
+        var runner = new WorkflowRunner(api.CurrentModel!, WorkflowRegistry.Get("SceneBuilder")!, api);
+        var pending = new PendingUpdate(
+            "Scene",
+            fx.Middle.Uuid,
+            new PropertySpec("ScenePurpose", WriteVia.SimpleList, ListEntryType: typeof(string)),
+            new List<string> { "Reveal" });
+        var result = WorkflowResult.Succeeded();
+        result.PendingUpdates.Add(pending);
+
+        runner.ClassifyScalarUpdates(result, new HashSet<string>(), "SceneBuilder");
+
+        Assert.AreEqual(UpdateKind.Fill, result.PendingUpdates[0].Kind);
+    }
+
+    [TestMethod]
+    public async Task SceneDevelopment_ScenePurpose_StaysUnclassified()
+    {
+        var api = CreateApi();
+        var fx = await BuildThreeSceneComplication(api);
+        fx.Middle.ScenePurpose.Add("Reveal");
+        var runner = new WorkflowRunner(api.CurrentModel!, WorkflowRegistry.Get("SceneDevelopment")!, api);
+        var pending = new PendingUpdate(
+            "Scene",
+            fx.Middle.Uuid,
+            new PropertySpec("ScenePurpose", WriteVia.SimpleList, ListEntryType: typeof(string)),
+            new List<string> { "Turn" });
+        var result = WorkflowResult.Succeeded();
+        result.PendingUpdates.Add(pending);
+
+        runner.ClassifyScalarUpdates(result, new HashSet<string>(), "SceneDevelopment");
+
+        Assert.AreEqual(UpdateKind.Unclassified, result.PendingUpdates[0].Kind);
+    }
+
+    [TestMethod]
+    public void NormalizeCompareText_RtfApostropheAndLineBreak_MatchesPlain()
+    {
+        var rtf = @"{\rtf1\ansi{\fonttbl{\f0 Segoe UI;}}\pard Leonard\rquote s badge-out approach.\par The trap is real.\par}";
+        var plain = "Leonard's badge-out approach. The trap is real.";
+
+        Assert.AreEqual(
+            WorkflowRunner.NormalizeCompareText(plain),
+            WorkflowRunner.NormalizeCompareText(rtf),
+            ignoreCase: true);
+    }
+
+    [TestMethod]
+    public async Task Classify_SameVisibleWordsAsRtfLive_DropsAsNoOp()
+    {
+        var api = CreateApi();
+        var fx = await BuildThreeSceneComplication(api);
+        var rtf = @"{\rtf1\ansi{\fonttbl{\f0 Segoe UI;}}\pard Leonard\rquote s badge-out approach.\par}";
+        api.UpdateElementProperty(fx.Middle.Uuid, "Description", rtf);
+
+        var runner = new WorkflowRunner(api.CurrentModel!, WorkflowRegistry.Get("SceneBuilder")!, api);
+        var result = WorkflowResult.Succeeded();
+        result.PendingUpdates.Add(new PendingUpdate(
+            "Scene",
+            fx.Middle.Uuid,
+            new PropertySpec("Description"),
+            "Leonard's badge-out approach."));
+
+        runner.ClassifyScalarUpdates(result, new HashSet<string>(), "SceneBuilder");
+
+        Assert.AreEqual(0, result.PendingUpdates.Count);
+    }
+
+    [TestMethod]
+    public async Task Classify_EmptyProposedVsFilled_DropsAsNoOp()
+    {
+        var api = CreateApi();
+        var fx = await BuildThreeSceneComplication(api);
+        api.UpdateElementProperty(fx.Middle.Uuid, "Description", "Leonard walks in.");
+
+        var runner = new WorkflowRunner(api.CurrentModel!, WorkflowRegistry.Get("SceneBuilder")!, api);
+        var result = WorkflowResult.Succeeded();
+        result.PendingUpdates.Add(new PendingUpdate(
+            "Scene",
+            fx.Middle.Uuid,
+            new PropertySpec("Description"),
+            string.Empty));
+
+        runner.ClassifyScalarUpdates(result, new HashSet<string>(), "SceneBuilder");
+
+        Assert.AreEqual(0, result.PendingUpdates.Count);
+    }
+
+    [TestMethod]
+    public async Task Classify_ShootoutRtfEcho_DropsAsNoOp()
+    {
+        var api = CreateApi();
+        var fx = await BuildThreeSceneComplication(api);
+        var rtf =
+            @"{\rtf1\ansi{\fonttbl{\f0 Segoe UI;}}\pard Leonard and Tony slowly approach a housing construction site in Fall Creek, a house Charlie Lacas is having built.\par}";
+        api.UpdateElementProperty(fx.Middle.Uuid, "Description", rtf);
+        var echo = new RichTextStripper().StripRichTextFormat(rtf);
+
+        var runner = new WorkflowRunner(api.CurrentModel!, WorkflowRegistry.Get("SceneBuilder")!, api);
+        var result = WorkflowResult.Succeeded();
+        result.PendingUpdates.Add(new PendingUpdate(
+            "Scene",
+            fx.Middle.Uuid,
+            new PropertySpec("Description"),
+            echo));
+
+        runner.ClassifyScalarUpdates(result, new HashSet<string>(), "SceneBuilder");
+
+        Assert.AreEqual(0, result.PendingUpdates.Count);
+    }
+
+    [TestMethod]
+    public async Task Classify_DifferentWords_StaysProtect()
+    {
+        var api = CreateApi();
+        var fx = await BuildThreeSceneComplication(api);
+        api.UpdateElementProperty(fx.Middle.Uuid, "Description", "Leonard walks in.");
+
+        var runner = new WorkflowRunner(api.CurrentModel!, WorkflowRegistry.Get("SceneBuilder")!, api);
+        var result = WorkflowResult.Succeeded();
+        result.PendingUpdates.Add(new PendingUpdate(
+            "Scene",
+            fx.Middle.Uuid,
+            new PropertySpec("Description"),
+            "Leonard rolls up to the site."));
+
+        runner.ClassifyScalarUpdates(result, new HashSet<string>(), "SceneBuilder");
+
+        Assert.AreEqual(1, result.PendingUpdates.Count);
+        Assert.AreEqual(UpdateKind.Protect, result.PendingUpdates[0].Kind);
+    }
+
+    [TestMethod]
+    public async Task ApplySeats_AddsProtagonistAntagonistAndViewpointToCast()
+    {
+        var api = CreateApi();
+        var fx = await BuildThreeSceneComplication(api);
+        var overview = api.CurrentModel!.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var protAdd = api.AddElement(StoryItemType.Character, overview.Uuid.ToString(), "Prot");
+        var antAdd = api.AddElement(StoryItemType.Character, overview.Uuid.ToString(), "Antag");
+        var vpAdd = api.AddElement(StoryItemType.Character, overview.Uuid.ToString(), "VP");
+        var prot = api.GetStoryElement(protAdd.Payload).Payload!;
+        var antag = api.GetStoryElement(antAdd.Payload).Payload!;
+        var vp = api.GetStoryElement(vpAdd.Payload).Payload!;
+
+        var runner = new WorkflowRunner(api.CurrentModel!, WorkflowRegistry.Get("SceneBuilder")!, api);
+        var result = WorkflowResult.Succeeded();
+        result.PendingUpdates.Add(new PendingUpdate("Scene", fx.Middle.Uuid, new PropertySpec("Protagonist"), prot.Uuid.ToString()));
+        result.PendingUpdates.Add(new PendingUpdate("Scene", fx.Middle.Uuid, new PropertySpec("Antagonist"), antag.Uuid.ToString()));
+        result.PendingUpdates.Add(new PendingUpdate("Scene", fx.Middle.Uuid, new PropertySpec("ViewpointCharacter"), vp.Uuid.ToString()));
+        var gathered = new Dictionary<string, StoryElement> { ["Scene"] = fx.Middle };
+
+        runner.ApplyUpdates(result, gathered);
+
+        var scene = (SceneModel)api.GetStoryElement(fx.Middle.Uuid).Payload!;
+        CollectionAssert.Contains(scene.CastMembers, prot.Uuid);
+        CollectionAssert.Contains(scene.CastMembers, antag.Uuid);
+        CollectionAssert.Contains(scene.CastMembers, vp.Uuid);
+    }
+
+    [TestMethod]
+    public async Task InventedProtagonistGuid_Dropped()
+    {
+        var api = CreateApi();
+        var fx = await BuildThreeSceneComplication(api);
+        var runner = new WorkflowRunner(api.CurrentModel!, WorkflowRegistry.Get("SceneBuilder")!, api);
+        var pending = new PendingUpdate(
+            "Scene",
+            fx.Middle.Uuid,
+            new PropertySpec("Protagonist"),
+            Guid.NewGuid().ToString());
+        var result = WorkflowResult.Succeeded();
+        result.PendingUpdates.Add(pending);
+
+        runner.ClassifyScalarUpdates(result, new HashSet<string>(), "SceneBuilder");
+
+        Assert.AreEqual(0, result.PendingUpdates.Count);
+        Assert.IsTrue(result.StatusMessages.Any(m => m.Contains("dropped")));
+    }
+
+    private static async Task<ThreeSceneFixture> BuildThreeSceneComplication(StoryCADApi api)
+    {
+        var create = await api.CreateEmptyOutline("Three scenes", "Author", "0");
+        Assert.IsTrue(create.IsSuccess);
+        var overview = api.CurrentModel!.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var spAdd = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "Story Problem");
+        var sp = (ProblemModel)api.GetStoryElement(spAdd.Payload).Payload!;
+        api.UpdateElementProperty(sp.Uuid, "ProblemCategory", "Story problem");
+        api.UpdateElementProperty(overview.Uuid, "StoryProblem", sp.Uuid);
+
+        var cAdd = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "Complication");
+        var complication = (ProblemModel)api.GetStoryElement(cAdd.Payload).Payload!;
+        api.UpdateElementProperty(complication.Uuid, "ProblemCategory", "Complication");
+        api.CreateBeat(complication.Uuid, "B1", "d");
+        api.CreateBeat(complication.Uuid, "B2", "d");
+        api.CreateBeat(complication.Uuid, "B3", "d");
+
+        var firstAdd = api.AddElement(StoryItemType.Scene, complication.Uuid.ToString(), "First");
+        var midAdd = api.AddElement(StoryItemType.Scene, complication.Uuid.ToString(), "Middle");
+        var lastAdd = api.AddElement(StoryItemType.Scene, complication.Uuid.ToString(), "Last");
+        var first = (SceneModel)api.GetStoryElement(firstAdd.Payload).Payload!;
+        var middle = (SceneModel)api.GetStoryElement(midAdd.Payload).Payload!;
+        var last = (SceneModel)api.GetStoryElement(lastAdd.Payload).Payload!;
+        api.AssignElementToBeat(complication.Uuid, 0, first.Uuid);
+        api.AssignElementToBeat(complication.Uuid, 1, middle.Uuid);
+        api.AssignElementToBeat(complication.Uuid, 2, last.Uuid);
+
+        return new ThreeSceneFixture(sp, complication, first, middle, last);
+    }
+
+    private sealed record ThreeSceneFixture(
+        ProblemModel StoryProblem,
+        ProblemModel Complication,
+        SceneModel First,
+        SceneModel Middle,
+        SceneModel Last);
+}

--- a/StoryCADTests/Collaborator/SceneBuilderWorkflowRegistryTests.cs
+++ b/StoryCADTests/Collaborator/SceneBuilderWorkflowRegistryTests.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StoryCADLib.Models;
+using StoryCollaborator.Models;
+using StoryCollaborator.Workflows;
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>Collaborator #208: SceneBuilder registry shape. Five Scene micro-workflows stay.</summary>
+[TestClass]
+public class SceneBuilderWorkflowRegistryTests
+{
+    [TestMethod]
+    public void SceneBuilder_Registry_IsScenePrimary_WithEmptyOptionalInputs()
+    {
+        var workflow = WorkflowRegistry.Get("SceneBuilder");
+        Assert.IsNotNull(workflow);
+        Assert.AreEqual(StoryItemType.Scene, workflow!.PrimaryElementType);
+
+        var io = workflow.GetIO();
+        var scene = io.RequiredInputs.Single(r => r.ElementLabel == "Scene");
+        Assert.AreEqual(StoryItemType.Scene, scene.ElementType);
+        Assert.IsFalse(scene.CreateIfMissing);
+        Assert.AreEqual(0, io.OptionalInputs.Count);
+
+        var choices = io.CollectionInputs.Single(c => c.RequestName == "CharacterChoices");
+        Assert.AreEqual(StoryItemType.Character, choices.ElementType);
+        Assert.AreEqual(ElementProjection.IdAndName, choices.Projection);
+        Assert.IsFalse(io.CollectionInputs.Any(c => c.RequestName == "ProblemChoices"));
+    }
+
+    [TestMethod]
+    public void SceneBuilder_Outputs_IncludeSceneTypeAndCast_OmitImages()
+    {
+        var io = WorkflowRegistry.Get("SceneBuilder")!.GetIO();
+        var props = io.Outputs.Single(o => o.ElementLabel == "Scene").PropertiesToUpdate;
+        var names = props.Select(p => p.Property).ToHashSet();
+
+        Assert.IsTrue(names.Contains("SceneType"));
+        Assert.IsTrue(names.Contains("CastMembers"));
+        Assert.IsTrue(names.Contains("Description"));
+        Assert.IsTrue(names.Contains("Notes"));
+        Assert.IsFalse(names.Contains("Images"));
+
+        var cast = props.Single(p => p.Property == "CastMembers");
+        Assert.AreEqual(WriteVia.CastMembers, cast.WriteVia);
+        Assert.AreEqual("cast", cast.JsonKey);
+
+        var purpose = props.Single(p => p.Property == "ScenePurpose");
+        Assert.AreEqual(WriteVia.SimpleList, purpose.WriteVia);
+    }
+
+    [TestMethod]
+    public void FiveSceneMicroWorkflows_RemainRegistered()
+    {
+        foreach (var label in new[] { "SceneSummary", "CastSceneRoles", "SceneDevelopment", "SceneConflict", "Sequel" })
+            Assert.IsNotNull(WorkflowRegistry.Get(label), label);
+    }
+
+    [TestMethod]
+    public void SceneSummary_StillDescriptionOnly_EmptyOptionalInputs()
+    {
+        var io = WorkflowRegistry.Get("SceneSummary")!.GetIO();
+        Assert.AreEqual(0, io.OptionalInputs.Count);
+        var props = io.Outputs.Single(o => o.ElementLabel == "Scene").PropertiesToUpdate;
+        Assert.AreEqual("Description", props.Single().Property);
+    }
+
+    [TestMethod]
+    public void DefaultStarredLabels_IncludeSceneBuilder_KeepSceneSummaryAndConflict()
+    {
+        CollectionAssert.Contains(WorkflowRegistry.DefaultStarredLabels.ToList(), "SceneBuilder");
+        CollectionAssert.Contains(WorkflowRegistry.DefaultStarredLabels.ToList(), "SceneSummary");
+        CollectionAssert.Contains(WorkflowRegistry.DefaultStarredLabels.ToList(), "SceneConflict");
+    }
+}

--- a/StoryCADTests/Collaborator/ValueDisplayTests.cs
+++ b/StoryCADTests/Collaborator/ValueDisplayTests.cs
@@ -57,6 +57,26 @@ public class ValueDisplayTests
     }
 
     [TestMethod]
+    public void Format_WithSeatGuidString_ResolvesElementName()
+    {
+        var guid = Guid.Parse("caa640c2-941d-4fa1-b02d-7c1c35e50c22");
+
+        var result = ValueDisplay.Format(guid.ToString("D"), g => g == guid ? "Two ambush gunmen" : null);
+
+        Assert.AreEqual("Two ambush gunmen", result);
+    }
+
+    [TestMethod]
+    public void Format_WithUnresolvedSeatGuidString_FallsBackToGuid()
+    {
+        var guid = Guid.NewGuid();
+
+        var result = ValueDisplay.Format(guid.ToString("D"));
+
+        Assert.AreEqual(guid.ToString("D"), result);
+    }
+
+    [TestMethod]
     public void Format_WithStringList_ReturnsBulletedLines()
     {
         var result = ValueDisplay.Format(new List<string> { "one", "two" });


### PR DESCRIPTION
## What
Adds Scene Builder to CollaboratorLib: registry label SceneBuilder (five Scene menus stay), contributing-Problem gather, Story Problem and empty-category bail, POST SceneBuilder, Fill/Protect, seat GUID names, seats join Cast on Accept.

## Why
Collaborator issue https://github.com/storybuilder-org/Collaborator/issues/208. Worker table already has SceneBuilder (#209). The app had no menu.

## How to test
1. Build StoryCAD Debug x64. Run SceneBuilderWorkflowRegistryTests, SceneBuilderResolverTests, ValueDisplayTests.
2. DEV BUILD, Danger Calls, select Scene Shootout, run Scene Builder against the **dev** Worker.
3. Confirm Story Problem bail if explorer parent is the Story Problem. Confirm Cast includes people the sketch names. Confirm Antagonist is not the partner on the same side.
4. Accept All: free fields write; Has your text needs confirm.

## Linkage
Related to Collaborator #208. Do not close that issue from this PR. Worker prompt follow-up is a separate Collaborator PR.
