### PR TITLE
feat(collaborator): per-beat Accept/Skip for ProblemBuilder beats; copy field_states into the run result (Collaborator #217)

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -1043,7 +1043,7 @@ public class Collaborator : ICollaborator
         {
             Key = u.Key,
             ElementName = u.ElementLabel,
-            PropertyDisplayName = u.Spec.Property,
+            PropertyDisplayName = u.DisplayNameOverride ?? u.Spec.Property,
             ProposedDisplay = proposed,
             CurrentDisplay = current,
             KindLabel = kindLabel,
@@ -1675,7 +1675,8 @@ public class Collaborator : ICollaborator
         {
             Key = u.Key,
             ElementName = ValueDisplay.SplitPascalCase(u.ElementLabel),
-            PropertyDisplayName = ValueDisplay.SplitPascalCase(u.Spec.Property),
+            // Collaborator #217 section 5.7: a beat row names itself ("Beat 3: Set-Up").
+            PropertyDisplayName = u.DisplayNameOverride ?? ValueDisplay.SplitPascalCase(u.Spec.Property),
             ProposedDisplay = string.IsNullOrEmpty(proposed) ? "(empty)" : proposed,
             CurrentDisplay = current,
             KindLabel = kindLabel,

--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -1209,18 +1209,29 @@ public class Collaborator : ICollaborator
                     var stageSession = new OverwriteAcceptanceSession();
 
                     var sceneBuilderOrphanBindDone = false;
+                    var lastAppliedKeys = new List<string>();
 
                     int ApplyPendingList(IReadOnlyList<PendingUpdate> list)
                     {
                         int applied = 0;
-                        if (list.Count > 0)
+                        lastAppliedKeys.Clear();
+                        foreach (var u in list)
                         {
+                            // One update per slice: the applied keys are then known, and a row
+                            // that returns 0 (#217 5.7: its beat was filled meanwhile) says why
+                            // in the status list instead of a bare "Failed to apply".
                             var slice = WorkflowResult.Succeeded();
-                            foreach (var u in list)
-                                slice.PendingUpdates.Add(u);
-                            applied = runner.ApplyUpdates(slice, gatheredElements);
-                            foreach (var u in list)
-                                _sessionTouchedFields.Add(u.SessionTouchKey);
+                            slice.PendingUpdates.Add(u);
+                            var n = runner.ApplyUpdates(slice, gatheredElements);
+                            foreach (var msg in slice.StatusMessages)
+                            {
+                                if (!msg.StartsWith("No-op ", StringComparison.Ordinal))
+                                    viewModel.AddStatusMessage(msg);
+                            }
+                            if (n > 0)
+                                lastAppliedKeys.Add(u.Key);
+                            applied += n;
+                            _sessionTouchedFields.Add(u.SessionTouchKey);
                         }
                         if (!sceneBuilderOrphanBindDone
                             && string.Equals(workflow.Label, "SceneBuilder", StringComparison.Ordinal))
@@ -1345,17 +1356,19 @@ public class Collaborator : ICollaborator
                             }
 
                             var count = ApplyPendingList(applyList);
+                            var appliedKeys = new HashSet<string>(lastAppliedKeys, StringComparer.OrdinalIgnoreCase);
                             foreach (var u in applyList)
                                 _sessionProposals?.MarkAccepted(u.Key);
                             result.PendingUpdates.Clear();
                             result.UpdatedProperties.Clear();
 
                             var sb = new System.Text.StringBuilder();
-                            if (count > 0)
+                            if (appliedKeys.Count > 0)
                             {
-                                sb.AppendLine($"Applied {count} update(s) to your outline:");
+                                // Only what applied: a beat row can return 0 (#217 5.7).
+                                sb.AppendLine($"Applied {appliedKeys.Count} update(s) to your outline:");
                                 sb.AppendLine();
-                                foreach (var u in applyList)
+                                foreach (var u in applyList.Where(u => appliedKeys.Contains(u.Key)))
                                 {
                                     var valuePreview = TruncateForChat(FormatValueForDisplay(u.Value));
                                     sb.AppendLine($"**{u.Key}**: {valuePreview}");

--- a/CollaboratorLib/Models/PropertySpec.cs
+++ b/CollaboratorLib/Models/PropertySpec.cs
@@ -75,13 +75,29 @@ namespace StoryCollaborator.Models
         string? CurrentDisplay = null,
         string? CraftExplanation = null)
     {
-        public string Key => $"{ElementLabel}.{Spec.Property}";
+        // Collaborator #217 section 5.7: one beat of a sheet is its own row, so its key carries
+        // the row index. Every Accept path finds a row by Key, so keys must stay unique.
+        public string Key => BeatRowIndex.HasValue
+            ? $"{ElementLabel}.{Spec.Property}[{BeatRowIndex.Value}]"
+            : $"{ElementLabel}.{Spec.Property}";
 
         /// <summary>Stable session key: element UUID + property (survives label renames).</summary>
         public string SessionTouchKey => $"{ElementUuid:N}.{Spec.Property}";
 
         public bool AcceptAllMayApply =>
             Kind is UpdateKind.Fill or UpdateKind.Refresh or UpdateKind.Unclassified;
+
+        /// <summary>
+        /// Collaborator #217 section 5.7: set when this update is one beat of a BeatSheet
+        /// proposal (Value is a <see cref="BeatRowValue"/>). Null for every other update.
+        /// </summary>
+        public int? BeatRowIndex { get; init; }
+
+        /// <summary>
+        /// Review pane name for this update when the property name is not the right label
+        /// (a beat row reads "Beat 3: Set-Up"). Null means show the property name.
+        /// </summary>
+        public string? DisplayNameOverride { get; init; }
     }
 
     /// <summary>
@@ -98,6 +114,21 @@ namespace StoryCollaborator.Models
         string? SceneNotes = null,
         string? SceneType = null,
         IReadOnlyList<Guid>? SceneCast = null);
+
+    /// <summary>
+    /// Collaborator #217 section 5.7: the value of one per-beat pending update. Row is the
+    /// proposal row; Sheet is the whole proposal, kept so the first accepted row can install
+    /// the sheet when the Problem has none. BindGuid set means the row binds that candidate;
+    /// null means it creates the Scene stub named in Row.SceneName.
+    /// </summary>
+    public sealed record BeatRowValue(
+        int Index,
+        string Title,
+        BeatInfo Row,
+        IReadOnlyList<BeatInfo> Sheet,
+        Guid? BindGuid,
+        string? ElementName,
+        string? ElementType);
 
     /// <summary>
     /// One relationship entry in a Relationships output.

--- a/CollaboratorLib/Models/PropertySpec.cs
+++ b/CollaboratorLib/Models/PropertySpec.cs
@@ -76,9 +76,11 @@ namespace StoryCollaborator.Models
         string? CraftExplanation = null)
     {
         // Collaborator #217 section 5.7: one beat of a sheet is its own row, so its key carries
-        // the row index. Every Accept path finds a row by Key, so keys must stay unique.
+        // the row index. Every Accept path finds a row by Key, so keys must stay unique. Two
+        // digits, because the pane orders rows by Key with an ordinal compare and [10] must
+        // not sort before [2].
         public string Key => BeatRowIndex.HasValue
-            ? $"{ElementLabel}.{Spec.Property}[{BeatRowIndex.Value}]"
+            ? $"{ElementLabel}.{Spec.Property}[{BeatRowIndex.Value:D2}]"
             : $"{ElementLabel}.{Spec.Property}";
 
         /// <summary>Stable session key: element UUID + property (survives label renames).</summary>

--- a/CollaboratorLib/Models/ValueDisplay.cs
+++ b/CollaboratorLib/Models/ValueDisplay.cs
@@ -59,6 +59,12 @@ internal static class ValueDisplay
             case List<string> entries:
                 return Bullets(entries);
 
+            // Collaborator #217 section 5.7: one beat row reads as what Accept will do to it.
+            case BeatRowValue row:
+                return row.BindGuid.HasValue
+                    ? $"binds {row.ElementName ?? ResolveName(row.BindGuid.Value, resolveElementName)} ({row.ElementType ?? "element"})"
+                    : $"new Scene \"{row.Row.SceneName?.Trim()}\"";
+
             case List<BeatInfo> beats:
                 return string.Join("\n", beats.Select((beat, i) =>
                     string.IsNullOrWhiteSpace(beat.Description)

--- a/CollaboratorLib/Services/SessionProposalSet.cs
+++ b/CollaboratorLib/Services/SessionProposalSet.cs
@@ -68,11 +68,22 @@ public sealed class SessionProposalSet
             return false;
 
         reopened = e.Status is ProposalSessionStatus.Accepted or ProposalSessionStatus.Skipped;
-        var updatedUpdate = e.Update with { Value = newValue };
+        object? patched = newValue;
+        var proposedText = newValue ?? string.Empty;
+        if (e.Update.Value is BeatRowValue row)
+        {
+            // Collaborator #217 section 5.7: a beat row is typed. Chat may rename the stub a
+            // Create row makes; a Bind row names an outline element and takes no free text.
+            if (row.BindGuid.HasValue)
+                return false;
+            patched = row with { Row = row.Row with { SceneName = newValue } };
+            proposedText = FormatValue(patched);
+        }
+        var updatedUpdate = e.Update with { Value = patched };
         _entries[key] = e with
         {
             Update = updatedUpdate,
-            ProposedText = newValue ?? string.Empty,
+            ProposedText = proposedText,
             Status = ProposalSessionStatus.Open
         };
         return true;

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -2225,7 +2225,10 @@ namespace StoryCollaborator
         /// </summary>
         internal bool ApplyBeatRow(Guid problemUuid, BeatRowValue row, WorkflowResult result)
         {
-            var sheet = row.Sheet as List<BeatInfo> ?? row.Sheet.ToList();
+            // Copy first: row.Sheet is the shared proposal list. A chat rename patched row.Row
+            // only, so this row's own slot must carry the patched BeatInfo.
+            var sheet = row.Sheet.ToList();
+            sheet[row.Index] = row.Row;
             var existingBeats = ReadBeats(problemUuid, result);
             if (existingBeats == null)
                 return false;
@@ -2252,7 +2255,11 @@ namespace StoryCollaborator
                 result.StatusMessages.Add($"Beat {row.Index}: no plan row; not applied");
                 return false;
             }
-            if (planned.Outcome is not (BeatRowOutcome.Bind or BeatRowOutcome.Create))
+            // The row applies only as what the pane showed it as: a Bind row binds the same
+            // candidate, a Create row creates. Anything else changed under the writer.
+            var expected = row.BindGuid.HasValue ? BeatRowOutcome.Bind : BeatRowOutcome.Create;
+            var sameBinding = !row.BindGuid.HasValue || planned.ElementGuid == row.BindGuid;
+            if (planned.Outcome != expected || !sameBinding)
             {
                 result.StatusMessages.Add($"Beat {row.Index}: now {planned.Outcome}; not applied");
                 return false;
@@ -2339,6 +2346,13 @@ namespace StoryCollaborator
                             result.StatusMessages.Add($"Beat {row.Index}: not applied, sheet has {sheetRows} rows");
                             break;
                     }
+                }
+
+                if (rows.Count == 0 && plan[0].InstallsBeat)
+                {
+                    // A sheetless Problem whose rows all Refuse or stay Empty still gets its
+                    // sheet (titles and descriptions) from the sheet-level Accept.
+                    continue;
                 }
 
                 var at = result.PendingUpdates.IndexOf(sheetUpdate);

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -227,13 +227,9 @@ namespace StoryCollaborator
                 result.StatusMessages.Add("Received AI response");
 
                 var outputResult = ExtractOutputs(planResult, gatheredElements, workflowIO.Outputs);
-
-                foreach (var msg in outputResult.StatusMessages)
-                    result.StatusMessages.Add(msg);
-                foreach (var kvp in outputResult.UpdatedProperties)
-                    result.UpdatedProperties[kvp.Key] = kvp.Value;
-                foreach (var pending in outputResult.PendingUpdates)
-                    result.PendingUpdates.Add(pending);
+                MergeExtractResult(result, outputResult);
+                // Collaborator #217 section 5.7: each beat that binds or creates is its own row.
+                ExpandBeatSheetUpdates(result);
 
                 if (string.Equals(workflowModel.Label, "SceneBuilder", StringComparison.Ordinal))
                     CaptureSceneBuilderProposal(planResult, result);
@@ -705,6 +701,18 @@ namespace StoryCollaborator
                     continue;
                 }
 
+                // Collaborator #217 section 5.7: a beat row was planned against the live sheet at
+                // extract time and only Bind and Create rows exist, so each one is a Fill.
+                if (update.Value is BeatRowValue)
+                {
+                    var row = update with { Kind = UpdateKind.Fill, CurrentDisplay = "empty" };
+                    kept.Add(row);
+                    display[row.Key] = FormatDisplayValue(row);
+                    fillCount++;
+                    _logger?.LogInformation("Classify {Key} kind=Fill source=plan", row.Key);
+                    continue;
+                }
+
                 if (update.Spec.WriteVia != WriteVia.Scalar)
                 {
                     kept.Add(update);
@@ -985,6 +993,7 @@ namespace StoryCollaborator
             {
                 WriteVia.Scalar => update.Value.ToString() ?? string.Empty,
                 WriteVia.SimpleList when update.Value is System.Collections.ICollection c => $"{c.Count} items",
+                WriteVia.BeatSheet when update.Value is BeatRowValue row => ValueDisplay.Format(row),
                 WriteVia.BeatSheet when update.Value is List<BeatInfo> beatList =>
                     FormatBeatSheetDisplay(update.ElementUuid, beatList),
                 WriteVia.BeatSheet when update.Value is System.Collections.ICollection c => $"{c.Count} beats",
@@ -1258,6 +1267,13 @@ namespace StoryCollaborator
 
                     case WriteVia.BeatSheet:
                     {
+                        // Collaborator #217 section 5.7: one accepted beat row applies on its own.
+                        if (update.Value is BeatRowValue row)
+                        {
+                            if (ApplyBeatRow(uuid, row, result))
+                                appliedCount++;
+                            break;
+                        }
                         // #167: merge proposed beats; never wipe filled assignments.
                         if (update.Value is not List<BeatInfo> beats) break;
                         ApplyBeatSheetMerge(uuid, beats, result);
@@ -1736,27 +1752,9 @@ namespace StoryCollaborator
             if (plan.Count == 0)
                 return $"{beats.Count} beats";
 
-            int kept = 0, bound = 0, created = 0, empty = 0, refused = 0, dropped = 0;
-            foreach (var row in plan)
-            {
-                switch (row.Outcome)
-                {
-                    case BeatRowOutcome.Keep: kept++; break;
-                    case BeatRowOutcome.Bind: bound++; break;
-                    case BeatRowOutcome.Create: created++; break;
-                    case BeatRowOutcome.Empty: empty++; break;
-                    case BeatRowOutcome.Refuse: refused++; break;
-                    case BeatRowOutcome.Drop: dropped++; break;
-                }
-            }
-
             // Drop rows start at the sheet's row count, so that count is the rows before them.
-            var sheetRows = plan.Count - dropped;
-            var sb = new System.Text.StringBuilder();
-            sb.Append(plan.Count).Append(plan[0].InstallsBeat ? " new " : " ").Append(Plural(plan.Count, "beat")).Append(": ");
-            sb.Append($"{kept} kept, {bound} bound, {created} new {Plural(created, "scene")}, {empty} empty");
-            if (refused > 0) sb.Append($", {refused} refused");
-            if (dropped > 0) sb.Append($", {dropped} dropped");
+            var sheetRows = plan.Count - plan.Count(r => r.Outcome == BeatRowOutcome.Drop);
+            var sb = new System.Text.StringBuilder(PlanSummary(plan));
 
             foreach (var row in plan)
             {
@@ -1788,6 +1786,34 @@ namespace StoryCollaborator
                 }
             }
 
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// The one-line summary of a plan: counts per outcome. Heads the sheet-level display and
+        /// is the status line the per-beat expansion (#217 section 5.7) leaves for the run.
+        /// </summary>
+        private static string PlanSummary(List<BeatRowPlan> plan)
+        {
+            int kept = 0, bound = 0, created = 0, empty = 0, refused = 0, dropped = 0;
+            foreach (var row in plan)
+            {
+                switch (row.Outcome)
+                {
+                    case BeatRowOutcome.Keep: kept++; break;
+                    case BeatRowOutcome.Bind: bound++; break;
+                    case BeatRowOutcome.Create: created++; break;
+                    case BeatRowOutcome.Empty: empty++; break;
+                    case BeatRowOutcome.Refuse: refused++; break;
+                    case BeatRowOutcome.Drop: dropped++; break;
+                }
+            }
+
+            var sb = new System.Text.StringBuilder();
+            sb.Append(plan.Count).Append(plan[0].InstallsBeat ? " new " : " ").Append(Plural(plan.Count, "beat")).Append(": ");
+            sb.Append($"{kept} kept, {bound} bound, {created} new {Plural(created, "scene")}, {empty} empty");
+            if (refused > 0) sb.Append($", {refused} refused");
+            if (dropped > 0) sb.Append($", {dropped} dropped");
             return sb.ToString();
         }
 
@@ -2120,60 +2146,207 @@ namespace StoryCollaborator
             var plan = PlanBeatSheetMerge(problemUuid, proposed);
 
             foreach (var row in plan)
+                ExecuteBeatRow(problemUuid, row, proposed[row.Index], existingBeats, result);
+        }
+
+        /// <summary>
+        /// Executes one plan row: creates the beat when the sheet is new, fills blank text on an
+        /// empty beat, then binds or creates. Returns true when the row bound or created. Shared
+        /// by the sheet-level apply and the per-beat apply (#217 section 5.7), so a row does the
+        /// same thing whichever path accepted it.
+        /// </summary>
+        private bool ExecuteBeatRow(
+            Guid problemUuid,
+            BeatRowPlan row,
+            BeatInfo beat,
+            List<(string BeatTitle, string BeatDescription, Guid? LinkedElement)> existingBeats,
+            WorkflowResult result)
+        {
+            if (row.Outcome == BeatRowOutcome.Drop)
             {
-                var beat = proposed[row.Index];
+                // Collaborator #77: a sheet that is already present is the user's. The chosen
+                // sheet sets the beat count, so do not append rows to it.
+                result.StatusMessages.Add(
+                    $"Beat {row.Index}: not applied, sheet has {existingBeats.Count} rows");
+                return false;
+            }
 
-                if (row.Outcome == BeatRowOutcome.Drop)
+            if (row.InstallsBeat)
+            {
+                _storyApi.CreateBeat(problemUuid, row.Title, beat.Description?.Trim() ?? string.Empty);
+            }
+            else
+            {
+                // Collaborator #77: a filled beat is the user's. Do not touch its assignment,
+                // its title, or its description. This test used to sit below the text write,
+                // so a filled beat with a blank description took model text under Accept All.
+                if (row.Outcome == BeatRowOutcome.Keep)
+                    return false;
+
+                var current = existingBeats[row.Index];
+                var newTitle = string.IsNullOrWhiteSpace(current.BeatTitle) && !string.IsNullOrWhiteSpace(beat.Title)
+                    ? beat.Title.Trim()
+                    : current.BeatTitle;
+                // Prefer keep filled description; fill blank only.
+                var newDesc = string.IsNullOrWhiteSpace(current.BeatDescription) && !string.IsNullOrWhiteSpace(beat.Description)
+                    ? beat.Description.Trim()
+                    : current.BeatDescription;
+
+                if (!string.Equals(newTitle, current.BeatTitle, StringComparison.Ordinal)
+                    || !string.Equals(newDesc, current.BeatDescription, StringComparison.Ordinal))
                 {
-                    // Collaborator #77: a sheet that is already present is the user's. The chosen
-                    // sheet sets the beat count, so do not append rows to it.
-                    result.StatusMessages.Add(
-                        $"Beat {row.Index}: not applied, sheet has {existingBeats.Count} rows");
+                    _storyApi.UpdateBeat(problemUuid, row.Index, newTitle ?? string.Empty, newDesc ?? string.Empty);
+                }
+            }
+
+            switch (row.Outcome)
+            {
+                case BeatRowOutcome.Bind:
+                    return AssignBeat(problemUuid, row.Index, row.ElementGuid!.Value, result);
+                case BeatRowOutcome.Create:
+                    return CreateSceneStub(problemUuid, row.Index, beat, result);
+                case BeatRowOutcome.Refuse:
+                    result.StatusMessages.Add(RefuseStatus(row));
+                    return false;
+                default:
+                    return false;
+            }
+        }
+
+        private static string RefuseStatus(BeatRowPlan row) => row.ElementName != null
+            ? $"Beat {row.Index} assigned_element {row.ElementGuid} already used on this sheet; left unassigned"
+            : $"Beat {row.Index} assigned_element {row.ElementGuid} not in candidate set; left unassigned";
+
+        /// <summary>
+        /// Collaborator #217 section 5.7: apply one accepted beat row. Earlier rows of the same
+        /// proposal may have given the Problem a sheet, a binding, or a stub since the plan was
+        /// made, so the row is planned again against the live sheet before it runs. Returns true
+        /// when the row bound or created.
+        /// </summary>
+        internal bool ApplyBeatRow(Guid problemUuid, BeatRowValue row, WorkflowResult result)
+        {
+            var sheet = row.Sheet as List<BeatInfo> ?? row.Sheet.ToList();
+            var existingBeats = ReadBeats(problemUuid, result);
+            if (existingBeats == null)
+                return false;
+
+            if (existingBeats.Count == 0)
+            {
+                // Install if missing: the first accepted row creates every beat of the sheet
+                // (titles and descriptions). Later rows find the sheet present and skip this.
+                for (int i = 0; i < sheet.Count; i++)
+                {
+                    var b = sheet[i];
+                    var title = string.IsNullOrWhiteSpace(b.Title) ? $"Beat {i + 1}" : b.Title.Trim();
+                    _storyApi.CreateBeat(problemUuid, title, b.Description?.Trim() ?? string.Empty);
+                }
+                result.StatusMessages.Add($"BeatSheet: installed {sheet.Count} {Plural(sheet.Count, "beat")}");
+                existingBeats = ReadBeats(problemUuid, result);
+                if (existingBeats == null)
+                    return false;
+            }
+
+            var planned = PlanBeatSheetMerge(problemUuid, sheet).FirstOrDefault(r => r.Index == row.Index);
+            if (planned == null)
+            {
+                result.StatusMessages.Add($"Beat {row.Index}: no plan row; not applied");
+                return false;
+            }
+            if (planned.Outcome is not (BeatRowOutcome.Bind or BeatRowOutcome.Create))
+            {
+                result.StatusMessages.Add($"Beat {row.Index}: now {planned.Outcome}; not applied");
+                return false;
+            }
+
+            return ExecuteBeatRow(problemUuid, planned, sheet[row.Index], existingBeats, result);
+        }
+
+        private List<(string BeatTitle, string BeatDescription, Guid? LinkedElement)>? ReadBeats(
+            Guid problemUuid, WorkflowResult result)
+        {
+            var existingResult = _storyApi.GetProblemStructure(problemUuid);
+            if (!existingResult.IsSuccess)
+            {
+                result.StatusMessages.Add($"BeatSheet: cannot load structure for {problemUuid}");
+                return null;
+            }
+            return existingResult.Payload.Beats?.ToList()
+                ?? new List<(string BeatTitle, string BeatDescription, Guid? LinkedElement)>();
+        }
+
+        /// <summary>
+        /// Folds an <see cref="ExtractOutputs"/> result into the run result. FieldStates rides
+        /// along: before #217 the merge left it behind, so classify never saw the model's intent
+        /// and every field fell through to the compare ladder (smoke of 2026-09-04).
+        /// </summary>
+        internal static void MergeExtractResult(WorkflowResult result, WorkflowResult outputResult)
+        {
+            foreach (var msg in outputResult.StatusMessages)
+                result.StatusMessages.Add(msg);
+            foreach (var kvp in outputResult.UpdatedProperties)
+                result.UpdatedProperties[kvp.Key] = kvp.Value;
+            foreach (var pending in outputResult.PendingUpdates)
+                result.PendingUpdates.Add(pending);
+            foreach (var kvp in outputResult.FieldStates)
+                result.FieldStates[kvp.Key] = kvp.Value;
+        }
+
+        /// <summary>
+        /// Collaborator #217 section 5.7: replace each sheet-level BeatSheet update with one update
+        /// per plan row that binds or creates, so Review Each offers Accept or Skip per beat. Keep,
+        /// Empty, Drop and Refuse rows make no row: there is nothing to accept, and Refuse and Drop
+        /// say why in the status list. A proposal whose structure cannot be planned stays whole.
+        /// </summary>
+        internal void ExpandBeatSheetUpdates(WorkflowResult result)
+        {
+            var sheets = result.PendingUpdates
+                .Where(u => u.Spec.WriteVia == WriteVia.BeatSheet && u.Value is List<BeatInfo>)
+                .ToList();
+
+            foreach (var sheetUpdate in sheets)
+            {
+                var beats = (List<BeatInfo>)sheetUpdate.Value!;
+                var plan = PlanBeatSheetMerge(sheetUpdate.ElementUuid, beats);
+                if (plan.Count == 0)
                     continue;
-                }
 
-                if (row.InstallsBeat)
+                result.StatusMessages.Add("BeatSheet: " + PlanSummary(plan));
+                var sheetRows = plan.Count - plan.Count(r => r.Outcome == BeatRowOutcome.Drop);
+                var rows = new List<PendingUpdate>();
+                foreach (var row in plan)
                 {
-                    _storyApi.CreateBeat(problemUuid, row.Title, beat.Description?.Trim() ?? string.Empty);
-                }
-                else
-                {
-                    // Collaborator #77: a filled beat is the user's. Do not touch its assignment,
-                    // its title, or its description. This test used to sit below the text write,
-                    // so a filled beat with a blank description took model text under Accept All.
-                    if (row.Outcome == BeatRowOutcome.Keep)
-                        continue;
-
-                    var current = existingBeats[row.Index];
-                    var newTitle = string.IsNullOrWhiteSpace(current.BeatTitle) && !string.IsNullOrWhiteSpace(beat.Title)
-                        ? beat.Title.Trim()
-                        : current.BeatTitle;
-                    // Prefer keep filled description; fill blank only.
-                    var newDesc = string.IsNullOrWhiteSpace(current.BeatDescription) && !string.IsNullOrWhiteSpace(beat.Description)
-                        ? beat.Description.Trim()
-                        : current.BeatDescription;
-
-                    if (!string.Equals(newTitle, current.BeatTitle, StringComparison.Ordinal)
-                        || !string.Equals(newDesc, current.BeatDescription, StringComparison.Ordinal))
+                    switch (row.Outcome)
                     {
-                        _storyApi.UpdateBeat(problemUuid, row.Index, newTitle ?? string.Empty, newDesc ?? string.Empty);
+                        case BeatRowOutcome.Bind:
+                        case BeatRowOutcome.Create:
+                            var binds = row.Outcome == BeatRowOutcome.Bind;
+                            var value = new BeatRowValue(
+                                row.Index, row.Title, beats[row.Index], beats,
+                                binds ? row.ElementGuid : null,
+                                row.ElementName,
+                                binds ? ElementTypeNameOf(row.ElementGuid!.Value) : null);
+                            rows.Add(new PendingUpdate(
+                                sheetUpdate.ElementLabel, sheetUpdate.ElementUuid, sheetUpdate.Spec, value)
+                            {
+                                BeatRowIndex = row.Index,
+                                DisplayNameOverride = $"Beat {row.Index + 1}: {row.Title}"
+                            });
+                            break;
+                        case BeatRowOutcome.Refuse:
+                            result.StatusMessages.Add(RefuseStatus(row));
+                            break;
+                        case BeatRowOutcome.Drop:
+                            result.StatusMessages.Add($"Beat {row.Index}: not applied, sheet has {sheetRows} rows");
+                            break;
                     }
                 }
 
-                switch (row.Outcome)
-                {
-                    case BeatRowOutcome.Bind:
-                        AssignBeat(problemUuid, row.Index, row.ElementGuid!.Value, result);
-                        break;
-                    case BeatRowOutcome.Create:
-                        CreateSceneStub(problemUuid, row.Index, beat, result);
-                        break;
-                    case BeatRowOutcome.Refuse:
-                        result.StatusMessages.Add(row.ElementName != null
-                            ? $"Beat {row.Index} assigned_element {row.ElementGuid} already used on this sheet; left unassigned"
-                            : $"Beat {row.Index} assigned_element {row.ElementGuid} not in candidate set; left unassigned");
-                        break;
-                }
+                var at = result.PendingUpdates.IndexOf(sheetUpdate);
+                result.PendingUpdates.RemoveAt(at);
+                result.PendingUpdates.InsertRange(at, rows);
+                result.UpdatedProperties.Remove(sheetUpdate.Key);
+                foreach (var r in rows)
+                    result.UpdatedProperties[r.Key] = FormatDisplayValue(r);
             }
         }
 
@@ -2181,7 +2354,7 @@ namespace StoryCollaborator
         /// Collaborator #150 / #77: create the Scene stub a Create row names, fill the #208
         /// stub contract, and assign it to the beat.
         /// </summary>
-        private void CreateSceneStub(Guid problemUuid, int beatIndex, BeatInfo beat, WorkflowResult result)
+        private bool CreateSceneStub(Guid problemUuid, int beatIndex, BeatInfo beat, WorkflowResult result)
         {
             var name = beat.SceneName!.Trim();
             var addResult = _storyApi.AddElement(StoryItemType.Scene, problemUuid.ToString(), name);
@@ -2189,7 +2362,7 @@ namespace StoryCollaborator
             {
                 result.StatusMessages.Add(
                     $"Beat {beatIndex} scene create failed: {addResult.ErrorMessage}");
-                return;
+                return false;
             }
 
             var newGuid = addResult.Payload;
@@ -2221,16 +2394,19 @@ namespace StoryCollaborator
                 }
             }
 
-            AssignBeat(problemUuid, beatIndex, newGuid, result);
+            var assigned = AssignBeat(problemUuid, beatIndex, newGuid, result);
             result.StatusMessages.Add($"Beat {beatIndex}: created Scene '{name}' ({newGuid})");
+            return assigned;
         }
 
-        private void AssignBeat(Guid problemUuid, int beatIndex, Guid element, WorkflowResult result)
+        private bool AssignBeat(Guid problemUuid, int beatIndex, Guid element, WorkflowResult result)
         {
             var assignResult = _storyApi.AssignElementToBeat(problemUuid, beatIndex, element);
-            if (!assignResult.IsSuccess)
-                result.StatusMessages.Add(
-                    $"Beat {beatIndex} assign failed: {assignResult.ErrorMessage}");
+            if (assignResult.IsSuccess)
+                return true;
+            result.StatusMessages.Add(
+                $"Beat {beatIndex} assign failed: {assignResult.ErrorMessage}");
+            return false;
         }
 
         /// <summary>

--- a/StoryCADTests/Collaborator/PerBeatAcceptTests.cs
+++ b/StoryCADTests/Collaborator/PerBeatAcceptTests.cs
@@ -106,8 +106,8 @@ public class PerBeatAcceptTests
         Assert.AreEqual(2, result.PendingUpdates.Count, "Keep, Refuse, Empty and Drop make no row");
         var bind = result.PendingUpdates[0];
         var create = result.PendingUpdates[1];
-        Assert.AreEqual("Problem.StructureBeats[1]", bind.Key);
-        Assert.AreEqual("Problem.StructureBeats[2]", create.Key);
+        Assert.AreEqual("Problem.StructureBeats[01]", bind.Key);
+        Assert.AreEqual("Problem.StructureBeats[02]", create.Key);
         Assert.AreEqual("Beat 2: Theme Stated", bind.DisplayNameOverride);
         Assert.AreEqual("Beat 3: Set-Up", create.DisplayNameOverride);
 
@@ -159,7 +159,7 @@ public class PerBeatAcceptTests
             Assert.AreEqual("empty", row.CurrentDisplay, row.Key);
             Assert.IsTrue(row.AcceptAllMayApply, "Accept All and Accept Free Remaining include the row");
         }
