### PR TITLE
feat(collaborator): ProblemBuilder offers free elements only and shows a per-beat plan (Collaborator #217)

### DIFF
--- a/CollaboratorLib/Models/CollectionInput.cs
+++ b/CollaboratorLib/Models/CollectionInput.cs
@@ -14,4 +14,12 @@ public sealed class CollectionInput
     public StoryItemType ElementType { get; init; }
 
     public ElementProjection Projection { get; init; }
+
+    /// <summary>
+    /// Collaborator #217 rule 5: when set, the label of the gathered element whose sheet these
+    /// candidates are for, and the collection offers only that Problem's free elements (on no
+    /// sheet, not in the trash, not the target, the Story Problem, or an ancestor). Null offers
+    /// every element of the type.
+    /// </summary>
+    public string? FreeElementsFor { get; init; }
 }

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -35,6 +35,43 @@ namespace StoryCollaborator
         public Dictionary<string, JsonObject> Elements { get; init; } = new();
     }
 
+    /// <summary>
+    /// Collaborator #217 rule 5: the elements ProblemBuilder may offer for one Problem's beats.
+    /// </summary>
+    internal sealed record CandidateSet(HashSet<Guid> Scenes, HashSet<Guid> Problems)
+    {
+        public bool Contains(Guid element) => Scenes.Contains(element) || Problems.Contains(element);
+    }
+
+    internal enum BeatRowOutcome
+    {
+        /// <summary>The existing beat at this index is filled; nothing touches it.</summary>
+        Keep,
+        /// <summary>The proposal's GUID is a candidate and binds to this empty beat.</summary>
+        Bind,
+        /// <summary>No bind applies and the proposal names a Scene stub to create.</summary>
+        Create,
+        /// <summary>The proposal's GUID is not a candidate, or was used earlier; stays empty.</summary>
+        Refuse,
+        /// <summary>Neither a bindable GUID nor a scene name; stays empty.</summary>
+        Empty,
+        /// <summary>Past the last beat of a present sheet; not applied.</summary>
+        Drop
+    }
+
+    /// <summary>
+    /// Collaborator #217 section 5.5: one proposal row's outcome, computed before apply.
+    /// InstallsBeat is true when the Problem had no sheet, so the row first creates the beat.
+    /// ElementName carries the bound element's name (Keep, Bind) or the stub's name (Create).
+    /// </summary>
+    internal sealed record BeatRowPlan(
+        int Index,
+        string Title,
+        BeatRowOutcome Outcome,
+        string? ElementName,
+        Guid? ElementGuid,
+        bool InstallsBeat);
+
     internal class WorkflowRunner
     {
         private static HttpClient _httpClient = new() { Timeout = TimeSpan.FromMinutes(3) };
@@ -160,7 +197,7 @@ namespace StoryCollaborator
                 if (workflowIO.ExampleLists.Count > 0)
                     EnrichWithExamples(body.Args);
 
-                ApplyDeclaredInjections(body.Args);
+                ApplyDeclaredInjections(body.Args, gatheredElements);
 
                 // Issue #90 step 8 item 5: the direct-to-OpenAI fallback retired along with
                 // OPENAI_API_KEY on the client. A proxy failure now propagates to the outer
@@ -271,7 +308,28 @@ namespace StoryCollaborator
                 var listResult = _storyApi.GetElementsByType(collection.ElementType);
                 if (!listResult.IsSuccess) continue;
 
-                var projected = (listResult.Payload ?? Enumerable.Empty<StoryElement>())
+                var elements = (listResult.Payload ?? Enumerable.Empty<StoryElement>()).ToList();
+
+                // Collaborator #217 rule 5: a collection declared FreeElementsFor offers only the
+                // candidates for that gathered element's sheet. The same set gates the apply.
+                if (collection.FreeElementsFor != null)
+                {
+                    if (gatheredElements.TryGetValue(collection.FreeElementsFor, out var target) && target != null)
+                    {
+                        var candidates = GetCandidates(target.Uuid);
+                        var total = elements.Count;
+                        elements = elements.Where(e => candidates.Contains(e.Uuid)).ToList();
+                        _logger?.LogInformation("Candidates for {RequestName}: {Count} of {Total}",
+                            collection.RequestName, elements.Count, total);
+                    }
+                    else
+                    {
+                        _logger?.LogWarning("{RequestName}: FreeElementsFor '{Label}' was not gathered; offering every element",
+                            collection.RequestName, collection.FreeElementsFor);
+                    }
+                }
+
+                var projected = elements
                     .Select(e => ProjectCollectionElement(e, collection.Projection))
                     .ToList();
                 body.Args[collection.RequestName] = JsonSerializer.Serialize(projected, serOpts);
@@ -915,7 +973,8 @@ namespace StoryCollaborator
         private static readonly System.Text.RegularExpressions.Regex WhitespaceRuns =
             new(@"\s+", System.Text.RegularExpressions.RegexOptions.Compiled);
 
-        private static string FormatDisplayValue(PendingUpdate update)
+        // Instance since #217: the BeatSheet arm plans the merge against the live structure.
+        private string FormatDisplayValue(PendingUpdate update)
         {
             if (update.Value == null)
                 return string.Empty;
@@ -925,7 +984,7 @@ namespace StoryCollaborator
                 WriteVia.Scalar => update.Value.ToString() ?? string.Empty,
                 WriteVia.SimpleList when update.Value is System.Collections.ICollection c => $"{c.Count} items",
                 WriteVia.BeatSheet when update.Value is List<BeatInfo> beatList =>
-                    FormatBeatSheetDisplay(beatList),
+                    FormatBeatSheetDisplay(update.ElementUuid, beatList),
                 WriteVia.BeatSheet when update.Value is System.Collections.ICollection c => $"{c.Count} beats",
                 WriteVia.CastMembers when update.Value is System.Collections.ICollection c => $"{c.Count} cast members",
                 WriteVia.Relationships when update.Value is System.Collections.ICollection c => $"{c.Count} relationships",
@@ -1391,18 +1450,6 @@ namespace StoryCollaborator
         }
 
         /// <summary>
-        /// #208 handoff: true when this Problem is the Story Problem. Ignore-case by design.
-        /// </summary>
-        private bool IsStoryProblem(Guid problemUuid)
-        {
-            var result = _storyApi.GetStoryElement(problemUuid);
-            if (result?.IsSuccess != true || result.Payload is not ProblemModel problem)
-                return false;
-            return string.Equals(problem.ProblemCategory?.Trim(), "Story problem",
-                StringComparison.OrdinalIgnoreCase);
-        }
-
-        /// <summary>
         /// Collaborator #77: ProblemCategory must be set before ProblemBuilder runs, because it
         /// picks the beat sheet class. ProblemBuilder runs on any Problem, the story problem
         /// included; #211 deleted BeatScenes, whose gate refused it.
@@ -1675,12 +1722,76 @@ namespace StoryCollaborator
             return null;
         }
 
