### PR TITLE
Fix elmah reporting and block error when server is unreachable

### DIFF
--- a/StoryCAD/App.xaml.cs
+++ b/StoryCAD/App.xaml.cs
@@ -246,7 +246,10 @@ public partial class App : Application
         MainWindow.UseStudio();
 #endif
 
-        if (!Debugger.IsAttached)
+        // Report field errors, not our own debug sessions. Inverted in 4c0360da
+        // (2025-10-16) while fixing elmah on Mac, which turned off reporting for
+        // every real user and forwarded developer sessions instead. Do not flip it.
+        if (Debugger.IsAttached)
         {
             _log.Log(LogLevel.Info, "Bypassing elmah.io as debugger is attached.");
         }

--- a/StoryCADLib/Services/Backend/BackendService.cs
+++ b/StoryCADLib/Services/Backend/BackendService.cs
@@ -62,6 +62,20 @@ public class BackendService
     public IReadOnlyList<UserMessage> UnreadMessages { get; private set; } = Array.Empty<UserMessage>();
 
     /// <summary>
+    ///     True when a MySqlException means "the backend is unreachable" rather than
+    ///     "the backend rejected us": 1042 the server name did not resolve (the driver
+    ///     wraps an ArgumentException, "The host name or IP address is invalid"),
+    ///     2003 the connection was refused, 2013 it was dropped mid-flight.
+    ///
+    ///     These are logged at Warn and retried on the next startup, never at Error.
+    ///     Only Error reaches elmah.io, and an unreachable host recurs on every launch
+    ///     of every affected client — so classifying it as Error turns one dead server
+    ///     into a permanent stream of error reports.
+    /// </summary>
+    private static bool IsBackendUnreachable(MySqlException ex) =>
+        ex.Number is 1042 or 2003 or 2013;
+
+    /// <summary>
     ///     Do any necessary posting to the backend MySQL server on app
     ///     startup. This will include either preferences or versions
     ///     posting that weren't successful during the last run.
@@ -118,7 +132,7 @@ public class BackendService
         {
             _logService.Log(LogLevel.Warn, $"Backend operation cancelled during startup: {ex.Message}");
         }