-        Assert.AreEqual("binds Free (Scene)", result.UpdatedProperties["Problem.StructureBeats[1]"]);
+        Assert.AreEqual("binds Free (Scene)", result.UpdatedProperties["Problem.StructureBeats[01]"]);
     }
 
     [TestMethod]
@@ -304,13 +304,90 @@ public class PerBeatAcceptTests
         var set = new SessionProposalSet();
         set.ReplaceFromPending(result.PendingUpdates, null);
 
-        Assert.IsFalse(set.TryApplyPatch("Problem.StructureBeats[1]", "Something else", out _),
+        Assert.IsFalse(set.TryApplyPatch("Problem.StructureBeats[01]", "Something else", out _),
             "a Bind row names an outline element and takes no free text");
-        Assert.IsTrue(set.TryApplyPatch("Problem.StructureBeats[2]", "The letter arrives", out _));
+        Assert.IsTrue(set.TryApplyPatch("Problem.StructureBeats[02]", "The letter arrives", out _));
 
-        var entry = set.Get("Problem.StructureBeats[2]");
+        var entry = set.Get("Problem.StructureBeats[02]");
         var value = (BeatRowValue)entry.Update.Value;
         Assert.AreEqual("The letter arrives", value.Row.SceneName);
         Assert.AreEqual("new Scene \"The letter arrives\"", entry.ProposedText);
+
+        // The patched row is what Accept applies, not the original slot of the shared proposal.
+        var applied = runner.ApplyUpdates(Slice(entry.Update), new Dictionary<string, StoryElement>());
+
+        Assert.AreEqual(1, applied);
+        var created = model.StoryElements.OfType<SceneModel>().Single(s => s.Name == "The letter arrives");
+        Assert.AreEqual(created.Uuid, target.StructureBeats[2].Guid);
+        Assert.IsFalse(model.StoryElements.OfType<SceneModel>().Any(s => s.Name == "Stub"),
+            "the original stub name is not used");
+    }
+
+    [TestMethod]
+    public void ApplyUpdates_BindRowWhoseCandidateWasPlacedMeanwhile_DoesNotBecomeAStub()
+    {
+        var (model, runner) = Arrange();
+        var target = new ProblemModel("Target", model, null);
+        var free = new SceneModel("Free", model, null);
+        var other = new ProblemModel("Other", model, null);
+        target.StructureBeats.Add(new StructureBeat("Catalyst", ""));
+        // The model row carries both a candidate and a stub name; the candidate wins at plan.
+        var proposal = new List<BeatInfo> { new("Catalyst", "", AssignedElement: free.Uuid, SceneName: "Fallback") };
+        var result = SheetResult(target, proposal);
+        runner.ExpandBeatSheetUpdates(result);
+        var bind = result.PendingUpdates.Single();
+        Assert.IsTrue(((BeatRowValue)bind.Value).BindGuid.HasValue, "shown to the writer as a bind");
+
+        // Between Review and Accept the writer places the Scene on another sheet by hand.
+        other.StructureBeats.Add(new StructureBeat("Row", "") { Guid = free.Uuid });
+
+        var slice = Slice(bind);
+        var applied = runner.ApplyUpdates(slice, new Dictionary<string, StoryElement>());
+
+        Assert.AreEqual(0, applied, "a row shown as a bind does not turn into a stub");
+        Assert.AreEqual(Guid.Empty, target.StructureBeats[0].Guid);
+        Assert.IsFalse(model.StoryElements.OfType<SceneModel>().Any(s => s.Name == "Fallback"));
+        Assert.IsTrue(slice.StatusMessages.Any(m => m.Contains("now Create; not applied")),
+            "the status line says why the row did not apply");
+    }
+
+    [TestMethod]
+    public void ExpandBeatSheetUpdates_TwelveRows_KeysSortInIndexOrder()
+    {
+        var (model, runner) = Arrange();
+        var target = new ProblemModel("Target", model, null);
+        var proposal = new List<BeatInfo>();
+        for (var i = 0; i < 12; i++)
+        {
+            target.StructureBeats.Add(new StructureBeat($"Row {i + 1}", ""));
+            proposal.Add(new($"Row {i + 1}", "", SceneName: $"Scene {i + 1}"));
+        }
+        var result = SheetResult(target, proposal);
+
+        runner.ExpandBeatSheetUpdates(result);
+
+        var keys = result.PendingUpdates.Select(u => u.Key).ToList();
+        Assert.AreEqual(12, keys.Count);
+        Assert.AreEqual("Problem.StructureBeats[00]", keys[0]);
+        Assert.AreEqual("Problem.StructureBeats[11]", keys[11]);
+        CollectionAssert.AreEqual(keys, keys.OrderBy(k => k, StringComparer.Ordinal).ToList(),
+            "the pane orders rows by Key with an ordinal compare");
+    }
+
+    [TestMethod]
+    public void ExpandBeatSheetUpdates_SheetlessProblemWithNothingToBind_KeepsTheSheetLevelUpdate()
+    {
+        var (model, runner) = Arrange();
+        var target = new ProblemModel("Target", model, null);
+        var proposal = new List<BeatInfo> { new("Opening Image", "Where we start"), new("Catalyst", "The turn") };
+        var result = SheetResult(target, proposal);
+
+        runner.ExpandBeatSheetUpdates(result);
+
+        var single = result.PendingUpdates.Single();
+        Assert.IsInstanceOfType(single.Value, typeof(List<BeatInfo>), "the sheet-level Accept still installs the titles");
+        runner.ApplyUpdates(Slice(single), new Dictionary<string, StoryElement>());
+        Assert.AreEqual(2, target.StructureBeats.Count);
+        Assert.AreEqual("The turn", target.StructureBeats[1].Description);
     }
 }