-        private static string FormatBeatSheetDisplay(List<BeatInfo> beats)
+        /// <summary>
+        /// Collaborator #217 section 5.5: the Review pane text for a beats proposal. One summary
+        /// line, then one line per row, rendered from the same plan the apply executes. The
+        /// one-line "9 beats (4 new scenes for empty beats)" it replaces hid which Scene went
+        /// to which beat until after Accept.
+        /// </summary>
+        internal string FormatBeatSheetDisplay(Guid problemUuid, List<BeatInfo> beats)
         {
-            var createCount = beats.Count(b => !string.IsNullOrWhiteSpace(b.SceneName));
-            if (createCount > 0)
-                return $"{beats.Count} beats ({createCount} new scenes for empty beats)";
-            return $"{beats.Count} beats";
+            var plan = PlanBeatSheetMerge(problemUuid, beats);
+            if (plan.Count == 0)
+                return $"{beats.Count} beats";
+
+            int kept = 0, bound = 0, created = 0, empty = 0, refused = 0, dropped = 0;
+            foreach (var row in plan)
+            {
+                switch (row.Outcome)
+                {
+                    case BeatRowOutcome.Keep: kept++; break;
+                    case BeatRowOutcome.Bind: bound++; break;
+                    case BeatRowOutcome.Create: created++; break;
+                    case BeatRowOutcome.Empty: empty++; break;
+                    case BeatRowOutcome.Refuse: refused++; break;
+                    case BeatRowOutcome.Drop: dropped++; break;
+                }
+            }
+
+            // Drop rows start at the sheet's row count, so that count is the rows before them.
+            var sheetRows = plan.Count - dropped;
+            var sb = new System.Text.StringBuilder();
+            sb.Append(plan[0].InstallsBeat ? $"{plan.Count} new beats: " : $"{plan.Count} beats: ");
+            sb.Append($"{kept} kept, {bound} bound, {created} new scenes, {empty} empty");
+            if (refused > 0) sb.Append($", {refused} refused");
+            if (dropped > 0) sb.Append($", {dropped} dropped");
+
+            foreach (var row in plan)
+            {
+                sb.Append('\n').Append(row.Index + 1).Append(". ").Append(row.Title).Append(": ");
+                switch (row.Outcome)
+                {
+                    case BeatRowOutcome.Keep:
+                        sb.Append("keeps ").Append(row.ElementName);
+                        break;
+                    case BeatRowOutcome.Bind:
+                        sb.Append("binds ").Append(row.ElementName)
+                            .Append(" (").Append(ElementTypeNameOf(row.ElementGuid!.Value)).Append(')');
+                        break;
+                    case BeatRowOutcome.Create:
+                        sb.Append("new Scene \"").Append(row.ElementName).Append('"');
+                        break;
+                    case BeatRowOutcome.Refuse:
+                        sb.Append(row.ElementGuid).Append(" is not a candidate, stays empty");
+                        break;
+                    case BeatRowOutcome.Drop:
+                        sb.Append("not applied, sheet has ").Append(sheetRows).Append(" rows");
+                        break;
+                    default:
+                        sb.Append("stays empty");
+                        break;
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private string ElementTypeNameOf(Guid element)
+        {
+            var result = _storyApi.GetStoryElement(element);
+            return result?.IsSuccess == true && result.Payload != null
+                ? result.Payload.ElementType.ToString()
+                : "element";
         }
 
         /// <summary>
@@ -1696,7 +1807,9 @@ namespace StoryCollaborator
         /// capability, not a label test. Extracted so the wiring itself is testable: when this
         /// lived inline in the request path, deleting it left the whole suite green.
         /// </summary>
-        internal void ApplyDeclaredInjections(Dictionary<string, string> args)
+        internal void ApplyDeclaredInjections(
+            Dictionary<string, string> args,
+            Dictionary<string, StoryElement> gatheredElements)
         {
             if (workflowModel.InjectsStockScenes)
                 EnrichWithStockScenes(args);
@@ -1706,6 +1819,65 @@ namespace StoryCollaborator
 
             if (workflowModel.InjectsBeatSheets)
                 EnrichWithBeatSheets(args);
+
+            if (workflowModel.InjectsCurrentBeats)
+            {
+                // The target is the gathered element of the workflow's primary type: the Problem
+                // the writer picked for ProblemBuilder. Absent, the Worker merges the placeholder
+                // to an empty string and the template falls back to the catalog sheet.
+                var target = gatheredElements.Values.FirstOrDefault(
+                    e => e != null && e.ElementType == workflowModel.PrimaryElementType);
+                if (target == null)
+                    _logger?.LogWarning("{Workflow}: no gathered {Type}; CurrentBeats not injected",
+                        workflowModel.Label, workflowModel.PrimaryElementType);
+                else
+                    EnrichWithCurrentBeats(args, target.Uuid);
+            }
+        }
+
+        /// <summary>
+        /// Collaborator #217 section 5.4: the target Problem's sheet as it is now, so the model
+        /// returns its rows (a custom sheet included) and leaves filled beats alone. The exact
+        /// text "none" when the Problem has no sheet.
+        /// </summary>
+        internal void EnrichWithCurrentBeats(Dictionary<string, string> args, Guid targetProblem)
+        {
+            var structure = _storyApi.GetProblemStructure(targetProblem);
+            var beats = structure.IsSuccess
+                ? structure.Payload.Beats?.ToList()
+                    ?? new List<(string BeatTitle, string BeatDescription, Guid? LinkedElement)>()
+                : new List<(string BeatTitle, string BeatDescription, Guid? LinkedElement)>();
+
+            if (!structure.IsSuccess)
+                _logger?.LogWarning("CurrentBeats: cannot load structure for {Problem}", targetProblem);
+
+            if (beats.Count == 0)
+            {
+                args["CurrentBeats"] = "none";
+                _logger?.LogInformation("Injected CurrentBeats (none)");
+                return;
+            }
+
+            var sb = new System.Text.StringBuilder();
+            var title = string.IsNullOrWhiteSpace(structure.Payload.Title) ? "(untitled)" : structure.Payload.Title;
+            sb.Append("Sheet: ").Append(title);
+            for (int i = 0; i < beats.Count; i++)
+            {
+                var beat = beats[i];
+                var bound = beat.LinkedElement.HasValue && beat.LinkedElement.Value != Guid.Empty
+                    ? ElementNameOf(beat.LinkedElement.Value)
+                    : "empty";
+                sb.Append('\n').Append(i + 1).Append(". ").Append(beat.BeatTitle).Append(": ").Append(bound);
+
+                var description = beat.BeatDescription ?? string.Empty;
+                if (description.StartsWith(@"{\rtf", StringComparison.Ordinal))
+                    description = new RichTextStripper().StripRichTextFormat(description) ?? string.Empty;
+                if (!string.IsNullOrWhiteSpace(description))
+                    sb.Append("\n  ").Append(description.Trim());
+            }
+
+            args["CurrentBeats"] = sb.ToString();
+            _logger?.LogInformation("Injected CurrentBeats ({Length} chars)", args["CurrentBeats"].Length);
         }
 
         internal void EnrichWithConflictTaxonomy(Dictionary<string, string> args)
@@ -1816,11 +1988,105 @@ namespace StoryCollaborator
         }
 
         /// <summary>
+        /// Collaborator #217 section 5.5: one outcome per proposal row, computed before apply.
+        /// <see cref="ApplyBeatSheetMerge"/> executes this plan and <see cref="FormatBeatSheetDisplay"/>
+        /// renders it, so the Review pane cannot show a bind the apply then refuses.
+        /// Empty when the Problem's structure cannot be loaded.
+        /// </summary>
+        internal List<BeatRowPlan> PlanBeatSheetMerge(Guid problemUuid, List<BeatInfo> proposed)
+        {
+            var plan = new List<BeatRowPlan>();
+            if (proposed == null || proposed.Count == 0)
+                return plan;
+
+            var existingResult = _storyApi.GetProblemStructure(problemUuid);
+            if (!existingResult.IsSuccess)
+                return plan;
+
+            var existingBeats = existingResult.Payload.Beats?.ToList()
+                ?? new List<(string BeatTitle, string BeatDescription, Guid? LinkedElement)>();
+
+            // Collaborator #217 rule 5: the same set the request offered. A GUID outside it is
+            // refused here whatever the model wrote.
+            var candidates = GetCandidates(problemUuid);
+            bool installs = existingBeats.Count == 0;
+            // Collaborator #77: capability, not label. A new workflow that sets SceneName used
+            // to create nothing because this line tested for the literal label "BeatScenes".
+            bool allowSceneCreate = workflowModel.CreatesScenesForBeats;
+
+            // GUIDs on this sheet already, plus each Bind this plan makes: one placement per sheet.
+            var usedOnSheet = new HashSet<Guid>(
+                existingBeats
+                    .Where(b => b.LinkedElement.HasValue && b.LinkedElement.Value != Guid.Empty)
+                    .Select(b => b.LinkedElement!.Value));
+
+            for (int i = 0; i < proposed.Count; i++)
+            {
+                var beat = proposed[i];
+                var title = string.IsNullOrWhiteSpace(beat.Title) ? $"Beat {i + 1}" : beat.Title.Trim();
+
+                if (!installs && i >= existingBeats.Count)
+                {
+                    // Collaborator #77: a present sheet sets the row count. The row is not applied.
+                    plan.Add(new BeatRowPlan(i, title, BeatRowOutcome.Drop, null, null, false));
+                    continue;
+                }
+
+                if (!installs)
+                {
+                    var current = existingBeats[i];
+                    if (!string.IsNullOrWhiteSpace(current.BeatTitle))
+                        title = current.BeatTitle;
+
+                    if (current.LinkedElement.HasValue && current.LinkedElement.Value != Guid.Empty)
+                    {
+                        // Collaborator #77: a filled beat is the writer's. Nothing touches it.
+                        plan.Add(new BeatRowPlan(i, title, BeatRowOutcome.Keep,
+                            ElementNameOf(current.LinkedElement.Value), current.LinkedElement.Value, false));
+                        continue;
+                    }
+                }
+
+                Guid? assigned = beat.AssignedElement.HasValue && beat.AssignedElement.Value != Guid.Empty
+                    ? beat.AssignedElement
+                    : null;
+
+                // Collaborator #77: an empty beat takes an existing free element before a new Scene.
+                // A proposal may carry both; creating then would leave the real Scene orphaned and
+                // put a duplicate on the sheet.
+                if (assigned.HasValue && candidates.Contains(assigned.Value) && usedOnSheet.Add(assigned.Value))
+                {
+                    plan.Add(new BeatRowPlan(i, title, BeatRowOutcome.Bind,
+                        ElementNameOf(assigned.Value), assigned.Value, installs));
+                    continue;
+                }
+
+                if (allowSceneCreate && !string.IsNullOrWhiteSpace(beat.SceneName))
+                {
+                    plan.Add(new BeatRowPlan(i, title, BeatRowOutcome.Create, beat.SceneName.Trim(), null, installs));
+                    continue;
+                }
+
+                if (assigned.HasValue)
+                {
+                    plan.Add(new BeatRowPlan(i, title, BeatRowOutcome.Refuse, null, assigned.Value, installs));
+                    continue;
+                }
+
+                plan.Add(new BeatRowPlan(i, title, BeatRowOutcome.Empty, null, null, installs));
+            }
+
+            return plan;
+        }
+
+        /// <summary>
         /// Collaborator #167: install or merge beat proposals without clearing filled assignments.
         /// Empty sheet: create proposed beats and assign valid candidates.
         /// Non-empty: fill blank descriptions; assign only empty slots; never reassign.
         /// Collaborator #150: empty slots with SceneName create a Scene under the problem and
         /// assign it, but only for a workflow that declares CreatesScenesForBeats.
+        /// Collaborator #217: executes <see cref="PlanBeatSheetMerge"/> row by row. The Review
+        /// pane rendered that same plan.
         /// </summary>
         internal void ApplyBeatSheetMerge(Guid problemUuid, List<BeatInfo> proposed, WorkflowResult result)
         {
@@ -1829,20 +2095,6 @@ namespace StoryCollaborator
                 result.StatusMessages.Add("BeatSheet: empty proposal; no changes");
                 return;
             }
-
-            var problemGuids = new HashSet<Guid>(GetCandidateGuids(StoryItemType.Problem));
-            var sceneGuids = new HashSet<Guid>(GetCandidateGuids(StoryItemType.Scene));
-
-            // #208 handoff product law: only the Story Problem may hold other Problems on its
-            // beats. A subproblem's beats take Scenes only. Compare ignore-case: the canonical
-            // value is "Story problem", and an Ordinal compare against "Story Problem" silently
-            // never matches. That bug shipped in the BeatScenes gate #211 deleted.
-            var validAssignGuids = IsStoryProblem(problemUuid)
-                ? new HashSet<Guid>(problemGuids.Concat(sceneGuids))
-                : new HashSet<Guid>(sceneGuids);
-            // Collaborator #77: capability, not label. A new workflow that sets SceneName used
-            // to create nothing because this line tested for the literal label "BeatScenes".
-            bool allowSceneCreate = workflowModel.CreatesScenesForBeats;
 
             var existingResult = _storyApi.GetProblemStructure(problemUuid);
             if (!existingResult.IsSuccess)
@@ -1853,164 +2105,214 @@ namespace StoryCollaborator
 
             var existingBeats = existingResult.Payload.Beats?.ToList()
                 ?? new List<(string BeatTitle, string BeatDescription, Guid? LinkedElement)>();
+            var candidates = GetCandidates(problemUuid);
+            var plan = PlanBeatSheetMerge(problemUuid, proposed);
 
-            // GUIDs already assigned on this problem (preserve; block multi-problem on same sheet).
-            var usedOnSheet = new HashSet<Guid>(
-                existingBeats
-                    .Where(b => b.LinkedElement.HasValue && b.LinkedElement.Value != Guid.Empty)
-                    .Select(b => b.LinkedElement!.Value));
-
-            if (existingBeats.Count == 0)
+            foreach (var row in plan)
             {
-                for (int i = 0; i < proposed.Count; i++)
+                var beat = proposed[row.Index];
+
+                if (row.Outcome == BeatRowOutcome.Drop)
                 {
-                    var beat = proposed[i];
-                    var title = string.IsNullOrWhiteSpace(beat.Title) ? $"Beat {i + 1}" : beat.Title.Trim();
-                    var desc = beat.Description?.Trim() ?? string.Empty;
-                    _storyApi.CreateBeat(problemUuid, title, desc);
-                    TryFillEmptyBeat(problemUuid, i, beat, allowSceneCreate, validAssignGuids, problemGuids, usedOnSheet, result);
-                }
-                return;
-            }
-
-            // Collaborator #77: a sheet that is already present is the user's. The chosen sheet
-            // sets the beat count, so do not append rows to it. An empty Problem is handled above.
-
-            int pairCount = Math.Min(existingBeats.Count, proposed.Count);
-            for (int i = 0; i < pairCount; i++)
-            {
-                var current = existingBeats[i];
-                var beat = proposed[i];
-
-                // Collaborator #77: a filled beat is the user's. Do not touch its assignment,
-                // its title, or its description. This test used to sit below the text write,
-                // so a filled beat with a blank description took model text under Accept All.
-                var alreadyFilled = current.LinkedElement.HasValue && current.LinkedElement.Value != Guid.Empty;
-                if (alreadyFilled)
+                    // Collaborator #77: a sheet that is already present is the user's. The chosen
+                    // sheet sets the beat count, so do not append rows to it.
+                    result.StatusMessages.Add(
+                        $"Beat {row.Index}: not applied, sheet has {existingBeats.Count} rows");
                     continue;
-
-                var newTitle = string.IsNullOrWhiteSpace(current.BeatTitle) && !string.IsNullOrWhiteSpace(beat.Title)
-                    ? beat.Title.Trim()
-                    : current.BeatTitle;
-                // Prefer keep filled description; fill blank only.
-                var newDesc = string.IsNullOrWhiteSpace(current.BeatDescription) && !string.IsNullOrWhiteSpace(beat.Description)
-                    ? beat.Description.Trim()
-                    : current.BeatDescription;
-
-                if (!string.Equals(newTitle, current.BeatTitle, StringComparison.Ordinal)
-                    || !string.Equals(newDesc, current.BeatDescription, StringComparison.Ordinal))
-                {
-                    _storyApi.UpdateBeat(problemUuid, i, newTitle ?? string.Empty, newDesc ?? string.Empty);
                 }
 
-                TryFillEmptyBeat(problemUuid, i, beat, allowSceneCreate, validAssignGuids, problemGuids, usedOnSheet, result);
+                if (row.InstallsBeat)
+                {
+                    _storyApi.CreateBeat(problemUuid, row.Title, beat.Description?.Trim() ?? string.Empty);
+                }
+                else
+                {
+                    // Collaborator #77: a filled beat is the user's. Do not touch its assignment,
+                    // its title, or its description. This test used to sit below the text write,
+                    // so a filled beat with a blank description took model text under Accept All.
+                    if (row.Outcome == BeatRowOutcome.Keep)
+                        continue;
+
+                    var current = existingBeats[row.Index];
+                    var newTitle = string.IsNullOrWhiteSpace(current.BeatTitle) && !string.IsNullOrWhiteSpace(beat.Title)
+                        ? beat.Title.Trim()
+                        : current.BeatTitle;
+                    // Prefer keep filled description; fill blank only.
+                    var newDesc = string.IsNullOrWhiteSpace(current.BeatDescription) && !string.IsNullOrWhiteSpace(beat.Description)
+                        ? beat.Description.Trim()
+                        : current.BeatDescription;
+
+                    if (!string.Equals(newTitle, current.BeatTitle, StringComparison.Ordinal)
+                        || !string.Equals(newDesc, current.BeatDescription, StringComparison.Ordinal))
+                    {
+                        _storyApi.UpdateBeat(problemUuid, row.Index, newTitle ?? string.Empty, newDesc ?? string.Empty);
+                    }
+                }
+
+                switch (row.Outcome)
+                {
+                    case BeatRowOutcome.Bind:
+                        AssignBeat(problemUuid, row.Index, row.ElementGuid!.Value, result);
+                        break;
+                    case BeatRowOutcome.Create:
+                        CreateSceneStub(problemUuid, row.Index, beat, result);
+                        break;
+                    case BeatRowOutcome.Refuse:
+                        result.StatusMessages.Add(candidates.Contains(row.ElementGuid!.Value)
+                            ? $"Beat {row.Index} assigned_element {row.ElementGuid} already used on this sheet; left unassigned"
+                            : $"Beat {row.Index} assigned_element {row.ElementGuid} not in candidate set; left unassigned");
+                        break;
+                }
             }
         }
 
         /// <summary>
-        /// Empty beat only: a workflow declaring CreatesScenesForBeats may create a Scene from
-        /// SceneName; otherwise assign GUID.
+        /// Collaborator #150 / #77: create the Scene stub a Create row names, fill the #208
+        /// stub contract, and assign it to the beat.
         /// </summary>
-        private void TryFillEmptyBeat(
-            Guid problemUuid,
-            int beatIndex,
-            BeatInfo beat,
-            bool allowSceneCreate,
-            HashSet<Guid> validAssignGuids,
-            HashSet<Guid> problemGuids,
-            HashSet<Guid> usedOnSheet,
-            WorkflowResult result)
+        private void CreateSceneStub(Guid problemUuid, int beatIndex, BeatInfo beat, WorkflowResult result)
         {
-            // Collaborator #77: an empty beat takes an existing free element before a new Scene.
-            // A proposal may carry both; creating then would leave the real Scene orphaned and
-            // put a duplicate on the sheet.
-            bool canBindProposed = beat.AssignedElement.HasValue
-                && beat.AssignedElement.Value != Guid.Empty
-                && validAssignGuids.Contains(beat.AssignedElement.Value)
-                && !usedOnSheet.Contains(beat.AssignedElement.Value);
-
-            if (allowSceneCreate && !canBindProposed && !string.IsNullOrWhiteSpace(beat.SceneName))
+            var name = beat.SceneName!.Trim();
+            var addResult = _storyApi.AddElement(StoryItemType.Scene, problemUuid.ToString(), name);
+            if (!addResult.IsSuccess)
             {
-                var name = beat.SceneName.Trim();
-                var addResult = _storyApi.AddElement(StoryItemType.Scene, problemUuid.ToString(), name);
-                if (!addResult.IsSuccess)
-                {
-                    result.StatusMessages.Add(
-                        $"Beat {beatIndex} scene create failed: {addResult.ErrorMessage}");
-                    return;
-                }
-
-                var newGuid = addResult.Payload;
-
-                // Collaborator #77 / #208 stub contract: Name, Description, Notes.
-                // Description is the scene summary. Notes carries problem context down to the
-                // scene, including the situation-sheet material that has no Problem property.
-                if (!string.IsNullOrWhiteSpace(beat.SceneDescription))
-                    _storyApi.UpdateElementProperty(newGuid, "Description", beat.SceneDescription.Trim());
-                if (!string.IsNullOrWhiteSpace(beat.SceneNotes))
-                    _storyApi.UpdateElementProperty(newGuid, "Notes", beat.SceneNotes.Trim());
-                if (!string.IsNullOrWhiteSpace(beat.SceneType))
-                    _storyApi.UpdateElementProperty(newGuid, "SceneType", beat.SceneType.Trim());
-
-                // Cast: only names that resolve to a Character. An unresolved name is skipped,
-                // never invented (#208 handoff stub contract).
-                if (beat.SceneCast != null)
-                {
-                    var characterGuids = new HashSet<Guid>(GetCandidateGuids(StoryItemType.Character));
-                    foreach (var castGuid in beat.SceneCast)
-                    {
-                        if (castGuid == Guid.Empty || !characterGuids.Contains(castGuid))
-                        {
-                            result.StatusMessages.Add(
-                                $"Beat {beatIndex} cast member {castGuid} did not resolve; skipped");
-                            continue;
-                        }
-                        _storyApi.AddCastMember(newGuid, castGuid);
-                    }
-                }
-
-                validAssignGuids.Add(newGuid);
-                TryAssignBeat(problemUuid, beatIndex, newGuid, validAssignGuids, problemGuids, usedOnSheet, result);
-                result.StatusMessages.Add($"Beat {beatIndex}: created Scene '{name}' ({newGuid})");
+                result.StatusMessages.Add(
+                    $"Beat {beatIndex} scene create failed: {addResult.ErrorMessage}");
                 return;
             }
 
-            TryAssignBeat(problemUuid, beatIndex, beat.AssignedElement, validAssignGuids, problemGuids, usedOnSheet, result);
+            var newGuid = addResult.Payload;
+
+            // Collaborator #77 / #208 stub contract: Name, Description, Notes.
+            // Description is the scene summary. Notes carries problem context down to the
+            // scene, including the situation-sheet material that has no Problem property.
+            if (!string.IsNullOrWhiteSpace(beat.SceneDescription))
+                _storyApi.UpdateElementProperty(newGuid, "Description", beat.SceneDescription.Trim());
+            if (!string.IsNullOrWhiteSpace(beat.SceneNotes))
+                _storyApi.UpdateElementProperty(newGuid, "Notes", beat.SceneNotes.Trim());
+            if (!string.IsNullOrWhiteSpace(beat.SceneType))
+                _storyApi.UpdateElementProperty(newGuid, "SceneType", beat.SceneType.Trim());
+
+            // Cast: only names that resolve to a Character. An unresolved name is skipped,
+            // never invented (#208 handoff stub contract).
+            if (beat.SceneCast != null)
+            {
+                var characterGuids = new HashSet<Guid>(GetCandidateGuids(StoryItemType.Character));
+                foreach (var castGuid in beat.SceneCast)
+                {
+                    if (castGuid == Guid.Empty || !characterGuids.Contains(castGuid))
+                    {
+                        result.StatusMessages.Add(
+                            $"Beat {beatIndex} cast member {castGuid} did not resolve; skipped");
+                        continue;
+                    }
+                    _storyApi.AddCastMember(newGuid, castGuid);
+                }
+            }
+
+            AssignBeat(problemUuid, beatIndex, newGuid, result);
+            result.StatusMessages.Add($"Beat {beatIndex}: created Scene '{name}' ({newGuid})");
         }
 
-        private void TryAssignBeat(
-            Guid problemUuid,
-            int beatIndex,
-            Guid? assigned,
-            HashSet<Guid> validAssignGuids,
-            HashSet<Guid> problemGuids,
-            HashSet<Guid> usedOnSheet,
-            WorkflowResult result)
+        private void AssignBeat(Guid problemUuid, int beatIndex, Guid element, WorkflowResult result)
         {
-            if (!assigned.HasValue || assigned.Value == Guid.Empty)
-                return;
-
-            if (!validAssignGuids.Contains(assigned.Value))
-            {
-                result.StatusMessages.Add(
-                    $"Beat {beatIndex} assigned_element {assigned.Value} not in candidate set; left unassigned");
-                return;
-            }
-
-            // One problem per beat sheet (and prefer one scene): skip if already used on this sheet.
-            if (usedOnSheet.Contains(assigned.Value))
-            {
-                result.StatusMessages.Add(
-                    $"Beat {beatIndex} assigned_element {assigned.Value} already used on this sheet; left unassigned");
-                return;
-            }
-
-            var assignResult = _storyApi.AssignElementToBeat(problemUuid, beatIndex, assigned.Value);
-            if (assignResult.IsSuccess)
-                usedOnSheet.Add(assigned.Value);
-            else
+            var assignResult = _storyApi.AssignElementToBeat(problemUuid, beatIndex, element);
+            if (!assignResult.IsSuccess)
                 result.StatusMessages.Add(
                     $"Beat {beatIndex} assign failed: {assignResult.ErrorMessage}");
+        }
+
+        /// <summary>
+        /// Collaborator #217 rule 5: the elements ProblemBuilder may offer for the target
+        /// Problem's beats. Free means on no sheet and not in the trash. Rule 2 (a Scene may sit
+        /// on many sheets) still holds by hand on the Structure tab; this run never offers the
+        /// second placement.
+        /// </summary>
+        internal CandidateSet GetCandidates(Guid targetProblem)
+        {
+            var scenes = GetLiveElements(StoryItemType.Scene);
+            var problems = GetLiveElements(StoryItemType.Problem);
+
+            // Placed: bound on a filled beat of any Problem that is not in the trash.
+            var placed = new HashSet<Guid>();
+            foreach (var problem in problems.OfType<ProblemModel>())
+            {
+                if (problem.StructureBeats == null)
+                    continue;
+                foreach (var beat in problem.StructureBeats)
+                {
+                    if (beat.Guid != Guid.Empty)
+                        placed.Add(beat.Guid);
+                }
+            }
+
+            var sceneSet = new HashSet<Guid>(scenes.Select(s => s.Uuid).Where(g => !placed.Contains(g)));
+            var problemSet = new HashSet<Guid>(problems.Select(p => p.Uuid).Where(g => !placed.Contains(g)));
+
+            // Self: OutlineService refuses a Problem on its own beat.
+            problemSet.Remove(targetProblem);
+
+            // Rule 3: the Story Problem is never bound to a beat.
+            var overviewResult = _storyApi.GetElementsByType(StoryItemType.StoryOverview);
+            if (overviewResult.IsSuccess
+                && overviewResult.Payload?.FirstOrDefault() is OverviewModel overview
+                && overview.StoryProblem != Guid.Empty)
+            {
+                problemSet.Remove(overview.StoryProblem);
+            }
+
+            // Rule 4: an ancestor on the target's beat would close a cycle. StoryCAD #1546's
+            // guard has not landed, so a visited set keeps a bad file from hanging this walk.
+            var visited = new HashSet<Guid> { targetProblem };
+            var cursor = ReadBoundStructure(targetProblem);
+            while (cursor != Guid.Empty && visited.Add(cursor))
+            {
+                problemSet.Remove(cursor);
+                cursor = ReadBoundStructure(cursor);
+            }
+
+            return new CandidateSet(sceneSet, problemSet);
+        }
+
+        private Guid ReadBoundStructure(Guid problemUuid)
+        {
+            var result = _storyApi.GetStoryElement(problemUuid);
+            return result?.IsSuccess == true && result.Payload is ProblemModel problem
+                ? problem.BoundStructure
+                : Guid.Empty;
+        }
+
+        /// <summary>Elements of one type that are not in the trash.</summary>
+        private List<StoryElement> GetLiveElements(StoryItemType type)
+        {
+            var result = _storyApi.GetElementsByType(type);
+            if (!result.IsSuccess || result.Payload == null)
+                return new List<StoryElement>();
+            return result.Payload.Where(e => !IsInTrash(e)).ToList();
+        }
+
+        /// <summary>
+        /// Trash: the node chain ends at the TrashCan root, the same test OutlineService makes
+        /// on its delete path. Walked here rather than through StoryNodeItem.RootNodeType so an
+        /// element with no parent node (a test-built one) logs nothing.
+        /// </summary>
+        private static bool IsInTrash(StoryElement element)
+        {
+            var node = element.Node;
+            if (node == null)
+                return false;
+            var guard = 0;
+            while (node.Parent != null && ++guard < 1000)
+                node = node.Parent;
+            return node.Type == StoryItemType.TrashCan;
+        }
+
+        private string ElementNameOf(Guid element)
+        {
+            var result = _storyApi.GetStoryElement(element);
+            return result?.IsSuccess == true && result.Payload != null
+                ? result.Payload.Name
+                : element.ToString();
         }
 
         private static List<JsonElement> ExtractTypedEntries(JsonElement elem)

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -324,8 +324,10 @@ namespace StoryCollaborator
                     }
                     else
                     {
-                        _logger?.LogWarning("{RequestName}: FreeElementsFor '{Label}' was not gathered; offering every element",
+                        // Rule 5 without a target is unsatisfiable; offer nothing rather than everything.
+                        _logger?.LogWarning("{RequestName}: FreeElementsFor '{Label}' was not gathered; offering nothing",
                             collection.RequestName, collection.FreeElementsFor);
+                        elements = new List<StoryElement>();
                     }
                 }
 
