### PR TITLE
fix(shell): File Open menu no longer stats every backup on open (#1548)

### DIFF
--- a/StoryCADLib/Services/Dialogs/FileOpenMenu.xaml.cs
+++ b/StoryCADLib/Services/Dialogs/FileOpenMenu.xaml.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace StoryCADLib.Services.Dialogs;
 
 /// <summary>
@@ -5,11 +7,20 @@ namespace StoryCADLib.Services.Dialogs;
 /// </summary>
 public sealed partial class FileOpenMenuPage : Page
 {
+    /// <summary>
+    ///     Newest backups the Backups tab lists. This constructor runs on the UI thread
+    ///     before the dialog shows, and it builds a StackPanel per entry; a backup folder
+    ///     on a cloud drive held 5,219 zips on 2026-09-04 and the menu took 5 s to appear.
+    ///     Older backups stay on disk; the tab shows the ones a writer would restore.
+    /// </summary>
+    private const int MaxBackupsListed = 100;
+
     public FileOpenVM FileOpenVM = Ioc.Default.GetRequiredService<FileOpenVM>();
 
     public FileOpenMenuPage()
     {
-         InitializeComponent();
+        var stopwatch = Stopwatch.StartNew();
+        InitializeComponent();
         FileOpenVM.RecentsTabContentVisibility = Visibility.Collapsed;
         FileOpenVM.SamplesTabContentVisibility = Visibility.Collapsed;
         FileOpenVM.BackupTabContentVisibility = Visibility.Collapsed;
@@ -51,11 +62,15 @@ public sealed partial class FileOpenMenuPage : Page
             FileOpenVM.RecentsUI.Add(item);
         }
 
-        // Get files from the backup directory in order of creation.
+        // Get the newest backups from the backup directory. Order comes from the
+        // timestamp in each file name, not from a stat per file: on a cloud-synced
+        // folder every GetLastWriteTime is a round trip, and the old code made three
+        // of them per zip before the dialog could show.
         // On macOS, the sandbox may deny access if the folder was only granted
         // via a previous session's folder picker. Gracefully handle this.
         var backupDir = Ioc.Default.GetRequiredService<PreferenceService>().Model.BackupDirectory;
         FileOpenVM.BackupPaths = Array.Empty<string>();
+        var totalBackups = 0;
         if (!string.IsNullOrWhiteSpace(backupDir))
         {
             try
@@ -65,9 +80,10 @@ public sealed partial class FileOpenMenuPage : Page
                     Directory.CreateDirectory(backupDir);
                 }
 
-                FileOpenVM.BackupPaths = Directory
-                    .GetFiles(backupDir)
-                    .OrderByDescending(File.GetLastWriteTime)
+                var allBackups = Directory.GetFiles(backupDir);
+                totalBackups = allBackups.Length;
+                FileOpenVM.BackupPaths = FileOpenVM.OrderBackupsNewestFirst(allBackups)
+                    .Take(MaxBackupsListed)
                     .ToArray();
             }
             catch (UnauthorizedAccessException)
@@ -82,13 +98,14 @@ public sealed partial class FileOpenMenuPage : Page
             }
         }
 
+        // BackupUI must stay index-aligned with BackupPaths: ConfirmClicked opens
+        // BackupPaths[SelectedBackupIndex]. GetFiles returned existing files, so no
+        // entry is skipped here, and the list is cleared first because FileOpenVM is a
+        // singleton and every earlier open had appended its rows to the last ones.
+        FileOpenVM.BackupUI.Clear();
         foreach (var file in FileOpenVM.BackupPaths)
         {
-            //Skip entries that don't exist or are empty
-            if (string.IsNullOrWhiteSpace(file) || !File.Exists(file))
-            {
-                continue;
-            }
+            var stamp = FileOpenVM.ParseBackupTimestamp(file) ?? File.GetLastWriteTime(file);
 
             //Create
             StackPanel item = new()
@@ -101,7 +118,7 @@ public sealed partial class FileOpenMenuPage : Page
             {
                 //Shows as OutlineName At DATETIME
                 Text = Path.GetFileNameWithoutExtension(file.Split(" as of ")[0])
-                       + " at " + File.GetLastWriteTime(file),
+                       + " at " + stamp,
                 FontSize = 16,
                 TextWrapping = TextWrapping.Wrap,
                 TextTrimming = TextTrimming.CharacterEllipsis
@@ -109,5 +126,8 @@ public sealed partial class FileOpenMenuPage : Page
 
             FileOpenVM.BackupUI.Add(item);
         }
+
+        Ioc.Default.GetRequiredService<ILogService>().Log(LogLevel.Info,
+            $"File menu: {FileOpenVM.RecentsUI.Count} recents, {FileOpenVM.BackupPaths.Length} of {totalBackups} backups listed in {stopwatch.ElapsedMilliseconds} ms");
     }
 }

--- a/StoryCADLib/ViewModels/FileOpenVM.cs
+++ b/StoryCADLib/ViewModels/FileOpenVM.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO.Compression;
 using System.Reflection;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -317,6 +318,38 @@ public class FileOpenVM : ObservableRecipient
     ///     Used to track which backup to open if needed.
     /// </summary>
     public string[] BackupPaths;