--- a/StoryCADTests/Collaborator/PerBeatAcceptTests.cs
+++ b/StoryCADTests/Collaborator/PerBeatAcceptTests.cs
@@ -1,0 +1,316 @@
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StoryCADLib.Models;
+using StoryCADLib.Models.Tools;
+using StoryCADLib.Services.API;
+using StoryCADLib.Services.Outline;
+using StoryCADLib.ViewModels;
+using StoryCADLib.ViewModels.Tools;
+using StoryCollaborator;
+using StoryCollaborator.Models;
+using StoryCollaborator.Services;
+using StoryCollaborator.Workflows;
+
+#nullable disable
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>
+///     Collaborator #217 section 5.7. The beats proposal becomes one Review pane row per beat
+///     that binds or creates, each its own Accept or Skip, and the run result carries the
+///     model's field_states so classify reads intent instead of falling through to compare.
+/// </summary>
+[TestClass]
+public class PerBeatAcceptTests
+{
+    private static readonly PropertySpec BeatsSpec =
+        new("StructureBeats", WriteVia.BeatSheet, JsonKey: "beats");
+
+    private static StoryCADApi CreateApi() => new(
+        Ioc.Default.GetRequiredService<OutlineService>(),
+        Ioc.Default.GetRequiredService<ListData>(),
+        Ioc.Default.GetRequiredService<ControlData>(),
+        Ioc.Default.GetRequiredService<ToolsData>());
+
+    private static (StoryModel Model, WorkflowRunner Runner) Arrange()
+    {
+        var model = new StoryModel();
+        var api = CreateApi();
+        api.CurrentModel = model;
+        var workflow = new Workflow("ProblemBuilder", "Problem Builder", "test", StoryItemType.Problem)
+        {
+            CreatesScenesForBeats = true
+        };
+        return (model, new WorkflowRunner(model, workflow, api));
+    }
+
+    /// <summary>
+    ///     A sheet of five beats, the first filled, plus one free Scene and one Scene placed on
+    ///     another Problem. The six-row proposal exercises every outcome in order:
+    ///     Keep, Bind, Create, Refuse, Empty, Drop.
+    /// </summary>
+    private static (ProblemModel Target, SceneModel Kept, SceneModel Free, List<BeatInfo> Proposal)
+        EveryOutcome(StoryModel model)
+    {
+        var target = new ProblemModel("Target", model, null) { StructureTitle = "Save The Cat (Mini)" };
+        var kept = new SceneModel("Kept", model, null);
+        var free = new SceneModel("Free", model, null);
+        var placed = new SceneModel("Placed", model, null);
+        var other = new ProblemModel("Other", model, null);
+        other.StructureBeats.Add(new StructureBeat("Row", "") { Guid = placed.Uuid });
+
+        target.StructureBeats.Add(new StructureBeat("Opening Image", "") { Guid = kept.Uuid });
+        target.StructureBeats.Add(new StructureBeat("Theme Stated", ""));
+        target.StructureBeats.Add(new StructureBeat("Set-Up", ""));
+        target.StructureBeats.Add(new StructureBeat("Catalyst", ""));
+        target.StructureBeats.Add(new StructureBeat("Debate", ""));
+
+        var proposal = new List<BeatInfo>
+        {
+            new("Opening Image", "", AssignedElement: free.Uuid),
+            new("Theme Stated", "", AssignedElement: free.Uuid),
+            new("Set-Up", "", SceneName: "Stub"),
+            new("Catalyst", "", AssignedElement: placed.Uuid),
+            new("Debate", ""),
+            new("Extra", "")
+        };
+        return (target, kept, free, proposal);
+    }
+
+    private static WorkflowResult SheetResult(ProblemModel target, List<BeatInfo> proposal)
+    {
+        var result = WorkflowResult.Succeeded();
+        var update = new PendingUpdate("Problem", target.Uuid, BeatsSpec, proposal);
+        result.PendingUpdates.Add(update);
+        result.UpdatedProperties[update.Key] = "6 beats";
+        return result;
+    }
+
+    private static WorkflowResult Slice(params PendingUpdate[] updates)
+    {
+        var slice = WorkflowResult.Succeeded();
+        foreach (var u in updates)
+            slice.PendingUpdates.Add(u);
+        return slice;
+    }
+
+    [TestMethod]
+    public void ExpandBeatSheetUpdates_EveryOutcome_OneRowPerBindOrCreate()
+    {
+        var (model, runner) = Arrange();
+        var (target, _, free, proposal) = EveryOutcome(model);
+        var result = SheetResult(target, proposal);
+
+        runner.ExpandBeatSheetUpdates(result);
+
+        Assert.AreEqual(2, result.PendingUpdates.Count, "Keep, Refuse, Empty and Drop make no row");
+        var bind = result.PendingUpdates[0];
+        var create = result.PendingUpdates[1];
+        Assert.AreEqual("Problem.StructureBeats[1]", bind.Key);
+        Assert.AreEqual("Problem.StructureBeats[2]", create.Key);
+        Assert.AreEqual("Beat 2: Theme Stated", bind.DisplayNameOverride);
+        Assert.AreEqual("Beat 3: Set-Up", create.DisplayNameOverride);
+
+        var bindValue = (BeatRowValue)bind.Value;
+        Assert.AreEqual(free.Uuid, bindValue.BindGuid);
+        Assert.AreEqual("Free", bindValue.ElementName);
+        Assert.AreEqual("Scene", bindValue.ElementType);
+        Assert.AreSame(proposal, bindValue.Sheet, "the row keeps the whole proposal for a sheet install");
+
+        var createValue = (BeatRowValue)create.Value;
+        Assert.IsNull(createValue.BindGuid);
+        Assert.AreEqual("Stub", createValue.Row.SceneName);
+
+        Assert.IsFalse(result.UpdatedProperties.ContainsKey("Problem.StructureBeats"),
+            "the sheet-level display entry is gone");
+        Assert.IsTrue(result.UpdatedProperties.ContainsKey(bind.Key));
+        StringAssert.Contains(string.Join("\n", result.StatusMessages),
+            "6 beats: 1 kept, 1 bound, 1 new scene, 1 empty, 1 refused, 1 dropped");
+        Assert.IsTrue(result.StatusMessages.Any(m => m.Contains("not in candidate set")), "Refuse keeps its status line");
+        Assert.IsTrue(result.StatusMessages.Any(m => m.Contains("not applied, sheet has 5 rows")), "Drop keeps its status line");
+    }
+
+    [TestMethod]
+    public void ValueDisplay_BeatRow_RendersWhatAcceptWillDo()
+    {
+        var (model, runner) = Arrange();
+        var (target, _, _, proposal) = EveryOutcome(model);
+        var result = SheetResult(target, proposal);
+        runner.ExpandBeatSheetUpdates(result);
+
+        Assert.AreEqual("binds Free (Scene)", ValueDisplay.Format(result.PendingUpdates[0].Value));
+        Assert.AreEqual("new Scene \"Stub\"", ValueDisplay.Format(result.PendingUpdates[1].Value));
+    }
+
+    [TestMethod]
+    public void ClassifyScalarUpdates_BeatRow_IsFillWithEmptyCurrent()
+    {
+        var (model, runner) = Arrange();
+        var (target, _, _, proposal) = EveryOutcome(model);
+        var result = SheetResult(target, proposal);
+        runner.ExpandBeatSheetUpdates(result);
+
+        runner.ClassifyScalarUpdates(result, null, "ProblemBuilder");
+
+        Assert.AreEqual(2, result.PendingUpdates.Count);
+        foreach (var row in result.PendingUpdates)
+        {
+            Assert.AreEqual(UpdateKind.Fill, row.Kind, row.Key);
+            Assert.AreEqual("empty", row.CurrentDisplay, row.Key);
+            Assert.IsTrue(row.AcceptAllMayApply, "Accept All and Accept Free Remaining include the row");
+        }
+        Assert.AreEqual("binds Free (Scene)", result.UpdatedProperties["Problem.StructureBeats[1]"]);
+    }
+
+    [TestMethod]
+    public void ApplyUpdates_OneBeatRow_BindsOnlyThatRow()
+    {
+        var (model, runner) = Arrange();
+        var (target, kept, free, proposal) = EveryOutcome(model);
+        var result = SheetResult(target, proposal);
+        runner.ExpandBeatSheetUpdates(result);
+        var bind = result.PendingUpdates[0];
+        var create = result.PendingUpdates[1];
+        var gathered = new Dictionary<string, StoryElement>();
+
+        var applied = runner.ApplyUpdates(Slice(bind), gathered);
+
+        Assert.AreEqual(1, applied);
+        Assert.AreEqual(kept.Uuid, target.StructureBeats[0].Guid, "the filled beat is untouched");
+        Assert.AreEqual(free.Uuid, target.StructureBeats[1].Guid, "the accepted row is bound");
+        Assert.AreEqual(Guid.Empty, target.StructureBeats[2].Guid, "the other row waits for its own Accept");
+        Assert.AreEqual(3, model.StoryElements.OfType<SceneModel>().Count(), "no stub was created");
+
+        applied = runner.ApplyUpdates(Slice(create), gathered);
+
+        Assert.AreEqual(1, applied);
+        var stub = model.StoryElements.OfType<SceneModel>().Single(s => s.Name == "Stub");
+        Assert.AreEqual(stub.Uuid, target.StructureBeats[2].Guid, "the second Accept creates and binds its stub");
+        Assert.AreEqual(5, target.StructureBeats.Count, "the sheet did not grow");
+    }
+
+    [TestMethod]
+    public void ApplyUpdates_BeatRowOnProblemWithNoSheet_InstallsSheetThenBinds()
+    {
+        var (model, runner) = Arrange();
+        var target = new ProblemModel("Target", model, null);
+        var free = new SceneModel("Free", model, null);
+        var proposal = new List<BeatInfo>
+        {
+            new("Opening Image", "Where we start", AssignedElement: free.Uuid),
+            new("Catalyst", "The turn", SceneName: "The letter arrives"),
+            new("Debate", "Second thoughts")
+        };
+        var result = SheetResult(target, proposal);
+        runner.ExpandBeatSheetUpdates(result);
+        Assert.AreEqual(2, result.PendingUpdates.Count);
+        var bind = result.PendingUpdates[0];
+        var create = result.PendingUpdates[1];
+        var gathered = new Dictionary<string, StoryElement>();
+
+        // Accept the second row first: the sheet must exist before any row can bind.
+        var applied = runner.ApplyUpdates(Slice(create), gathered);
+
+        Assert.AreEqual(1, applied);
+        Assert.AreEqual(3, target.StructureBeats.Count, "the first accepted row installs every beat");
+        Assert.AreEqual("Opening Image", target.StructureBeats[0].Title);
+        Assert.AreEqual("Second thoughts", target.StructureBeats[2].Description);
+        var stub = model.StoryElements.OfType<SceneModel>().Single(s => s.Name == "The letter arrives");
+        Assert.AreEqual(stub.Uuid, target.StructureBeats[1].Guid);
+        Assert.AreEqual(Guid.Empty, target.StructureBeats[0].Guid, "the skipped row stays empty");
+
+        applied = runner.ApplyUpdates(Slice(bind), gathered);
+
+        Assert.AreEqual(1, applied);
+        Assert.AreEqual(3, target.StructureBeats.Count, "the sheet is installed once");
+        Assert.AreEqual(free.Uuid, target.StructureBeats[0].Guid);
+    }
+
+    [TestMethod]
+    public void ApplyUpdates_BeatRowWhoseBeatWasFilledMeanwhile_DoesNotApply()
+    {
+        var (model, runner) = Arrange();
+        var (target, _, free, proposal) = EveryOutcome(model);
+        var result = SheetResult(target, proposal);
+        runner.ExpandBeatSheetUpdates(result);
+        var bind = result.PendingUpdates[0];
+        var byHand = new SceneModel("By hand", model, null);
+        target.StructureBeats[1].Guid = byHand.Uuid;
+
+        var applied = runner.ApplyUpdates(Slice(bind), new Dictionary<string, StoryElement>());
+
+        Assert.AreEqual(0, applied, "the row is planned again at apply and finds the beat filled");
+        Assert.AreEqual(byHand.Uuid, target.StructureBeats[1].Guid);
+        Assert.IsFalse(target.StructureBeats.Any(b => b.Guid == free.Uuid));
+    }
+
+    [TestMethod]
+    public void MergeExtractResult_CopiesFieldStates()
+    {
+        var result = WorkflowResult.Succeeded();
+        var extract = WorkflowResult.Succeeded();
+        extract.StatusMessages.Add("Received");
+        extract.PendingUpdates.Add(new PendingUpdate("Problem", Guid.NewGuid(), new PropertySpec("Name"), "x"));
+        extract.UpdatedProperties["Problem.Name"] = "x";
+        extract.FieldStates["Name"] = OutputFieldState.Unchanged;
+
+        WorkflowRunner.MergeExtractResult(result, extract);
+
+        Assert.AreEqual(1, result.StatusMessages.Count);
+        Assert.AreEqual(1, result.PendingUpdates.Count);
+        Assert.AreEqual("x", result.UpdatedProperties["Problem.Name"]);
+        Assert.AreEqual(OutputFieldState.Unchanged, result.FieldStates["Name"]);
+    }
+
+    [TestMethod]
+    public void ClassifyScalarUpdates_AfterMerge_ReadsTheModelsFieldState()
+    {
+        var (model, runner) = Arrange();
+        var problem = new ProblemModel("Catching the drug dealer Lacas", model, null);
+        var elements = new Dictionary<string, StoryElement> { ["Problem"] = problem };
+        var outputs = new List<ElementOutput>
+        {
+            new()
+            {
+                ElementType = StoryItemType.Problem,
+                ElementLabel = "Problem",
+                PropertiesToUpdate = new List<PropertySpec> { new("Name") }
+            }
+        };
+        const string json = "{\"Name\":\"Tracking Lacas\",\"field_states\":{\"Name\":\"Unchanged\"}}";
+
+        // Old merge: pending copied, field_states left behind. Compare sees a different
+        // non-empty Name and protects it, the row the 2026-09-04 smoke showed.
+        var stale = WorkflowResult.Succeeded();
+        foreach (var u in runner.ExtractOutputs(json, elements, outputs).PendingUpdates)
+            stale.PendingUpdates.Add(u);
+        runner.ClassifyScalarUpdates(stale, null, "ProblemBuilder");
+        Assert.AreEqual(UpdateKind.Protect, stale.PendingUpdates.Single().Kind, "without the map, compare protects");
+
+        var merged = WorkflowResult.Succeeded();
+        WorkflowRunner.MergeExtractResult(merged, runner.ExtractOutputs(json, elements, outputs));
+        runner.ClassifyScalarUpdates(merged, null, "ProblemBuilder");
+
+        Assert.AreEqual(0, merged.PendingUpdates.Count, "Unchanged from the model is a NoOp, so the row is dropped");
+    }
+
+    [TestMethod]
+    public void SessionProposalSet_ChatPatch_RenamesAStubAndRefusesABind()
+    {
+        var (model, runner) = Arrange();
+        var (target, _, _, proposal) = EveryOutcome(model);
+        var result = SheetResult(target, proposal);
+        runner.ExpandBeatSheetUpdates(result);
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(result.PendingUpdates, null);
+
+        Assert.IsFalse(set.TryApplyPatch("Problem.StructureBeats[1]", "Something else", out _),
+            "a Bind row names an outline element and takes no free text");
+        Assert.IsTrue(set.TryApplyPatch("Problem.StructureBeats[2]", "The letter arrives", out _));
+
+        var entry = set.Get("Problem.StructureBeats[2]");
+        var value = (BeatRowValue)entry.Update.Value;
+        Assert.AreEqual("The letter arrives", value.Row.SceneName);
+        Assert.AreEqual("new Scene \"The letter arrives\"", entry.ProposedText);
+    }
+}