@@ -1751,8 +1753,8 @@ namespace StoryCollaborator
             // Drop rows start at the sheet's row count, so that count is the rows before them.
             var sheetRows = plan.Count - dropped;
             var sb = new System.Text.StringBuilder();
-            sb.Append(plan[0].InstallsBeat ? $"{plan.Count} new beats: " : $"{plan.Count} beats: ");
-            sb.Append($"{kept} kept, {bound} bound, {created} new scenes, {empty} empty");
+            sb.Append(plan.Count).Append(plan[0].InstallsBeat ? " new " : " ").Append(Plural(plan.Count, "beat")).Append(": ");
+            sb.Append($"{kept} kept, {bound} bound, {created} new {Plural(created, "scene")}, {empty} empty");
             if (refused > 0) sb.Append($", {refused} refused");
             if (dropped > 0) sb.Append($", {dropped} dropped");
 
@@ -1772,10 +1774,13 @@ namespace StoryCollaborator
                         sb.Append("new Scene \"").Append(row.ElementName).Append('"');
                         break;
                     case BeatRowOutcome.Refuse:
-                        sb.Append(row.ElementGuid).Append(" is not a candidate, stays empty");
+                        if (row.ElementName != null)
+                            sb.Append(row.ElementName).Append(" is already bound on this sheet, stays empty");
+                        else
+                            sb.Append(row.ElementGuid).Append(" is not a candidate, stays empty");
                         break;
                     case BeatRowOutcome.Drop:
-                        sb.Append("not applied, sheet has ").Append(sheetRows).Append(" rows");
+                        sb.Append("not applied, sheet has ").Append(sheetRows).Append(' ').Append(Plural(sheetRows, "row"));
                         break;
                     default:
                         sb.Append("stays empty");
@@ -1785,6 +1790,8 @@ namespace StoryCollaborator
 
             return sb.ToString();
         }
+
+        private static string Plural(int count, string noun) => count == 1 ? noun : noun + "s";
 
         private string ElementTypeNameOf(Guid element)
         {
@@ -1822,34 +1829,35 @@ namespace StoryCollaborator
 
             if (workflowModel.InjectsCurrentBeats)
             {
-                // The target is the gathered element of the workflow's primary type: the Problem
-                // the writer picked for ProblemBuilder. Absent, the Worker merges the placeholder
-                // to an empty string and the template falls back to the catalog sheet.
-                var target = gatheredElements.Values.FirstOrDefault(
-                    e => e != null && e.ElementType == workflowModel.PrimaryElementType);
-                if (target == null)
-                    _logger?.LogWarning("{Workflow}: no gathered {Type}; CurrentBeats not injected",
-                        workflowModel.Label, workflowModel.PrimaryElementType);
-                else
+                // The target is the gathered "Problem", the label the category gate and the
+                // request loop read. Absent, the Worker merges the placeholder to an empty
+                // string and the template falls back to the catalog sheet.
+                if (gatheredElements.TryGetValue("Problem", out var target) && target != null)
                     EnrichWithCurrentBeats(args, target.Uuid);
+                else
+                    _logger?.LogWarning("{Workflow}: no gathered Problem; CurrentBeats not injected",
+                        workflowModel.Label);
             }
         }
 
         /// <summary>
         /// Collaborator #217 section 5.4: the target Problem's sheet as it is now, so the model
         /// returns its rows (a custom sheet included) and leaves filled beats alone. The exact