-        catch (MySqlException ex) when (ex.Number == 2003 || ex.Number == 2013)
+        catch (MySqlException ex) when (IsBackendUnreachable(ex))
         {
             _logService.Log(LogLevel.Warn, $"Backend server temporarily unavailable (Code {ex.Number}): {ex.Message}");
             _logService.Log(LogLevel.Info, "Backend telemetry will retry on next startup");
@@ -245,7 +259,7 @@ public class BackendService
         {
             _logService.Log(LogLevel.Warn, $"Operation cancelled during preferences posting: {ex.Message}");
         }
-        catch (MySqlException ex) when (ex.Number == 2003 || ex.Number == 2013)
+        catch (MySqlException ex) when (IsBackendUnreachable(ex))
         {
             _logService.Log(LogLevel.Warn, $"Transient MySQL error during preferences posting (Code {ex.Number}): {ex.Message}");
         }
@@ -309,7 +323,7 @@ public class BackendService
         {
             _logService.Log(LogLevel.Warn, $"Operation cancelled during version posting: {ex.Message}");
         }
-        catch (MySqlException ex) when (ex.Number == 2003 || ex.Number == 2013)
+        catch (MySqlException ex) when (IsBackendUnreachable(ex))
         {
             _logService.Log(LogLevel.Warn, $"Transient MySQL error during version posting (Code {ex.Number}): {ex.Message}");
         }

--- a/StoryCADTests/Services/Backend/BackendServiceTests.cs
+++ b/StoryCADTests/Services/Backend/BackendServiceTests.cs
@@ -287,6 +287,77 @@ public class BackendTests
 
     #endregion
 
+    #region Backend Unreachable Classification Tests (MySQL 1042)
+
+    /// <summary>
+    ///     MySQL 1042 ("Unable to connect to any of the specified MySQL hosts") is raised
+    ///     when the server name fails to resolve - the inner exception is
+    ///     ArgumentException("The host name or IP address is invalid"). That is the same
+    ///     "backend unreachable" condition as 2003/2013, so it must be logged as a Warning
+    ///     and retried on the next startup, never reported to elmah.io as an Error.
+    ///
+    ///     Regression guard: before this fix 1042 fell through to the generic
+    ///     catch (MySqlException) handler, which calls LogException(LogLevel.Error, ...)
+    ///     and therefore produced elmah Error events on every launch for any client
+    ///     pointed at a retired database host.
+    /// </summary>
+    [TestMethod]
+    public async Task PostPreferences_WithMySqlBadHost_LogsAsWarningNotError()
+    {
+        // Arrange
+        var testLogger = new TestLogService();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var preferenceService = Ioc.Default.GetRequiredService<PreferenceService>();
+        var testSqlIo = new TestMySqlIo();
+        testSqlIo.SetConnectionString("fake");
+        testSqlIo.ExceptionToThrow = CreateMySqlException(1042,
+            "Unable to connect to any of the specified MySQL hosts");
+        var backendService = new BackendService(testLogger, appState, preferenceService, testSqlIo);
+
+        // Act
+        await backendService.PostPreferences(preferenceService.Model);
+
+        // Assert
+        Assert.IsTrue(testLogger.HasWarning("Transient MySQL error during preferences posting"),
+            "1042 should be classified as an unreachable-backend condition, like 2003/2013");
+        Assert.IsTrue(testLogger.HasWarning("Code 1042"),
+            "Should log error code 1042");
+        Assert.AreEqual(0, testLogger.ErrorCount,
+            "1042 must not be logged at Error - Error is what reaches elmah.io");
+    }
+
+    /// <summary>
+    ///     PostVersion mirror of PostPreferences_WithMySqlBadHost_LogsAsWarningNotError.
+    ///     Both posts run back-to-back on startup, so an unresolvable host produced two
+    ///     Error paths per launch before this fix.
+    /// </summary>
+    [TestMethod]
+    public async Task PostVersion_WithMySqlBadHost_LogsAsWarningNotError()
+    {
+        // Arrange
+        var testLogger = new TestLogService();
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var preferenceService = Ioc.Default.GetRequiredService<PreferenceService>();
+        var testSqlIo = new TestMySqlIo();
+        testSqlIo.SetConnectionString("fake");
+        testSqlIo.ExceptionToThrow = CreateMySqlException(1042,
+            "Unable to connect to any of the specified MySQL hosts");
+        var backendService = new BackendService(testLogger, appState, preferenceService, testSqlIo);
+
+        // Act
+        await backendService.PostVersion();
+
+        // Assert
+        Assert.IsTrue(testLogger.HasWarning("Transient MySQL error during version posting"),
+            "1042 should be classified as an unreachable-backend condition, like 2003/2013");
+        Assert.IsTrue(testLogger.HasWarning("Code 1042"),
+            "Should log error code 1042");
+        Assert.AreEqual(0, testLogger.ErrorCount,
+            "1042 must not be logged at Error - Error is what reaches elmah.io");
+    }
+
+    #endregion
+
     #region StartupRecording Exception Handling Tests
 
     /// <summary>
@@ -965,7 +1036,8 @@ public class TestableBackendService : BackendService
         {
             _testLogService.Log(LogLevel.Warn, $"Backend operation cancelled during startup: {ex.Message}");
         }
-        catch (MySqlException ex) when (ex.Number == 2003 || ex.Number == 2013)
+        // Mirrors BackendService.IsBackendUnreachable; keep the two in step.
+        catch (MySqlException ex) when (ex.Number is 1042 or 2003 or 2013)
         {
             _testLogService.Log(LogLevel.Warn, $"Backend server temporarily unavailable (Code {ex.Number}): {ex.Message}");
             _testLogService.Log(LogLevel.Info, "Backend telemetry will retry on next startup");


### PR DESCRIPTION
This PR fixes two issues:

- Fixes elmah reporting being disabled for prod builds and enabled in dev builds but should be the other way around (fixes #1539)
- Blocks transient mysql server errors, we cannot control the users connection (it may be blocked) or the server may be down (fixes #1537)