+
+    /// <summary>
+    ///     Reads the timestamp BackupService.BackupProject writes into a backup file name,
+    ///     "{Outline} as of yyyyMMdd_HHmm.zip". Null when the name does not carry one.
+    ///     The File Open menu sorts and labels backups from this instead of stat-ing each
+    ///     file: on a cloud-synced folder holding 5,000 zips, one GetLastWriteTime per file
+    ///     held the menu for about five seconds before it could show (2026-09-04).
+    /// </summary>
+    public static DateTime? ParseBackupTimestamp(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        const string separator = " as of ";
+        var name = Path.GetFileNameWithoutExtension(path);
+        var index = name.LastIndexOf(separator, StringComparison.Ordinal);
+        if (index < 0)
+            return null;
+
+        var stamp = name[(index + separator.Length)..];
+        return DateTime.TryParseExact(stamp, "yyyyMMdd_HHmm", CultureInfo.InvariantCulture,
+            DateTimeStyles.None, out var when)
+            ? when
+            : null;
+    }
+
+    /// <summary>
+    ///     Newest first by the name stamp. A file whose name carries no stamp falls back to
+    ///     its last-write time, so a hand-renamed backup still sorts instead of vanishing.
+    /// </summary>
+    public static List<string> OrderBackupsNewestFirst(IEnumerable<string> paths) =>
+        paths.OrderByDescending(p => ParseBackupTimestamp(p) ?? File.GetLastWriteTime(p)).ToList();
 
     /// <summary>
     ///     Internal names of samples

--- a/StoryCADTests/ViewModels/FileOpenVMTests.Backups.cs
+++ b/StoryCADTests/ViewModels/FileOpenVMTests.Backups.cs
@@ -1,0 +1,50 @@
+using StoryCADLib.ViewModels;
+
+namespace StoryCADTests.ViewModels;
+
+/// <summary>
+///     Backup-name parsing the File Open menu uses to sort and label the Backups tab
+///     without a stat per file. BackupService writes "{Outline} as of yyyyMMdd_HHmm.zip".
+/// </summary>
+public partial class FileOpenVMTests
+{
+    [TestMethod]
+    [TestCategory("CrossPlatform")]
+    public void ParseBackupTimestamp_WellFormedName_ReturnsStamp()
+    {
+        var when = FileOpenVM.ParseBackupTimestamp(@"G:\Backups\Danger Calls as of 20260904_0657.zip");
+
+        Assert.AreEqual(new DateTime(2026, 9, 4, 6, 57, 0), when);
+    }
+
+    [TestMethod]
+    [TestCategory("CrossPlatform")]
+    public void ParseBackupTimestamp_OutlineNameContainsAsOf_UsesLastStamp()
+    {
+        var when = FileOpenVM.ParseBackupTimestamp(@"C:\b\Notes as of Tuesday as of 20250101_2359.zip");
+
+        Assert.AreEqual(new DateTime(2025, 1, 1, 23, 59, 0), when);
+    }
+
+    [TestMethod]
+    [TestCategory("CrossPlatform")]
+    public void ParseBackupTimestamp_NameWithoutPattern_ReturnsNull()
+    {
+        Assert.IsNull(FileOpenVM.ParseBackupTimestamp(@"C:\b\Danger Calls.zip"));
+        Assert.IsNull(FileOpenVM.ParseBackupTimestamp(@"C:\b\Danger Calls as of yesterday.zip"));
+        Assert.IsNull(FileOpenVM.ParseBackupTimestamp(string.Empty));
+    }
+
+    [TestMethod]
+    [TestCategory("CrossPlatform")]
+    public void OrderBackupsNewestFirst_ThreeStampedNames_NewestFirst()
+    {
+        var oldest = @"C:\b\Story as of 20260101_0900.zip";
+        var middle = @"C:\b\Story as of 20260615_1200.zip";
+        var newest = @"C:\b\Story as of 20260904_0657.zip";
+
+        var ordered = FileOpenVM.OrderBackupsNewestFirst(new[] { middle, oldest, newest });
+
+        CollectionAssert.AreEqual(new[] { newest, middle, oldest }, ordered);
+    }
+}


### PR DESCRIPTION
Fixes #1548.

## What changed

- `FileOpenVM` gains two static helpers: `ParseBackupTimestamp(path)` reads the `as of yyyyMMdd_HHmm` stamp that `BackupService` writes into every backup name (last occurrence, so an outline named with "as of" still parses), and `OrderBackupsNewestFirst(paths)` sorts by that stamp, falling back to `File.GetLastWriteTime` only for names without one.
- `FileOpenMenuPage` constructor: backups are ordered by the name stamp and cut to the newest 100 (`MaxBackupsListed`, with the reason in its comment) before any UI is built; the per-file `File.Exists` and `File.GetLastWriteTime` in the build loop are gone, the display time comes from the parsed stamp; `BackupUI.Clear()` runs before the rebuild, which also fixes rows accumulating on every reopen and the selection index drifting from `BackupPaths`; one Info line per open, `File menu: {n} recents, {shown} of {total} backups listed in {ms} ms`, from a `Stopwatch`.
- Recents loop, the macOS sandbox `try/catch`, and its warning are unchanged.

## Why

The menu took 5.0 to 5.9 s to appear on every open (logs 2026-09-02 and 2026-09-04). The constructor stat-called every file in a 5,000-file backup folder on a cloud drive three times and built 5,000 `StackPanel`s on the UI thread. Details and measurements in #1548.

## How to test

```
"C:\Program Files\Microsoft Visual Studio\18\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe" StoryCADTests\bin\x64\Debug\net10.0-windows10.0.22621\StoryCADTests.dll /Tests:FileOpenVMTests,BackupServiceTests
```

New: `FileOpenVMTests.Backups.cs`, four tests (well-formed name; outline name containing "as of"; no pattern; ordering of three). Both heads build. Full suite in the fix worktree: 1532 total, 1515 passed, 15 skipped, 2 failed, and the two failures are `CheckDotEnvFile` and `CheckDoppler`, which need the gitignored `StoryCADTests/.env` that the fresh worktree does not have; they pass in a normal checkout.

By hand: open File > Open with a large backup folder. The log line reports the elapsed time; expect well under a second. Open the menu twice and check the Backups tab lists each backup once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eWUufU7sGmwotbdr9ML93