-        /// text "none" when the Problem has no sheet.
+        /// text "none" when the Problem has no sheet. When the structure cannot be read the arg
+        /// stays unset: "none" would tell the model there is no sheet, while an empty merge
+        /// makes the template fall back to the catalog.
         /// </summary>
         internal void EnrichWithCurrentBeats(Dictionary<string, string> args, Guid targetProblem)
         {
             var structure = _storyApi.GetProblemStructure(targetProblem);
-            var beats = structure.IsSuccess
-                ? structure.Payload.Beats?.ToList()
-                    ?? new List<(string BeatTitle, string BeatDescription, Guid? LinkedElement)>()
-                : new List<(string BeatTitle, string BeatDescription, Guid? LinkedElement)>();
-
             if (!structure.IsSuccess)
-                _logger?.LogWarning("CurrentBeats: cannot load structure for {Problem}", targetProblem);
+            {
+                _logger?.LogWarning("CurrentBeats: cannot load structure for {Problem}; not injected", targetProblem);
+                return;
+            }
+
+            var beats = structure.Payload.Beats?.ToList()
+                ?? new List<(string BeatTitle, string BeatDescription, Guid? LinkedElement)>();
 
             if (beats.Count == 0)
             {
@@ -2054,7 +2062,8 @@ namespace StoryCollaborator
                 // Collaborator #77: an empty beat takes an existing free element before a new Scene.
                 // A proposal may carry both; creating then would leave the real Scene orphaned and
                 // put a duplicate on the sheet.
-                if (assigned.HasValue && candidates.Contains(assigned.Value) && usedOnSheet.Add(assigned.Value))
+                bool isCandidate = assigned.HasValue && candidates.Contains(assigned.Value);
+                if (isCandidate && usedOnSheet.Add(assigned!.Value))
                 {
                     plan.Add(new BeatRowPlan(i, title, BeatRowOutcome.Bind,
                         ElementNameOf(assigned.Value), assigned.Value, installs));
@@ -2069,7 +2078,10 @@ namespace StoryCollaborator
 
                 if (assigned.HasValue)
                 {
-                    plan.Add(new BeatRowPlan(i, title, BeatRowOutcome.Refuse, null, assigned.Value, installs));
+                    // A named Refuse is a candidate an earlier row already bound (a sheet is a
+                    // linear order). An unnamed one is outside the set.
+                    plan.Add(new BeatRowPlan(i, title, BeatRowOutcome.Refuse,
+                        isCandidate ? ElementNameOf(assigned.Value) : null, assigned.Value, installs));
                     continue;
                 }
 
@@ -2105,7 +2117,6 @@ namespace StoryCollaborator
 
             var existingBeats = existingResult.Payload.Beats?.ToList()
                 ?? new List<(string BeatTitle, string BeatDescription, Guid? LinkedElement)>();
-            var candidates = GetCandidates(problemUuid);
             var plan = PlanBeatSheetMerge(problemUuid, proposed);
 
             foreach (var row in plan)
@@ -2158,7 +2169,7 @@ namespace StoryCollaborator
                         CreateSceneStub(problemUuid, row.Index, beat, result);
                         break;
                     case BeatRowOutcome.Refuse:
-                        result.StatusMessages.Add(candidates.Contains(row.ElementGuid!.Value)
+                        result.StatusMessages.Add(row.ElementName != null
                             ? $"Beat {row.Index} assigned_element {row.ElementGuid} already used on this sheet; left unassigned"
                             : $"Beat {row.Index} assigned_element {row.ElementGuid} not in candidate set; left unassigned");
                         break;
@@ -2293,19 +2304,10 @@ namespace StoryCollaborator
 
         /// <summary>
         /// Trash: the node chain ends at the TrashCan root, the same test OutlineService makes
-        /// on its delete path. Walked here rather than through StoryNodeItem.RootNodeType so an
-        /// element with no parent node (a test-built one) logs nothing.
+        /// on its delete path. A deserialized element with no node is not trashed.
         /// </summary>
-        private static bool IsInTrash(StoryElement element)
-        {
-            var node = element.Node;
-            if (node == null)
-                return false;
-            var guard = 0;
-            while (node.Parent != null && ++guard < 1000)
-                node = node.Parent;
-            return node.Type == StoryItemType.TrashCan;
-        }
+        private static bool IsInTrash(StoryElement element) =>
+            element.Node != null && StoryNodeItem.RootNodeType(element.Node) == StoryItemType.TrashCan;
 
         private string ElementNameOf(Guid element)
         {

--- a/CollaboratorLib/Workflows/Workflow.cs
+++ b/CollaboratorLib/Workflows/Workflow.cs
@@ -55,6 +55,13 @@ namespace StoryCollaborator.Workflows
         /// </summary>
         public bool InjectsStockScenes { get; set; }
 
+        /// <summary>
+        /// Collaborator #217: inject the primary element's current beat sheet as CurrentBeats,
+        /// so the model returns that sheet's rows and leaves filled beats alone. "none" when the
+        /// element has no sheet.
+        /// </summary>
+        public bool InjectsCurrentBeats { get; set; }
+
         // Additional properties
         public StoryModel? Model { get; set; }
         public string Plugins { get; set; } = string.Empty;

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -355,7 +355,7 @@ namespace StoryCollaborator.Workflows
                                  "with scenes for its empty beats.",
                     explanation: "One pass over a Problem you selected. It writes the fields a Problem " +
                                  "needs to be usable, chooses a beat sheet that fits the Problem Category " +
-                                 "and Conflict Type, binds scenes you already wrote to empty beats, and " +
+                                 "and Conflict Type, binds free scenes and problems to empty beats, and " +
                                  "creates scene stubs for the rest. It never changes a beat you filled and " +
                                  "never adds beats to a sheet you already chose. Set Problem Category, " +
                                  "Protagonist, and Antagonist before you run it.",
@@ -438,17 +438,20 @@ namespace StoryCollaborator.Workflows
                         },
                         CollectionInputs = new List<CollectionInput>
                         {
+                            // #217 rule 5: free elements for this Problem's sheet only.
                             new CollectionInput
                             {
                                 RequestName = "ProblemChoices",
                                 ElementType = StoryItemType.Problem,
-                                Projection = ElementProjection.BaseStoryElement
+                                Projection = ElementProjection.BaseStoryElement,
+                                FreeElementsFor = "Problem"
                             },
                             new CollectionInput
                             {
                                 RequestName = "SceneChoices",
                                 ElementType = StoryItemType.Scene,
-                                Projection = ElementProjection.BaseStoryElement
+                                Projection = ElementProjection.BaseStoryElement,
+                                FreeElementsFor = "Problem"
                             },
                             // #208 handoff: cast on a created stub, resolved from this set.
                             new CollectionInput
@@ -465,7 +468,8 @@ namespace StoryCollaborator.Workflows
                     RequiresProblemCategory = true,
                     InjectsConflictTaxonomy = true,
                     InjectsBeatSheets = true,
-                    InjectsStockScenes = true
+                    InjectsStockScenes = true,
+                    InjectsCurrentBeats = true
                 },
                 // === Character Workflows ===
                 // #182 DefineCharacter: world identity + personality. Occupation Role lives here.

--- a/StoryCADTests/Collaborator/BeatSheetPlanTests.cs
+++ b/StoryCADTests/Collaborator/BeatSheetPlanTests.cs
@@ -1,0 +1,206 @@
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StoryCADLib.Models;
+using StoryCADLib.Models.Tools;
+using StoryCADLib.Services.API;
+using StoryCADLib.Services.Outline;
+using StoryCADLib.ViewModels;
+using StoryCADLib.ViewModels.Tools;
+using StoryCollaborator;
+using StoryCollaborator.Models;
+using StoryCollaborator.Workflows;
+
+#nullable disable
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>
+///     Collaborator #217 section 5.5. One planner, two consumers: the Review pane renders the
+///     plan and ApplyBeatSheetMerge executes it, so the pane cannot show a bind the apply then
+///     refuses. The old one-line display hid which Scene went to which beat until after Accept.
+/// </summary>
+[TestClass]
+public class BeatSheetPlanTests
+{
+    private static StoryCADApi CreateApi() => new(
+        Ioc.Default.GetRequiredService<OutlineService>(),
+        Ioc.Default.GetRequiredService<ListData>(),
+        Ioc.Default.GetRequiredService<ControlData>(),
+        Ioc.Default.GetRequiredService<ToolsData>());
+
+    private static (StoryModel Model, WorkflowRunner Runner) Arrange()
+    {
+        var model = new StoryModel();
+        var api = CreateApi();
+        api.CurrentModel = model;
+        var workflow = new Workflow("ProblemBuilder", "Problem Builder", "test", StoryItemType.Problem)
+        {
+            CreatesScenesForBeats = true
+        };
+        return (model, new WorkflowRunner(model, workflow, api));
+    }
+
+    /// <summary>
+    ///     A sheet of five beats, the first filled, plus one free Scene and one Scene placed on
+    ///     another Problem. The six-row proposal exercises every outcome in order:
+    ///     Keep, Bind, Create, Refuse, Empty, Drop.
+    /// </summary>
+    private static (ProblemModel Target, SceneModel Kept, SceneModel Free, SceneModel Placed, List<BeatInfo> Proposal)
+        EveryOutcome(StoryModel model)
+    {
+        var target = new ProblemModel("Target", model, null) { StructureTitle = "Save The Cat (Mini)" };
+        var kept = new SceneModel("Kept", model, null);
+        var free = new SceneModel("Free", model, null);
+        var placed = new SceneModel("Placed", model, null);
+        var other = new ProblemModel("Other", model, null);
+        other.StructureBeats.Add(new StructureBeat("Row", "") { Guid = placed.Uuid });
+
+        target.StructureBeats.Add(new StructureBeat("Opening Image", "") { Guid = kept.Uuid });
+        target.StructureBeats.Add(new StructureBeat("Theme Stated", ""));
+        target.StructureBeats.Add(new StructureBeat("Set-Up", ""));
+        target.StructureBeats.Add(new StructureBeat("Catalyst", ""));
+        target.StructureBeats.Add(new StructureBeat("Debate", ""));
+
+        var proposal = new List<BeatInfo>
+        {
+            new("Opening Image", "", AssignedElement: free.Uuid),
+            new("Theme Stated", "", AssignedElement: free.Uuid),
+            new("Set-Up", "", SceneName: "Stub"),
+            new("Catalyst", "", AssignedElement: placed.Uuid),
+            new("Debate", ""),
+            new("Extra", "")
+        };
+        return (target, kept, free, placed, proposal);
+    }
+
+    [TestMethod]
+    public void PlanBeatSheetMerge_EveryOutcome_MatchesWhatApplyDoes()
+    {
+        var (model, runner) = Arrange();
+        var (target, kept, free, placed, proposal) = EveryOutcome(model);
+
+        var plan = runner.PlanBeatSheetMerge(target.Uuid, proposal);
+
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                BeatRowOutcome.Keep, BeatRowOutcome.Bind, BeatRowOutcome.Create,
+                BeatRowOutcome.Refuse, BeatRowOutcome.Empty, BeatRowOutcome.Drop
+            },
+            plan.Select(r => r.Outcome).ToArray());
+        Assert.IsTrue(plan.All(r => !r.InstallsBeat), "a present sheet installs no beat");
+
+        runner.ApplyBeatSheetMerge(target.Uuid, proposal, new WorkflowResult());
+
+        var stub = model.StoryElements.OfType<SceneModel>().Single(s => s.Name == "Stub");
+        Assert.AreEqual(5, target.StructureBeats.Count, "Drop: the sheet did not grow");
+        Assert.AreEqual(kept.Uuid, target.StructureBeats[0].Guid, "Keep: the filled beat is untouched");
+        Assert.AreEqual(free.Uuid, target.StructureBeats[1].Guid, "Bind: the free Scene is bound");
+        Assert.AreEqual(stub.Uuid, target.StructureBeats[2].Guid, "Create: the stub is created and bound");
+        Assert.AreEqual(Guid.Empty, target.StructureBeats[3].Guid, "Refuse: the placed Scene is not bound");
+        Assert.AreEqual(Guid.Empty, target.StructureBeats[4].Guid, "Empty: nothing to bind");
+        Assert.AreEqual(4, model.StoryElements.OfType<SceneModel>().Count(), "one Scene was created, no other");
+        Assert.AreEqual(placed.Uuid, model.StoryElements.OfType<ProblemModel>().Single(p => p.Name == "Other").StructureBeats[0].Guid,
+            "the other sheet keeps its Scene");
+    }
+
+    [TestMethod]
+    public void FormatBeatSheetDisplay_PresentSheet_RendersSummaryAndOneLinePerRow()
+    {
+        var (model, runner) = Arrange();
+        var (target, _, _, placed, proposal) = EveryOutcome(model);
+
+        var text = runner.FormatBeatSheetDisplay(target.Uuid, proposal);
+
+        Assert.AreEqual(
+            "6 beats: 1 kept, 1 bound, 1 new scenes, 1 empty, 1 refused, 1 dropped\n" +
+            "1. Opening Image: keeps Kept\n" +
+            "2. Theme Stated: binds Free (Scene)\n" +
+            "3. Set-Up: new Scene \"Stub\"\n" +
+            $"4. Catalyst: {placed.Uuid} is not a candidate, stays empty\n" +
+            "5. Debate: stays empty\n" +
+            "6. Extra: not applied, sheet has 5 rows",
+            text);
+    }
+
+    [TestMethod]
+    public void FormatBeatSheetDisplay_EmptyProblem_SaysNewBeats()
+    {
+        var (model, runner) = Arrange();
+        var target = new ProblemModel("Fresh", model, null);
+        var free = new ProblemModel("Free problem", model, null);
+        var proposal = new List<BeatInfo>
+        {
+            new("Goal", "what the character wants", AssignedElement: free.Uuid),
+            new("Outcome", "how it lands")
+        };
+
+        var text = runner.FormatBeatSheetDisplay(target.Uuid, proposal);
+
+        Assert.AreEqual(
+            "2 new beats: 0 kept, 1 bound, 0 new scenes, 1 empty\n" +
+            "1. Goal: binds Free problem (Problem)\n" +
+            "2. Outcome: stays empty",
+            text);
+    }
+
+    [TestMethod]
+    public void ApplyBeatSheetMerge_PlacedGuid_IsRefusedWithStatus()
+    {
+        var (model, runner) = Arrange();
+        var target = new ProblemModel("Target", model, null);
+        var other = new ProblemModel("Other", model, null);
+        var placed = new SceneModel("Placed", model, null);
+        other.StructureBeats.Add(new StructureBeat("Row", "") { Guid = placed.Uuid });
+        target.StructureBeats.Add(new StructureBeat("Catalyst", ""));
+        var result = new WorkflowResult();
+
+        runner.ApplyBeatSheetMerge(target.Uuid, new List<BeatInfo> { new("Catalyst", "", AssignedElement: placed.Uuid) }, result);
+
+        Assert.AreEqual(Guid.Empty, target.StructureBeats[0].Guid);
+        Assert.IsTrue(result.StatusMessages.Any(m => m.Contains("not in candidate set")), string.Join(" | ", result.StatusMessages));
+    }
+
+    [TestMethod]
+    public void ApplyBeatSheetMerge_AncestorGuid_IsRefusedAndMakesNoCycle()
+    {
+        var (model, runner) = Arrange();
+        var parent = new ProblemModel("Parent", model, null);
+        var target = new ProblemModel("Target", model, null);
+        parent.StructureBeats.Add(new StructureBeat("Act II", "") { Guid = target.Uuid });
+        target.BoundStructure = parent.Uuid;
+        target.StructureBeats.Add(new StructureBeat("Catalyst", ""));
+        var result = new WorkflowResult();
+
+        runner.ApplyBeatSheetMerge(target.Uuid, new List<BeatInfo> { new("Catalyst", "", AssignedElement: parent.Uuid) }, result);
+
+        Assert.AreEqual(Guid.Empty, target.StructureBeats[0].Guid, "the parent is not bound below itself (rule 4)");
+        Assert.AreEqual(Guid.Empty, parent.BoundStructure, "the parent keeps no sheet parent");
+        Assert.IsTrue(result.StatusMessages.Any(m => m.Contains("not in candidate set")));
+    }
+
+    [TestMethod]
+    public void PlanBeatSheetMerge_SameCandidateTwice_BindsOnceAndRefusesTheSecond()
+    {
+        var (model, runner) = Arrange();
+        var target = new ProblemModel("Target", model, null);
+        var free = new SceneModel("Free", model, null);
+        target.StructureBeats.Add(new StructureBeat("Setup", ""));
+        target.StructureBeats.Add(new StructureBeat("Payoff", ""));
+        var proposal = new List<BeatInfo>
+        {
+            new("Setup", "", AssignedElement: free.Uuid),
+            new("Payoff", "", AssignedElement: free.Uuid)
+        };
+
+        var plan = runner.PlanBeatSheetMerge(target.Uuid, proposal);
+        var result = new WorkflowResult();
+        runner.ApplyBeatSheetMerge(target.Uuid, proposal, result);
+
+        Assert.AreEqual(BeatRowOutcome.Bind, plan[0].Outcome);
+        Assert.AreEqual(BeatRowOutcome.Refuse, plan[1].Outcome, "a sheet is a linear order; one placement per Scene");
+        Assert.AreEqual(free.Uuid, target.StructureBeats[0].Guid);
+        Assert.AreEqual(Guid.Empty, target.StructureBeats[1].Guid);
+        Assert.IsTrue(result.StatusMessages.Any(m => m.Contains("already used on this sheet")));
+    }
+}

--- a/StoryCADTests/Collaborator/BeatSheetPlanTests.cs
+++ b/StoryCADTests/Collaborator/BeatSheetPlanTests.cs
@@ -113,7 +113,7 @@ public class BeatSheetPlanTests
         var text = runner.FormatBeatSheetDisplay(target.Uuid, proposal);
 
         Assert.AreEqual(
-            "6 beats: 1 kept, 1 bound, 1 new scenes, 1 empty, 1 refused, 1 dropped\n" +
+            "6 beats: 1 kept, 1 bound, 1 new scene, 1 empty, 1 refused, 1 dropped\n" +
             "1. Opening Image: keeps Kept\n" +
             "2. Theme Stated: binds Free (Scene)\n" +
             "3. Set-Up: new Scene \"Stub\"\n" +
@@ -167,16 +167,49 @@ public class BeatSheetPlanTests
         var (model, runner) = Arrange();
         var parent = new ProblemModel("Parent", model, null);
         var target = new ProblemModel("Target", model, null);
+        var sibling = new ProblemModel("Free sibling", model, null);
         parent.StructureBeats.Add(new StructureBeat("Act II", "") { Guid = target.Uuid });
         target.BoundStructure = parent.Uuid;
         target.StructureBeats.Add(new StructureBeat("Catalyst", ""));
+        target.StructureBeats.Add(new StructureBeat("Midpoint", ""));
         var result = new WorkflowResult();
 
-        runner.ApplyBeatSheetMerge(target.Uuid, new List<BeatInfo> { new("Catalyst", "", AssignedElement: parent.Uuid) }, result);
+        runner.ApplyBeatSheetMerge(target.Uuid, new List<BeatInfo>
+        {
+            new("Catalyst", "", AssignedElement: parent.Uuid),
+            new("Midpoint", "", AssignedElement: sibling.Uuid)
+        }, result);
 
         Assert.AreEqual(Guid.Empty, target.StructureBeats[0].Guid, "the parent is not bound below itself (rule 4)");
         Assert.AreEqual(Guid.Empty, parent.BoundStructure, "the parent keeps no sheet parent");
+        Assert.AreEqual(sibling.Uuid, target.StructureBeats[1].Guid,
+            "a free Problem outside the chain binds on the same subproblem (rule 3), so the refusal is the ancestor rule, not the old Story-Problem-only branch");
+        Assert.AreEqual(target.Uuid, sibling.BoundStructure);
         Assert.IsTrue(result.StatusMessages.Any(m => m.Contains("not in candidate set")));
+    }
+
+    [TestMethod]
+    public void FormatBeatSheetDisplay_DuplicateCandidate_NamesItAsAlreadyBound()
+    {
+        var (model, runner) = Arrange();
+        var target = new ProblemModel("Target", model, null);
+        var free = new SceneModel("Free", model, null);
+        target.StructureBeats.Add(new StructureBeat("Setup", ""));
+        target.StructureBeats.Add(new StructureBeat("Payoff", ""));
+        var proposal = new List<BeatInfo>
+        {
+            new("Setup", "", AssignedElement: free.Uuid),
+            new("Payoff", "", AssignedElement: free.Uuid)
+        };
+
+        var text = runner.FormatBeatSheetDisplay(target.Uuid, proposal);
+
+        Assert.AreEqual(
+            "2 beats: 0 kept, 1 bound, 0 new scenes, 0 empty, 1 refused\n" +
+            "1. Setup: binds Free (Scene)\n" +
+            "2. Payoff: Free is already bound on this sheet, stays empty",
+            text,
+            "the writer sees the Scene bound by name one line up, so the refusal names it rather than calling it a non-candidate");
     }
 
     [TestMethod]
@@ -199,6 +232,7 @@ public class BeatSheetPlanTests
 
         Assert.AreEqual(BeatRowOutcome.Bind, plan[0].Outcome);
         Assert.AreEqual(BeatRowOutcome.Refuse, plan[1].Outcome, "a sheet is a linear order; one placement per Scene");
+        Assert.AreEqual("Free", plan[1].ElementName, "a refused candidate carries its name; an outside-the-set GUID carries none");
         Assert.AreEqual(free.Uuid, target.StructureBeats[0].Guid);
         Assert.AreEqual(Guid.Empty, target.StructureBeats[1].Guid);
         Assert.IsTrue(result.StatusMessages.Any(m => m.Contains("already used on this sheet")));

--- a/StoryCADTests/Collaborator/CandidateSetTests.cs
+++ b/StoryCADTests/Collaborator/CandidateSetTests.cs
@@ -172,6 +172,18 @@ public class CandidateSetTests
     }
 
     [TestMethod]
+    public void BuildWorkflowRequestBody_FreeElementsForLabelNotGathered_OffersNothing()
+    {
+        var (model, _, runner) = Arrange();
+        new SceneModel("Free", model, null);
+
+        var body = runner.BuildWorkflowRequestBody(new Dictionary<string, StoryElement>());
+
+        Assert.AreEqual(0, OfferedGuids(body, "SceneChoices").Count,
+            "rule 5 without a target is unsatisfiable, so the collection offers nothing rather than everything");
+    }
+
+    [TestMethod]
     public void BuildWorkflowRequestBody_CollectionWithoutFreeElementsFor_OffersEveryElement()
     {
         var model = new StoryModel();

--- a/StoryCADTests/Collaborator/CandidateSetTests.cs
+++ b/StoryCADTests/Collaborator/CandidateSetTests.cs
@@ -1,0 +1,203 @@
+using System.Text.Json;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StoryCADLib.Models;
+using StoryCADLib.Models.Tools;
+using StoryCADLib.Services.API;
+using StoryCADLib.Services.Outline;
+using StoryCADLib.ViewModels;
+using StoryCADLib.ViewModels.Tools;
+using StoryCollaborator;
+using StoryCollaborator.Models;
+using StoryCollaborator.Workflows;
+
+#nullable disable
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>
+///     Collaborator #217 rule 5: ProblemBuilder offers free elements only. Free means on no
+///     sheet and not in the trash. The target, the Story Problem, and the target's ancestors
+///     are never Problem candidates. Rule 2 (a Scene may sit on many sheets) stays a hand
+///     operation on the Structure tab; this run never offers the second placement.
+/// </summary>
+[TestClass]
+public class CandidateSetTests
+{
+    private static StoryCADApi CreateApi() => new(
+        Ioc.Default.GetRequiredService<OutlineService>(),
+        Ioc.Default.GetRequiredService<ListData>(),
+        Ioc.Default.GetRequiredService<ControlData>(),
+        Ioc.Default.GetRequiredService<ToolsData>());
+
+    private static (StoryModel Model, StoryCADApi Api, WorkflowRunner Runner) Arrange()
+    {
+        var model = new StoryModel();
+        var api = CreateApi();
+        api.CurrentModel = model;
+        var workflow = WorkflowRegistry.Get("ProblemBuilder");
+        return (model, api, new WorkflowRunner(model, workflow, api));
+    }
+
+    /// <summary>Bind an element on a new beat of the owner's sheet, the way OutlineService does.</summary>
+    private static void Place(ProblemModel owner, StoryElement element)
+    {
+        owner.StructureBeats.Add(new StructureBeat("Beat", "row") { Guid = element.Uuid });
+        if (element is ProblemModel child)
+            child.BoundStructure = owner.Uuid;
+    }
+
+    private static List<Guid> OfferedGuids(WorkflowProxyBody body, string requestName) =>
+        JsonDocument.Parse(body.Args[requestName]).RootElement
+            .EnumerateArray()
+            .Select(e => Guid.Parse(e.GetProperty("GUID").GetString()))
+            .ToList();
+
+    [TestMethod]
+    public void GetCandidates_SceneInTrash_IsExcluded()
+    {
+        var (model, _, runner) = Arrange();
+        var target = new ProblemModel("Target", model, null);
+        var trash = new TrashCanModel(model, null);
+        var deleted = new SceneModel("Deleted", model, trash.Node);
+        var live = new SceneModel("Live", model, null);
+
+        var candidates = runner.GetCandidates(target.Uuid);
+
+        Assert.IsFalse(candidates.Scenes.Contains(deleted.Uuid), "a Scene under the trash is not offered");
+        Assert.IsTrue(candidates.Scenes.Contains(live.Uuid), "a Scene outside the trash on no sheet is offered");
+    }
+
+    [TestMethod]
+    public void GetCandidates_ScenePlacedOnAnotherProblemsSheet_IsExcluded()
+    {
+        var (model, _, runner) = Arrange();
+        var target = new ProblemModel("Target", model, null);
+        var other = new ProblemModel("Other", model, null);
+        var placed = new SceneModel("Placed", model, null);
+        Place(other, placed);
+
+        var candidates = runner.GetCandidates(target.Uuid);
+
+        Assert.IsFalse(candidates.Scenes.Contains(placed.Uuid),
+            "a Scene on another Problem's sheet is placed; the second placement is a hand operation (rule 2)");
+    }
+
+    [TestMethod]
+    public void GetCandidates_ScenePlacedOnTargetsOwnSheet_IsExcluded()
+    {
+        var (model, _, runner) = Arrange();
+        var target = new ProblemModel("Target", model, null);
+        var placed = new SceneModel("Placed", model, null);
+        Place(target, placed);
+
+        var candidates = runner.GetCandidates(target.Uuid);
+
+        Assert.IsFalse(candidates.Scenes.Contains(placed.Uuid), "a Scene already on this sheet is not offered again");
+    }
+
+    [TestMethod]
+    public void GetCandidates_SelfStoryProblemAndAncestors_AreExcluded()
+    {
+        var (model, _, runner) = Arrange();
+        var overview = new OverviewModel("Overview", model, null);
+        model.ExplorerView.Add(overview.Node);
+        var storyProblem = new ProblemModel("Story problem", model, null) { ProblemCategory = "Story problem" };
+        overview.StoryProblem = storyProblem.Uuid;
+
+        // A holds B, B holds C. A is on no sheet, so only the ancestor walk removes it.
+        var a = new ProblemModel("A", model, null);
+        var b = new ProblemModel("B", model, null);
+        var c = new ProblemModel("C", model, null);
+        var free = new ProblemModel("Free", model, null);
+        Place(a, b);
+        Place(b, c);
+
+        var candidates = runner.GetCandidates(c.Uuid);
+
+        Assert.IsFalse(candidates.Problems.Contains(c.Uuid), "the target is never its own candidate");
+        Assert.IsFalse(candidates.Problems.Contains(storyProblem.Uuid), "the Story Problem is never bound to a beat (rule 3)");
+        Assert.IsFalse(candidates.Problems.Contains(b.Uuid), "B is placed on A's sheet");
+        Assert.IsFalse(candidates.Problems.Contains(a.Uuid), "A on C's beat would close a cycle (rule 4)");
+        Assert.IsTrue(candidates.Problems.Contains(free.Uuid), "a Problem on no sheet outside the chain is offered");
+    }
+
+    [TestMethod]
+    public void GetCandidates_CycleAlreadyInFile_DoesNotHang()
+    {
+        var (model, _, runner) = Arrange();
+        var a = new ProblemModel("A", model, null);
+        var c = new ProblemModel("C", model, null);
+        // A bad file from before the StoryCAD #1546 guard: each names the other as parent.
+        a.BoundStructure = c.Uuid;
+        c.BoundStructure = a.Uuid;
+
+        var candidates = runner.GetCandidates(c.Uuid);
+
+        Assert.IsFalse(candidates.Problems.Contains(a.Uuid), "the walk still removes the ancestor it reached");
+    }
+
+    [TestMethod]
+    public void GetCandidates_FreeSceneAndFreeProblem_AreIncluded()
+    {
+        var (model, _, runner) = Arrange();
+        var target = new ProblemModel("Target", model, null);
+        var scene = new SceneModel("Free scene", model, null);
+        var problem = new ProblemModel("Free problem", model, null);
+
+        var candidates = runner.GetCandidates(target.Uuid);
+
+        Assert.IsTrue(candidates.Scenes.Contains(scene.Uuid));
+        Assert.IsTrue(candidates.Problems.Contains(problem.Uuid));
+        Assert.IsTrue(candidates.Contains(scene.Uuid) && candidates.Contains(problem.Uuid));
+    }
+
+    [TestMethod]
+    public void BuildWorkflowRequestBody_ProblemBuilder_OffersCandidatesOnly()
+    {
+        var (model, _, runner) = Arrange();
+        var target = new ProblemModel("Target", model, null);
+        var other = new ProblemModel("Other", model, null);
+        var placed = new SceneModel("Placed", model, null);
+        var free = new SceneModel("Free", model, null);
+        Place(other, placed);
+
+        var body = runner.BuildWorkflowRequestBody(
+            new Dictionary<string, StoryElement> { ["Problem"] = target });
+
+        CollectionAssert.AreEquivalent(new List<Guid> { free.Uuid }, OfferedGuids(body, "SceneChoices"),
+            "SceneChoices holds the free Scene and nothing else");
+        CollectionAssert.AreEquivalent(new List<Guid> { other.Uuid }, OfferedGuids(body, "ProblemChoices"),
+            "ProblemChoices holds the free Problem; the target is not offered to itself");
+    }
+
+    [TestMethod]
+    public void BuildWorkflowRequestBody_CollectionWithoutFreeElementsFor_OffersEveryElement()
+    {
+        var model = new StoryModel();
+        var api = CreateApi();
+        api.CurrentModel = model;
+        var other = new ProblemModel("Other", model, null);
+        var placed = new SceneModel("Placed", model, null);
+        var free = new SceneModel("Free", model, null);
+        Place(other, placed);
+        var workflow = new Workflow("Plain", "Plain", "t", "t", new WorkflowIO
+        {
+            CollectionInputs = new List<CollectionInput>
+            {
+                new()
+                {
+                    RequestName = "SceneChoices",
+                    ElementType = StoryItemType.Scene,
+                    Projection = ElementProjection.IdAndName
+                }
+            }
+        });
+
+        var body = new WorkflowRunner(model, workflow, api).BuildWorkflowRequestBody(
+            new Dictionary<string, StoryElement>());
+
+        CollectionAssert.AreEquivalent(new List<Guid> { placed.Uuid, free.Uuid }, OfferedGuids(body, "SceneChoices"),
+            "a collection that does not declare FreeElementsFor still gets every element of the type");
+    }
+}

--- a/StoryCADTests/Collaborator/CurrentBeatsInjectionTests.cs
+++ b/StoryCADTests/Collaborator/CurrentBeatsInjectionTests.cs
@@ -1,0 +1,107 @@
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StoryCADLib.Models;
+using StoryCADLib.Models.Tools;
+using StoryCADLib.Services.API;
+using StoryCADLib.Services.Outline;
+using StoryCADLib.ViewModels;
+using StoryCADLib.ViewModels.Tools;
+using StoryCollaborator;
+using StoryCollaborator.Workflows;
+
+#nullable disable
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>
+///     Collaborator #217 section 5.4. The template told the model to keep filled beats and to
+///     return the rows of a sheet the Problem arrived with, and showed it neither. CurrentBeats
+///     is that sheet: "none" without one, else the title and one line per beat with its binding.
+/// </summary>
+[TestClass]
+public class CurrentBeatsInjectionTests
+{
+    private static StoryCADApi CreateApi() => new(
+        Ioc.Default.GetRequiredService<OutlineService>(),
+        Ioc.Default.GetRequiredService<ListData>(),
+        Ioc.Default.GetRequiredService<ControlData>(),
+        Ioc.Default.GetRequiredService<ToolsData>());
+
+    private static (StoryModel Model, WorkflowRunner Runner) Arrange(Workflow workflow = null)
+    {
+        var model = new StoryModel();
+        var api = CreateApi();
+        api.CurrentModel = model;
+        workflow ??= new Workflow("ProblemBuilder", "Problem Builder", "test", StoryItemType.Problem);
+        return (model, new WorkflowRunner(model, workflow, api));
+    }
+
+    [TestMethod]
+    public void EnrichWithCurrentBeats_NoSheet_WritesNone()
+    {
+        var (model, runner) = Arrange();
+        var problem = new ProblemModel("Fresh", model, null);
+        var args = new Dictionary<string, string>();
+
+        runner.EnrichWithCurrentBeats(args, problem.Uuid);
+
+        Assert.AreEqual("none", args["CurrentBeats"], "the template's fallback rule keys on the exact text none");
+    }
+
+    [TestMethod]
+    public void EnrichWithCurrentBeats_Sheet_ListsEachBeatWithItsBinding()
+    {
+        var (model, runner) = Arrange();
+        var problem = new ProblemModel("Subplot", model, null) { StructureTitle = "Save The Cat (Mini)" };
+        var scene = new SceneModel("The lighthouse at dawn", model, null);
+        problem.StructureBeats.Add(new StructureBeat("Opening Image", "") { Guid = scene.Uuid });
+        problem.StructureBeats.Add(new StructureBeat("Catalyst", ""));
+        var args = new Dictionary<string, string>();
+
+        runner.EnrichWithCurrentBeats(args, problem.Uuid);
+
+        Assert.AreEqual(
+            "Sheet: Save The Cat (Mini)\n1. Opening Image: The lighthouse at dawn\n2. Catalyst: empty",
+            args["CurrentBeats"]);
+    }
+
+    [TestMethod]
+    public void EnrichWithCurrentBeats_BeatDescription_FollowsOnAnIndentedLine()
+    {
+        var (model, runner) = Arrange();
+        var problem = new ProblemModel("Subplot", model, null);
+        problem.StructureBeats.Add(new StructureBeat("Catalyst", "the turn"));
+        var args = new Dictionary<string, string>();
+
+        runner.EnrichWithCurrentBeats(args, problem.Uuid);
+
+        Assert.AreEqual("Sheet: (untitled)\n1. Catalyst: empty\n  the turn", args["CurrentBeats"]);
+    }
+
+    [TestMethod]
+    public void ApplyDeclaredInjections_RegisteredProblemBuilder_InjectsCurrentBeatsForTheGatheredProblem()
+    {
+        var registered = WorkflowRegistry.All.Single(w => w.Label == "ProblemBuilder");
+        var (model, runner) = Arrange(registered);
+        var problem = new ProblemModel("Subplot", model, null);
+        var args = new Dictionary<string, string>();
+
+        runner.ApplyDeclaredInjections(args, new Dictionary<string, StoryElement> { ["Problem"] = problem });
+
+        Assert.IsTrue(registered.InjectsCurrentBeats, "ProblemBuilder declares the injection");
+        Assert.AreEqual("none", args["CurrentBeats"]);
+    }
+
+    [TestMethod]
+    public void ApplyDeclaredInjections_NoGatheredProblem_SkipsCurrentBeats()
+    {
+        var registered = WorkflowRegistry.All.Single(w => w.Label == "ProblemBuilder");
+        var (_, runner) = Arrange(registered);
+        var args = new Dictionary<string, string>();
+
+        runner.ApplyDeclaredInjections(args, new Dictionary<string, StoryElement>());
+
+        Assert.IsFalse(args.ContainsKey("CurrentBeats"),
+            "with no target the placeholder merges to empty on the Worker and the template falls back to the catalog");
+    }
+}

--- a/StoryCADTests/Collaborator/DeclaredInjectionWiringTests.cs
+++ b/StoryCADTests/Collaborator/DeclaredInjectionWiringTests.cs
@@ -78,13 +78,23 @@ public class DeclaredInjectionWiringTests
     }
 
     [TestMethod]
-    public void RegisteredProblemBuilder_InjectsAllThree()
+    public void RegisteredProblemBuilder_InjectsAllFour()
     {
         var registered = WorkflowRegistry.All.Single(w => w.Label == "ProblemBuilder");
-        var keys = Inject(registered).Keys.ToList();
+        var model = new StoryModel();
+        var api = CreateApi();
+        api.CurrentModel = model;
+        var problem = new ProblemModel("Under test", model, null);
+        var args = new Dictionary<string, string>();
+
+        // #217: CurrentBeats needs the gathered Problem; the other three do not.
+        new WorkflowRunner(model, registered, api).ApplyDeclaredInjections(
+            args, new Dictionary<string, StoryElement> { ["Problem"] = problem });
+        var keys = args.Keys.ToList();
 
         CollectionAssert.Contains(keys, "ConflictTaxonomy");
         CollectionAssert.Contains(keys, "BeatSheets");
         CollectionAssert.Contains(keys, "StockScenes");
+        CollectionAssert.Contains(keys, "CurrentBeats");
     }
 }