### PR DESCRIPTION
PR 3 for storybuilder-org/Collaborator#217, from the 2026-09-04 smoke. Design section 5.7 on the issue. Companion Worker change: storybuilder-org/Collaborator#233.

## What changed

- **One Review pane item per beat.** After the model's beats proposal is planned against the live outline, each row that binds an existing element or creates a Scene stub becomes its own pending update, named `Beat 3: Set-Up`, with Proposed `binds Lena refuses the pilot job (Scene)` or `new Scene "Teo counts the fuel drums"` and Yours `empty`. Kept, empty, dropped and refused rows produce no item; refused and dropped rows leave a status line, and one status line carries the sheet summary (`10 beats: 1 kept, 2 bound, 5 new scenes, 2 empty`).
- **Per-beat Accept, Skip, Accept All, Accept Free Remaining.** Row items classify as Fill (`source=plan`), so every existing accept path treats them like any free field. Accept applies that row only. On a Problem with no sheet, the first accepted row installs the proposed sheet's beats (titles and descriptions) and later rows find it present. Each accept re-plans its row against the live outline, so a beat filled by hand between Review and Accept is left alone and the row reports "Failed to apply" instead of pretending.
- **StructureTitle and StructureDescription** stay separate scalar rows, as before.
- **`field_states` now reaches classify.** `RunAsync` merged the extract result's status messages, display strings and pending updates into the run result but never its `FieldStates`, so every classify line since #216 read `source=compare`. The merge is now `MergeExtractResult`, which copies the map, and a test drives extract, merge and classify together and asserts `source=state`. (Former Collaborator #232, folded in.)
- **Chat patch on a beat row.** A "rename that stub" patch from the proposal chat renames a Create row's scene, and the accept creates it under the new name; a patch against a Bind row is refused rather than replacing the typed value with a string.
- **One behavior change to know about.** Before, accepting the sheet also filled a blank description on beats that stayed empty. Now only rows that bind or create are items, so an empty beat's blank description is left blank. A Problem with no sheet and no bindable rows still gets the proposed sheet installed as one item.

