### PR TITLE
docs: list Scene Builder for scene craft (#208)

### DIFF
--- a/docs/StoryCAD Collaborator/Workflows_and_Writing_Craft.md
+++ b/docs/StoryCAD Collaborator/Workflows_and_Writing_Craft.md
@@ -30,7 +30,7 @@ StoryCAD’s manual already teaches the craft spine: idea and premise, problems,
 | Outer want vs inner need? | [Defining Problems](../Writing%20with%20StoryCAD/Defining_Problems.html) (outer and inner problems) | Inner and Outer Problems |
 | How is the story shaped? | [Plotting with StoryCAD](../Writing%20with%20StoryCAD/Plotting_with_StoryCAD.html), Overview Structure | Problem Structure |
 | Who is this character? | [Defining Characters](../Writing%20with%20StoryCAD/Defining_Characters.html) | Character Story Function; Flaw and Backstory; Define Character |
-| What happens in this scene? | [Defining Scenes](../Writing%20with%20StoryCAD/Defining_Scenes.html), [Plotting in Scenes](../Writing%20with%20StoryCAD/Plotting_in_Scenes.html) | Scene Summary; Scene Conflict |
+| What happens in this scene? | [Defining Scenes](../Writing%20with%20StoryCAD/Defining_Scenes.html), [Plotting in Scenes](../Writing%20with%20StoryCAD/Plotting_in_Scenes.html) | Scene Builder |
 
 Names on the list may be slightly longer in the app (for example, a full “Ideation…” label). The work is the same: one craft focus per run.
 


### PR DESCRIPTION
## What
Collaborator user manual craft table: ``What happens in this scene?`` now names Scene Builder instead of Scene Summary and Scene Conflict.

## Why
Collaborator #208. Scene Builder is the combined Scene workflow. This section has no per-workflow pages; the table is where workflows are named.

## How to test
Open ``docs/StoryCAD Collaborator/Workflows_and_Writing_Craft.md`` and check the scene row.

## Linkage
Related to Collaborator #208. Does not close it.