--- a/StoryCADTests/Collaborator/DeclaredInjectionWiringTests.cs
+++ b/StoryCADTests/Collaborator/DeclaredInjectionWiringTests.cs
@@ -32,7 +32,7 @@ public class DeclaredInjectionWiringTests
         var api = CreateApi();
         api.CurrentModel = model;
         var args = new Dictionary<string, string>();
-        new WorkflowRunner(model, workflow, api).ApplyDeclaredInjections(args);
+        new WorkflowRunner(model, workflow, api).ApplyDeclaredInjections(args, new Dictionary<string, StoryElement>());
         return args;
     }
 

--- a/StoryCADTests/Collaborator/HandoffContractTests.cs
+++ b/StoryCADTests/Collaborator/HandoffContractTests.cs
@@ -119,19 +119,4 @@ public class HandoffContractTests
         Assert.AreEqual(other.Uuid, problem.StructureBeats[0].Guid,
             "the Story Problem's beats may hold other Problems");
     }
-
-    [TestMethod]
-    public void StoryProblemCategory_ComparesIgnoringCase()
-    {
-        var (model, problem, runner) = Arrange("story problem");
-        var other = new ProblemModel("A complication", model, null);
-        problem.StructureBeats.Add(new StructureBeat("Act I", "setup"));
-
-        runner.ApplyBeatSheetMerge(problem.Uuid,
-            new List<BeatInfo> { new("Act I", "setup", AssignedElement: other.Uuid) },
-            new WorkflowResult());
-
-        Assert.AreEqual(other.Uuid, problem.StructureBeats[0].Guid,
-            "the handoff requires an ignore-case compare; do not repeat the Ordinal bug");
-    }
 }