An independent review of the first commit found one blocking defect (the chat rename reached the pane but not the apply) and three should-fix items (a re-plan could flip a Bind row into a stub; Review Each walked Beat 11 before Beat 2 past nine rows; a failed row gave no reason). All are fixed in the second commit with tests.

Files: `CollaboratorLib/WorkflowRunner.cs`, `CollaboratorLib/Models/PropertySpec.cs` (`BeatRowValue`, `PendingUpdate.BeatRowIndex`, `DisplayNameOverride`), `CollaboratorLib/Models/ValueDisplay.cs`, `CollaboratorLib/Collaborator.cs`, `CollaboratorLib/Services/SessionProposalSet.cs`, `StoryCADTests/Collaborator/PerBeatAcceptTests.cs`.

## Why

The smoke showed the whole sheet as one Accept or Skip with the review card reading `n. Title — description` and `Yours: (empty)`: the card is built by `ValueDisplay.Format`, a path PR 1 did not touch. Terry had asked for per-beat accept in the #217 discussions. The `field_states` gap was found in the same run.

## How to test

```
"C:\Program Files\Microsoft Visual Studio\18\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe" StoryCADTests\bin\x64\Debug\net10.0-windows10.0.22621\StoryCADTests.dll /Tests:PerBeatAcceptTests,BeatSheetPlanTests,CandidateSetTests,CurrentBeatsInjectionTests,HandoffContractTests,BeatSheetMergeGuardTests,FreeScenePreferenceTests,SceneStubContractTests
```

| Run | Result |
|-----|--------|
| Ten beat-related classes | 54 passed, 0 failed |
| Full suite (Windows head) | 1537 total, 1522 passed, 0 failed, 15 skipped (pre-existing gated integration tests) |

Both heads build. By hand, after Collaborator #233 deploys: run Problem Builder on a subproblem with a partly filled sheet. The pane lists one row per beat that would bind or create; Review Each offers Accept or Skip on each; the Structure tab shows only the accepted beats changed. In the log, classify lines read `source=state` for the keys the model named.

Refs storybuilder-org/Collaborator#217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eWUufU7sGmwotbdr9ML93