--- a/StoryCADTests/Collaborator/HandoffContractTests.cs
+++ b/StoryCADTests/Collaborator/HandoffContractTests.cs
@@ -16,8 +16,8 @@ namespace StoryCADTests.Collaborator;
 
 /// <summary>
 ///     Collaborator #208 handoff, product law for #77:
-///     stub carries SceneType and CastMembers; a subproblem's beats take Scenes only,
-///     the Story Problem's beats may also take Problems.
+///     stub carries SceneType and CastMembers. Collaborator #217 (StoryCAD #1546 rule 4):
+///     any Problem's beats may hold free Scenes and free Problems together.
 /// </summary>
 [TestClass]
 public class HandoffContractTests
@@ -91,7 +91,7 @@ public class HandoffContractTests
     }
 
     [TestMethod]
-    public void SubproblemBeat_RefusesAProblemBinding()
+    public void SubproblemBeat_BindsAFreeProblem()
     {
         var (model, problem, runner) = Arrange("Complication");
         var other = new ProblemModel("Another problem", model, null);
@@ -101,8 +101,8 @@ public class HandoffContractTests
             new List<BeatInfo> { new("Catalyst", "the turn", AssignedElement: other.Uuid) },
             new WorkflowResult());
 
-        Assert.AreEqual(Guid.Empty, problem.StructureBeats[0].Guid,
-            "a subproblem's beats take Scenes only");
+        Assert.AreEqual(other.Uuid, problem.StructureBeats[0].Guid,
+            "#217: a subproblem's beats take free Problems as well as Scenes (StoryCAD #1546 rule 4)");
     }
 
     [TestMethod]

--- a/docs/StoryCAD Collaborator/Tutorial/A_Path_to_Try.md
+++ b/docs/StoryCAD Collaborator/Tutorial/A_Path_to_Try.md
@@ -34,7 +34,7 @@ Treat it as a starting point, not a rule. As you learn which workflows your writ
    Craft: [Defining Problems](../../Writing%20with%20StoryCAD/Defining_Problems.html)
 
 4. **Problem Builder**  
-   Goal, motivation, and conflict for both sides of that problem, then a beat sheet that fits it and scene stubs for the empty beats. Set Problem Category, Protagonist, and Antagonist on the Problem first: Problem Builder reads all three, and a blank category stops the run before it starts.  
+   Goal, motivation, and conflict for both sides of that problem, then a beat sheet that fits it. Scenes and problems you have not yet placed on any beat sheet go on its empty beats, and scene stubs fill the rest. Set Problem Category, Protagonist, and Antagonist on the Problem first: Problem Builder reads all three, and a blank category stops the run before it starts.  
    Craft: [Defining Problems](../../Writing%20with%20StoryCAD/Defining_Problems.html) (GMC), [Plotting with StoryCAD](../../Writing%20with%20StoryCAD/Plotting_with_StoryCAD.html)
 
 5. **Inner and Outer Problems**  

--- a/docs/StoryCAD Collaborator/Tutorial/A_Path_to_Try.md
+++ b/docs/StoryCAD Collaborator/Tutorial/A_Path_to_Try.md
@@ -34,7 +34,7 @@ Treat it as a starting point, not a rule. As you learn which workflows your writ
    Craft: [Defining Problems](../../Writing%20with%20StoryCAD/Defining_Problems.html)
 
 4. **Problem Builder**  
-   Goal, motivation, and conflict for both sides of that problem, then a beat sheet that fits it. Scenes and problems you have not yet placed on any beat sheet go on its empty beats, and scene stubs fill the rest. Set Problem Category, Protagonist, and Antagonist on the Problem first: Problem Builder reads all three, and a blank category stops the run before it starts.  
+   Goal, motivation, and conflict for both sides of that problem, then a beat sheet that fits it. Scenes and Problems that sit on no beat sheet yet fill its empty beats, and scene stubs fill the rest. Set Problem Category, Protagonist, and Antagonist on the Problem first: Problem Builder reads all three, and a blank category stops the run before it starts.  
    Craft: [Defining Problems](../../Writing%20with%20StoryCAD/Defining_Problems.html) (GMC), [Plotting with StoryCAD](../../Writing%20with%20StoryCAD/Plotting_with_StoryCAD.html)
 
 5. **Inner and Outer Problems**  


### PR DESCRIPTION
PR 1 of 2 for storybuilder-org/Collaborator#217. PR 2 is the Worker template change, storybuilder-org/Collaborator#231. Design: the #217 issue body, sections 5.1 to 5.6, 7 and 9.

## What changed

`CollaboratorLib` only, plus one manual line.

- **Candidate set** (`WorkflowRunner.GetCandidates`). ProblemBuilder now offers free elements only: Scenes and Problems on no beat sheet, not in the trash, and for Problems not the target, not the Story Problem, and not an ancestor of the target (walk of `BoundStructure` with a visited set). One function feeds both the request and the apply.
- **Request filter.** `CollectionInput.FreeElementsFor` names the gathered element whose sheet the candidates are for. The registry sets it to `Problem` on ProblemBuilder's `SceneChoices` and `ProblemChoices`; `CharacterChoices` and every other workflow's collections are unchanged. One Info line per filtered collection logs the counts.
- **Apply.** `ApplyBeatSheetMerge` reads the candidate set for every Problem. The Story-Problem-only branch and its `IsStoryProblem` helper are gone (StoryCAD #1546 rule 4: any Problem's beats may hold Problems). A proposal GUID outside the set is refused with the existing status text. Filled beats stay untouched; blank title and description fill on unfilled beats only; a present sheet does not grow; the stub contract (Name, Description, Notes, SceneType, resolved cast) is unchanged.
- **CurrentBeats input.** `Workflow.InjectsCurrentBeats`, set on ProblemBuilder. `EnrichWithCurrentBeats` writes the target's sheet as `Sheet: {title}` then `{n}. {Title}: {bound element name}` or `{n}. {Title}: empty`, description on an indented line, or `none` when the Problem has no sheet. The Worker template (PR 2) reads it as `{{$CurrentBeats}}`; an older Worker merges the unknown arg to nothing.
- **Plan and Review pane.** `PlanBeatSheetMerge` computes one `BeatRowPlan` per proposal row (Keep, Bind, Create, Refuse, Empty, Drop, plus an install flag for a Problem with no sheet). The apply executes the plan and the Review pane renders it, so the pane cannot show a bind the apply then refuses. The beats row in the pane now reads, for example:

  ```
  9 beats: 3 kept, 2 bound, 3 new scenes, 1 empty
  1. Opening Image: keeps The lighthouse at dawn
  2. Theme Stated: binds Lena refuses the pilot job (Scene)
  3. Set-Up: new Scene "Teo counts the fuel drums"
  4. Catalyst: stays empty
  ```

  instead of `9 beats (3 new scenes for empty beats)`.
- **Wording.** Registry `explanation` says "binds free scenes and problems to empty beats". `docs/StoryCAD Collaborator/Tutorial/A_Path_to_Try.md` says the same in the writer's words.

## Why

The #217 quote from the #77 smoke: scene assignments were confusing and poor. The candidate lists held trashed and already-placed elements, the model never saw the current sheet (so a custom sheet paired rows by position onto the wrong beats), the client kept a Story-Problem-only rule the beat tree does not have, and the pane showed one line for the whole beats proposal. This PR fixes all four on the client. Preservation rules are untouched (#215, #216).

## How to test

```
"C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\MSBuild.exe" StoryCAD.sln -t:Build -p:Configuration=Debug -p:Platform=x64
"C:\Program Files\Microsoft Visual Studio\18\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe" StoryCADTests\bin\x64\Debug\net10.0-windows10.0.22621\StoryCADTests.dll /Tests:CandidateSetTests,CurrentBeatsInjectionTests,BeatSheetPlanTests,HandoffContractTests,DeclaredInjectionWiringTests,BeatSheetMergeGuardTests,FreeScenePreferenceTests,SceneStubContractTests
```

New test classes: `CandidateSetTests`, `CurrentBeatsInjectionTests`, `BeatSheetPlanTests`. `HandoffContractTests.SubproblemBeat_RefusesAProblemBinding` is inverted to `SubproblemBeat_BindsAFreeProblem`. Both heads build (Debug x64, zero errors).

| Run | Result |
|-----|--------|
| Eight Collaborator classes above | 40 passed, 0 failed |
| Full suite (`vstest.console.exe`, Windows head) | 1528 total, 1513 passed, 0 failed, 15 skipped (pre-existing gated integration tests) |

By hand, after PR 2 deploys to the dev Worker: run Problem Builder on a subproblem with a partly filled sheet, a trashed Scene, and a free Problem. The pane shows one line per beat; the trashed Scene and the placed Scenes are never bound.

Refs storybuilder-org/Collaborator#217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eWUufU7sGmwotbdr9ML93
