### PR TITLE
fix(Collaborator #237): proposal chat patches reach the list and Accept; chat rules state the mechanism; Try Again sends the rejected proposals

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -891,21 +891,30 @@ public class Collaborator : ICollaborator
                 }
 
                 ChatPatchParser.TryParse(responseText, out var display, out var patches);
-                _chatHistory?.AddAssistantMessage(display);
+                var listChanged = false;
 
                 if (patches.Count > 0 && _sessionProposals != null)
                 {
                     // Collaborator #237 item 5: report what was applied, by name, and what was
                     // not. The old text said "Updated" for every parsed patch, so a key the
                     // session did not know produced a success line over an unchanged list.
+                    // The Scorecard chat of 2026-09-05 added a second way: the model re-sent
+                    // the text already in the list and the app said "Changed". Same text is
+                    // now reported as unchanged.
                     var changed = new List<string>();
+                    var unchanged = new List<string>();
                     var unknown = new List<string>();
                     foreach (var p in patches)
                     {
                         var resolved = _sessionProposals.ResolveKey(p.Key);
-                        if (resolved != null && _sessionProposals.TryApplyPatch(resolved, p.Value, out _))
+                        if (resolved != null &&
+                            _sessionProposals.TryApplyPatch(resolved, p.Value, out var reopened, out var textChanged))
                         {
-                            changed.Add(_sessionProposals.Get(resolved)?.DisplayName ?? resolved);
+                            var name = _sessionProposals.Get(resolved)?.DisplayName ?? resolved;
+                            if (textChanged || reopened)
+                                changed.Add(name);
+                            else
+                                unchanged.Add(name);
                         }
                         else
                         {
@@ -918,17 +927,30 @@ public class Collaborator : ICollaborator
                     if (changed.Count > 0)
                     {
                         var synced = SyncWorkflowResultFromSession();
-                        RefreshProposalSnapshotInHistory();
+                        listChanged = synced;
                         notes.Add(synced
                             ? $"Changed {string.Join(", ", changed)}. The list shows the new text. Accept to write the outline."
                             : $"Changed {string.Join(", ", changed)} in chat only. The list could not be refreshed; run the workflow again.");
                     }
+                    if (unchanged.Count > 0)
+                        notes.Add($"{string.Join(", ", unchanged)} already read that way; nothing changed there.");
                     if (unknown.Count > 0)
                         notes.Add($"No proposal in this run is named {string.Join(", ", unknown)}; nothing changed for it.");
 
                     var note = string.Join(" ", notes);
                     display = string.IsNullOrWhiteSpace(display) ? note : display + "\n\n" + note;
                 }
+                else if (ChatPatchParser.HasUnreadPatchBlock(responseText, patches))
+                {
+                    _logger?.LogWarning("Chat reply named patches but none could be read");
+                    display += "\n\nCollaborator wrote a change the app could not read. Ask for it again.";
+                }
+
+                // The history holds what the writer saw, note included, so the model knows the
+                // app applied its patch. The refreshed snapshot follows the assistant turn.
+                _chatHistory?.AddAssistantMessage(display);
+                if (listChanged)
+                    RefreshProposalSnapshotInHistory();
 
                 _logger?.LogDebug("Assistant response (display): {Response}", display);
                 return display;

--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -209,7 +209,9 @@ public class Collaborator : ICollaborator
                     if (workflowTag is Workflow workflow)
                     {
                         // Short name on top bar (Label, not long Title path).
-                        viewModel.ActiveWorkflowName = FormatWorkflowShortName(workflow.Label);
+                        // Collaborator #237 item 8: one name per workflow everywhere; the
+                        // list shows the title, so the top bar does too.
+                        viewModel.ActiveWorkflowName = workflow.Title;
                         viewModel.HasPendingUpdates = false;
 
                         // Clear shell status; gather cancel has no chat page (#123).
@@ -321,8 +323,11 @@ public class Collaborator : ICollaborator
             var gapDetails = RequiredFieldGapScanner.FindGapDetails(_storyApi, _storyModel);
             if (gapDetails.Count > 0)
             {
+                // Collaborator #237 item 10: the count is the number of missing fields, which is
+                // what the page lists. It used to count elements, so an Overview with five
+                // empty fields read as "(1)".
                 viewModel.MenuItems.Add(WrappingNavItem(
-                    $"{GapWorkflowOwnership.OutlineGapsNavTitle} ({gapDetails.Count})",
+                    $"{GapWorkflowOwnership.OutlineGapsNavTitle} ({RequiredFieldGapScanner.MissingFieldCount(gapDetails)})",
                     GapWorkflowOwnership.OutlineGapsTag));
             }
         }
@@ -890,23 +895,39 @@ public class Collaborator : ICollaborator
 
                 if (patches.Count > 0 && _sessionProposals != null)
                 {
-                    var applied = 0;
+                    // Collaborator #237 item 5: report what was applied, by name, and what was
+                    // not. The old text said "Updated" for every parsed patch, so a key the
+                    // session did not know produced a success line over an unchanged list.
+                    var changed = new List<string>();
+                    var unknown = new List<string>();
                     foreach (var p in patches)
                     {
-                        if (_sessionProposals.TryApplyPatch(p.Key, p.Value, out _))
-                            applied++;
+                        var resolved = _sessionProposals.ResolveKey(p.Key);
+                        if (resolved != null && _sessionProposals.TryApplyPatch(resolved, p.Value, out _))
+                        {
+                            changed.Add(_sessionProposals.Get(resolved)?.DisplayName ?? resolved);
+                        }
                         else
-                            _logger?.LogDebug("Ignored chat patch for unknown key {Key}", p.Key);
+                        {
+                            unknown.Add(p.Key);
+                            _logger?.LogWarning("Ignored chat patch for unknown key {Key}", p.Key);
+                        }
                     }
 
-                    if (applied > 0)
+                    var notes = new List<string>();
+                    if (changed.Count > 0)
                     {
-                        SyncWorkflowResultFromSession();
+                        var synced = SyncWorkflowResultFromSession();
                         RefreshProposalSnapshotInHistory();
-                        display = string.IsNullOrWhiteSpace(display)
-                            ? $"Updated {applied} proposal(s). Accept to write the outline."
-                            : display + $"\n\n({applied} proposal(s) updated — Accept to write the outline.)";
+                        notes.Add(synced
+                            ? $"Changed {string.Join(", ", changed)}. The list shows the new text. Accept to write the outline."
+                            : $"Changed {string.Join(", ", changed)} in chat only. The list could not be refreshed; run the workflow again.");
                     }
+                    if (unknown.Count > 0)
+                        notes.Add($"No proposal in this run is named {string.Join(", ", unknown)}; nothing changed for it.");
+
+                    var note = string.Join(" ", notes);
+                    display = string.IsNullOrWhiteSpace(display) ? note : display + "\n\n" + note;
                 }
 
                 _logger?.LogDebug("Assistant response (display): {Response}", display);
@@ -949,7 +970,10 @@ public class Collaborator : ICollaborator
         _sessionProposals.ReplaceFromPending(result.PendingUpdates, ResolveElementName);
 
         _chatHistory = new ChatHistory();
-        _chatHistory.AddSystemMessage(SessionProposalSet.BuildSystemInstructions(workflow.Title));
+        // Collaborator #237 item 3: the chat knows the run's order, so a change to one
+        // proposal re-derives the ones written after it.
+        _chatHistory.AddSystemMessage(SessionProposalSet.BuildSystemInstructions(
+            workflow.Title, _sessionProposals.All.Select(e => e.DisplayName).ToList()));
         _chatHistory.AddSystemMessage(_sessionProposals.BuildSnapshotText());
 
         viewModel.ConversationList.Clear();
@@ -979,10 +1003,18 @@ public class Collaborator : ICollaborator
     /// Push session proposals into WorkflowResult (open only for Accept) and
     /// Property Updates UI (all statuses so Skip does not blank the panel — #145).
     /// </summary>
-    private void SyncWorkflowResultFromSession()
+    private bool SyncWorkflowResultFromSession()
     {
         if (_sessionProposals == null || _activeWorkflowResult == null || _activeWorkflowViewModel == null)
-            return;
+        {
+            // Collaborator #237 item 5: this used to return in silence, and the caller
+            // reported success anyway. It cannot happen while a chat session is open, so
+            // say so where a log reader will see it.
+            _logger?.LogWarning(
+                "Proposal sync skipped: session={Session} result={Result} viewModel={ViewModel}",
+                _sessionProposals != null, _activeWorkflowResult != null, _activeWorkflowViewModel != null);
+            return false;
+        }
 
         var open = _sessionProposals.OpenAsPendingUpdates().ToList();
         _activeWorkflowResult.PendingUpdates.Clear();
@@ -994,6 +1026,7 @@ public class Collaborator : ICollaborator
         }
 
         PushSessionSetToViewModel(_activeWorkflowViewModel);
+        return true;
     }
 
     /// <summary>
@@ -1146,7 +1179,8 @@ public class Collaborator : ICollaborator
     private async Task ExecuteWorkflowWithFeedback(
         StoryCADLib.Collaborator.ViewModels.WorkflowViewModel viewModel,
         Workflow workflow,
-        Dictionary<string, StoryElement> gatheredElements)
+        Dictionary<string, StoryElement> gatheredElements,
+        string? rejectedProposals = null)
     {
         try
         {
@@ -1160,7 +1194,11 @@ public class Collaborator : ICollaborator
 
             // Execute via WorkflowRunner
             var runnerLogger = _loggerFactory?.CreateLogger<WorkflowRunner>();
-            var runner = new WorkflowRunner(_storyModel!, workflow, _storyApi!, runnerLogger, _settings, _auditLogger);
+            var runner = new WorkflowRunner(_storyModel!, workflow, _storyApi!, runnerLogger, _settings, _auditLogger)
+            {
+                // Collaborator #237 item 11: a Try Again carries what the writer rejected.
+                RejectedProposals = rejectedProposals
+            };
             _auditLogger?.Log(StoryCADLib.Services.Logging.LogLevel.Info,
                 $"Workflow started: {workflow.Title} with {gatheredElements.Count} elements");
             var result = await runner.RunAsync(gatheredElements);
@@ -1402,10 +1440,14 @@ public class Collaborator : ICollaborator
                     {
                         try
                         {
+                            // Collaborator #237 item 11: Try Again means "give me something
+                            // different". Capture the rows the writer saw before they clear, so
+                            // the rerun can tell the model what to depart from.
+                            var rejected = WorkflowRunner.FormatRejectedProposals(viewModel.PendingUpdateItems);
                             stageSession.ClearStage();
                             viewModel.ClearPendingUpdates();
-                            viewModel.AddStatusMessage("Re-running workflow...");
-                            await ExecuteWorkflowWithFeedback(viewModel, workflow, gatheredElements);
+                            viewModel.AddStatusMessage("Re-running workflow for a different result...");
+                            await ExecuteWorkflowWithFeedback(viewModel, workflow, gatheredElements, rejected);
                         }
                         catch (Exception ex)
                         {
@@ -1559,14 +1601,16 @@ public class Collaborator : ICollaborator
                         }
                     };
 
-                    var fillCount = result.PendingUpdates.Count(u => u.Kind is UpdateKind.Fill or UpdateKind.Refresh or UpdateKind.Unclassified);
                     var protectCount = result.PendingUpdates.Count(u => u.Kind == UpdateKind.Protect);
                     // #145: clear chat, seed proposal set, unlock Send; show full set on the left
                     BeginProposalChatSession(viewModel, workflow, result);
                     PushSessionSetToViewModel(viewModel);
+                    // Collaborator #237 item 9: plain words, no em dash, one count.
+                    var replaceNote = protectCount > 0
+                        ? $" {protectCount} of them would replace text you wrote; those ask for confirmation."
+                        : string.Empty;
                     viewModel.ConversationList.Add(ChatMessage.FromCollaborator(
-                        $"Found {result.PendingUpdates.Count} property update(s) " +
-                        $"({fillCount} free, {protectCount} replace existing text — confirmation required). " +
+                        $"Found {result.PendingUpdates.Count} property update(s).{replaceNote} " +
                         "Choose Accept All, Review Each, or Try Again. Chat can revise these proposals."));
                 }
                 else
@@ -1789,9 +1833,6 @@ public class Collaborator : ICollaborator
 
         return null;
     }
-
-    private static string FormatWorkflowShortName(string? label) =>
-        ValueDisplay.SplitPascalCase(label);
 
     /// <summary>Nav group header for a workflow's primary element type (#129).</summary>
     private static string GroupTitle(StoryItemType type) => type switch

--- a/CollaboratorLib/Context/RequiredFieldGapScanner.cs
+++ b/CollaboratorLib/Context/RequiredFieldGapScanner.cs
@@ -17,6 +17,13 @@ public static class RequiredFieldGapScanner
     }
 
     /// <summary>
+    /// Collaborator #237 item 10: the number the Outline gaps nav row shows. It is the number
+    /// of missing fields across every element, which is what the Outline gaps page lists.
+    /// </summary>
+    public static int MissingFieldCount(IReadOnlyList<GapDetail> details) =>
+        details?.Sum(d => d.MissingProperties.Count) ?? 0;
+
+    /// <summary>
     /// Full gap report for the Outline gaps workflow (phase 6).
     /// </summary>
     public static IReadOnlyList<GapDetail> FindGapDetails(IStoryCADAPI api, StoryModel model)

--- a/CollaboratorLib/Services/ChatPatchParser.cs
+++ b/CollaboratorLib/Services/ChatPatchParser.cs
@@ -49,11 +49,10 @@ public static class ChatPatchParser
             TryReadPatchesObject(raw.Trim(), list);
 
         patches = list;
+        // Collaborator #237 item 5: a reply that is only JSON leaves the display empty. The
+        // caller says what changed from what it applied, never from what was parsed; a
+        // parsed patch whose key matched nothing used to be reported as "Updated".
         displayText = CollapseBlankLines(working.Trim());
-        if (string.IsNullOrWhiteSpace(displayText) && list.Count > 0)
-            displayText = list.Count == 1
-                ? $"Updated {list[0].Key}."
-                : $"Updated {list.Count} proposals.";
         return true;
     }
 

--- a/CollaboratorLib/Services/ChatPatchParser.cs
+++ b/CollaboratorLib/Services/ChatPatchParser.cs
@@ -56,11 +56,35 @@ public static class ChatPatchParser
         return true;
     }
 
+    /// <summary>
+    /// Collaborator #237: a reply that names patches but yields none was a silent drop. The
+    /// caller tells the writer the change could not be read instead of saying nothing.
+    /// </summary>
+    public static bool HasUnreadPatchBlock(string? raw, IReadOnlyList<Patch> parsed) =>
+        parsed.Count == 0 &&
+        !string.IsNullOrEmpty(raw) &&
+        raw.Contains("\"patches\"", StringComparison.OrdinalIgnoreCase);
+
+    private static readonly JsonDocumentOptions Lenient = new()
+    {
+        AllowTrailingCommas = true,
+        CommentHandling = JsonCommentHandling.Skip
+    };
+
     private static bool TryReadPatchesObject(string json, List<Patch> into)
+    {
+        // Collaborator #237: models put raw line breaks inside JSON strings (the Concept
+        // what-ifs are one per line). That is invalid JSON and used to drop the whole patch
+        // set. Escape control characters inside strings and parse again before giving up.
+        return TryReadPatchesObjectOnce(json, into) ||
+               TryReadPatchesObjectOnce(EscapeControlCharsInsideStrings(json), into);
+    }
+
+    private static bool TryReadPatchesObjectOnce(string json, List<Patch> into)
     {
         try
         {
-            using var doc = JsonDocument.Parse(json);
+            using var doc = JsonDocument.Parse(json, Lenient);
             if (!doc.RootElement.TryGetProperty("patches", out var arr) ||
                 arr.ValueKind != JsonValueKind.Array)
                 return false;
@@ -85,6 +109,52 @@ public static class ChatPatchParser
         {
             return false;
         }
+    }
+
+    private static string EscapeControlCharsInsideStrings(string json)
+    {
+        var sb = new System.Text.StringBuilder(json.Length + 16);
+        var inString = false;
+        var escaped = false;
+        foreach (var c in json)
+        {
+            if (!inString)
+            {
+                if (c == '"') inString = true;
+                sb.Append(c);
+                continue;
+            }
+            if (escaped)
+            {
+                sb.Append(c);
+                escaped = false;
+                continue;
+            }
+            switch (c)
+            {
+                case '\\':
+                    escaped = true;
+                    sb.Append(c);
+                    break;
+                case '"':
+                    inString = false;
+                    sb.Append(c);
+                    break;
+                case '\n':
+                    sb.Append("\\n");
+                    break;
+                case '\r':
+                    sb.Append("\\r");
+                    break;
+                case '\t':
+                    sb.Append("\\t");
+                    break;
+                default:
+                    sb.Append(c);
+                    break;
+            }
+        }
+        return sb.ToString();
     }
 
     private static string CollapseBlankLines(string s)

--- a/CollaboratorLib/Services/SessionProposalSet.cs
+++ b/CollaboratorLib/Services/SessionProposalSet.cs
@@ -20,6 +20,10 @@ public sealed class SessionProposalSet
     private readonly Dictionary<string, Entry> _entries =
         new(StringComparer.OrdinalIgnoreCase);
 
+    // Collaborator #237 item 3: the run wrote its properties in this order, each from the
+    // ones before it. The snapshot and the chat rules follow it.
+    private readonly List<string> _order = new();
+
     public int Count => _entries.Count;
 
     public bool ContainsKey(string key) => _entries.ContainsKey(key);
@@ -27,7 +31,10 @@ public sealed class SessionProposalSet
     public Entry? Get(string key) =>
         _entries.TryGetValue(key, out var e) ? e : null;
 
-    public IEnumerable<Entry> All => _entries.Values;
+    public IEnumerable<Entry> All => _order.Select(k => _entries[k]);
+
+    /// <summary>Keys in the order the run wrote them.</summary>
+    public IReadOnlyList<string> OrderedKeys => _order;
 
     /// <summary>Replace session set from a new workflow extract (open rows).</summary>
     public void ReplaceFromPending(
@@ -35,14 +42,38 @@ public sealed class SessionProposalSet
         Func<Guid, string?>? resolveElementName = null)
     {
         _entries.Clear();
+        _order.Clear();
         foreach (var u in pending)
         {
             // Keep full outline value at classify time — needed after Skip when the writer
             // asks "what is this field now?" (outline text, not a truncated proposal).
             var outline = u.CurrentDisplay ?? string.Empty;
+            if (!_entries.ContainsKey(u.Key))
+                _order.Add(u.Key);
             _entries[u.Key] = new Entry(
                 u, ProposalSessionStatus.Open, FormatValue(u.Value, resolveElementName), outline);
         }
+    }
+
+    /// <summary>
+    /// Collaborator #237 item 5: the model does not always spell a patch key as
+    /// "ElementLabel.Property". Accept the exact key, a bare property name that matches one
+    /// entry, or a "Label.Property" that matches one entry on its property part. Null when
+    /// nothing matches or the bare name is ambiguous.
+    /// </summary>
+    public string? ResolveKey(string? key)
+    {
+        if (string.IsNullOrWhiteSpace(key)) return null;
+        var wanted = key.Trim();
+        if (_entries.TryGetValue(wanted, out var exact))
+            return exact.Update.Key;
+
+        var property = wanted.Contains('.') ? wanted[(wanted.LastIndexOf('.') + 1)..] : wanted;
+        var matches = _order
+            .Where(k => string.Equals(_entries[k].Update.Spec.Property, property, StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(_entries[k].DisplayName, property, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        return matches.Count == 1 ? matches[0] : null;
     }
 
     public void MarkAccepted(string key)
@@ -64,8 +95,10 @@ public sealed class SessionProposalSet
     public bool TryApplyPatch(string key, string newValue, out bool reopened)
     {
         reopened = false;
-        if (!_entries.TryGetValue(key, out var e))
+        var resolved = ResolveKey(key);
+        if (resolved == null || !_entries.TryGetValue(resolved, out var e))
             return false;
+        key = resolved;
 
         reopened = e.Status is ProposalSessionStatus.Accepted or ProposalSessionStatus.Skipped;
         object? patched = newValue;
@@ -109,12 +142,12 @@ public sealed class SessionProposalSet
             return "(No proposals in this session.)";
 
         var sb = new StringBuilder();
-        sb.AppendLine("Property proposals for this workflow run.");
-        sb.AppendLine("For each key: status, Collaborator proposed text, and outline value when the run classified the field.");
+        sb.AppendLine("Property proposals for this workflow run, in the order the run wrote them.");
+        sb.AppendLine("For each proposal: its name, status, patch key, Collaborator proposed text, and outline value when the run classified the field.");
         sb.AppendLine("If status is skipped, the writer kept the outline value (use Outline for \"as it is now\").");
         sb.AppendLine("If status is accepted, the outline should match what was accepted (use Proposed if Outline empty).");
         sb.AppendLine();
-        foreach (var e in _entries.Values.OrderBy(x => x.Update.Key, StringComparer.OrdinalIgnoreCase))
+        foreach (var e in All)
         {
             var status = e.Status switch
             {
@@ -123,7 +156,7 @@ public sealed class SessionProposalSet
                 ProposalSessionStatus.Skipped => "skipped",
                 _ => "?"
             };
-            sb.AppendLine($"### {e.Update.Key} [{status}]");
+            sb.AppendLine($"### {e.DisplayName} [{status}] (patch key: {e.Update.Key})");
             sb.AppendLine("Proposed (Collaborator):");
             sb.AppendLine(Cap(e.ProposedText, maxValueChars));
             sb.AppendLine("Outline (value on the story element when classified):");
@@ -148,20 +181,42 @@ public sealed class SessionProposalSet
         _entries.Values.Count(e => e.Status == ProposalSessionStatus.Open);
 
     public static string BuildSystemInstructions(string workflowTitle) =>
-        "You help revise property proposals from the '" + workflowTitle + "' workflow run. " +
-        "This is not general story chat and you do not have the full outline loaded beyond the snapshot.\n\n" +
-        "Rules:\n" +
-        "- Answer the writer in plain text only (no Markdown).\n" +
-        "- The snapshot gives, for each key: status, Proposed (Collaborator), and Outline (story element when classified).\n" +
-        "- If the writer asks what a field is \"now\" and status is skipped, quote the full Outline text from the snapshot.\n" +
-        "- If status is open, quote Proposed (and Outline if they ask what is already on the element).\n" +
-        "- If status is accepted, prefer Proposed as what was written.\n" +
-        "- You may only change keys listed in the property proposals snapshot.\n" +
-        "- If the writer wants a field changed, include a JSON block (optionally fenced) of the form: " +
-        "{\"patches\":[{\"key\":\"ElementLabel.Property\",\"value\":\"new text\"}]}\n" +
-        "- If the request is not about those proposals, say clearly it is out of scope for this chat. " +
-        "Do not invent patches. Suggest Accept, Try Again, another workflow, or editing the outline.\n" +
-        "- Do not invent element IDs or properties outside the proposal list. Do not claim text is missing if Outline or Proposed is present in the snapshot.";
+        BuildSystemInstructions(workflowTitle, Array.Empty<string>());
+
+    /// <summary>
+    /// Chat rules. <paramref name="orderedNames"/> lists the proposals in the order the run
+    /// wrote them (Collaborator #237 item 3): a change to one re-derives every proposal after
+    /// it. One name or none adds no order rule.
+    /// </summary>
+    public static string BuildSystemInstructions(string workflowTitle, IReadOnlyList<string> orderedNames)
+    {
+        var text =
+            "You help revise property proposals from the '" + workflowTitle + "' workflow run. " +
+            "This is not general story chat and you do not have the full outline loaded beyond the snapshot.\n\n" +
+            "Rules:\n" +
+            "- Answer the writer in plain text only (no Markdown).\n" +
+            "- The snapshot gives, for each proposal: its name, status, patch key, Proposed (Collaborator), and Outline (story element when classified).\n" +
+            "- When you talk to the writer, call a proposal by its name (for example Concept). Do not show the writer a patch key or a status word. The patch key belongs only inside the patches JSON.\n" +
+            "- If the writer asks what a field is \"now\" and status is skipped, quote the full Outline text from the snapshot.\n" +
+            "- If status is open, quote Proposed (and Outline if they ask what is already on the element).\n" +
+            "- If status is accepted, prefer Proposed as what was written.\n" +
+            "- You may only change proposals listed in the snapshot.\n" +
+            "- If the writer wants a field changed, include a JSON block (optionally fenced) of the form: " +
+            "{\"patches\":[{\"key\":\"ElementLabel.Property\",\"value\":\"new text\"}]}\n";
+        if (orderedNames.Count > 1)
+        {
+            text +=
+                "- The run wrote the proposals in this order, each from the ones before it: " +
+                string.Join(", ", orderedNames) + ". " +
+                "When you change one, also rewrite every proposal after it in that order so it follows from the change, " +
+                "and include a patch for each proposal you rewrote.\n";
+        }
+        text +=
+            "- If the request is not about those proposals, say clearly it is out of scope for this chat. " +
+            "Do not invent patches. Suggest Accept, Try Again, another workflow, or editing the outline.\n" +
+            "- Do not invent element IDs or properties outside the proposal list. Do not claim text is missing if Outline or Proposed is present in the snapshot.";
+        return text;
+    }
 
     /// <summary>
     /// Human-readable proposal text. Must not use object.ToString() on lists
@@ -174,5 +229,9 @@ public sealed class SessionProposalSet
         PendingUpdate Update,
         ProposalSessionStatus Status,
         string ProposedText,
-        string OutlineText);
+        string OutlineText)
+    {
+        /// <summary>The name the pane shows for this proposal.</summary>
+        public string DisplayName => Update.DisplayNameOverride ?? Update.Spec.Property;
+    }
 }

--- a/CollaboratorLib/Services/SessionProposalSet.cs
+++ b/CollaboratorLib/Services/SessionProposalSet.cs
@@ -92,9 +92,20 @@ public sealed class SessionProposalSet
     /// Apply a chat patch. Re-opens Accepted/Skipped as Open.
     /// Returns false if key is not in the session set.
     /// </summary>
-    public bool TryApplyPatch(string key, string newValue, out bool reopened)
+    public bool TryApplyPatch(string key, string newValue, out bool reopened) =>
+        TryApplyPatch(key, newValue, out reopened, out _);
+
+    /// <summary>
+    /// Apply a chat patch and say whether the text differs from what the list already shows.
+    /// Collaborator #237: the Scorecard chat of 2026-09-05 re-sent the text already in the
+    /// list, and the app answered "Changed Concept, Premise." over a list that looked the same.
+    /// <paramref name="changed"/> is false when the patch text equals the current proposed
+    /// text after line-ending and edge-whitespace normalization.
+    /// </summary>
+    public bool TryApplyPatch(string key, string newValue, out bool reopened, out bool changed)
     {
         reopened = false;
+        changed = false;
         var resolved = ResolveKey(key);
         if (resolved == null || !_entries.TryGetValue(resolved, out var e))
             return false;
@@ -112,6 +123,7 @@ public sealed class SessionProposalSet
             patched = row with { Row = row.Row with { SceneName = newValue } };
             proposedText = FormatValue(patched);
         }
+        changed = !string.Equals(Normalize(proposedText), Normalize(e.ProposedText), StringComparison.Ordinal);
         var updatedUpdate = e.Update with { Value = patched };
         _entries[key] = e with
         {
@@ -168,6 +180,9 @@ public sealed class SessionProposalSet
         return sb.ToString().TrimEnd();
     }
 
+    private static string Normalize(string? text) =>
+        (text ?? string.Empty).Replace("\r\n", "\n").Trim();
+
     private static string Cap(string? text, int maxValueChars)
     {
         var val = text ?? string.Empty;
@@ -187,22 +202,46 @@ public sealed class SessionProposalSet
     /// Chat rules. <paramref name="orderedNames"/> lists the proposals in the order the run
     /// wrote them (Collaborator #237 item 3): a change to one re-derives every proposal after
     /// it. One name or none adds no order rule.
+    /// Collaborator #237: the Scorecard chat of 2026-09-05 told the writer "I can't see or
+    /// control your patch system" and asked the writer to apply the patches. The model was
+    /// never told that the app applies its patches JSON to the list. The mechanism is stated
+    /// first, and the rules forbid handing that work back to the writer.
     /// </summary>
     public static string BuildSystemInstructions(string workflowTitle, IReadOnlyList<string> orderedNames)
     {
         var text =
             "You help revise property proposals from the '" + workflowTitle + "' workflow run. " +
             "This is not general story chat and you do not have the full outline loaded beyond the snapshot.\n\n" +
+            "How this chat works:\n" +
+            "- The snapshot is the proposal list the writer sees on screen. For each proposal it gives: its name, status, patch key, Proposed (Collaborator), and Outline (story element when classified).\n" +
+            "- The app reads the patches JSON out of your reply, replaces the proposal text in the list with each patch value, and hides the JSON from the writer. Your patch is the change. Nothing else changes the list.\n" +
+            "- After the app applies a patch it adds an \"Updated property proposals\" snapshot to this conversation. The latest snapshot is what the writer sees now.\n\n" +
             "Rules:\n" +
             "- Answer the writer in plain text only (no Markdown).\n" +
-            "- The snapshot gives, for each proposal: its name, status, patch key, Proposed (Collaborator), and Outline (story element when classified).\n" +
             "- When you talk to the writer, call a proposal by its name (for example Concept). Do not show the writer a patch key or a status word. The patch key belongs only inside the patches JSON.\n" +
+            "- If the writer wants a field changed, include a JSON block (optionally fenced) of the form: " +
+            "{\"patches\":[{\"key\":\"ElementLabel.Property\",\"value\":\"new text\"}]}. " +
+            "The value is the complete new text for that proposal, ready to write to the outline: not a summary of the change, not a diff. " +
+            "Keep line breaks as \\n inside the JSON string. A reply without patches JSON changes nothing.\n" +
+            "- Tell the writer in one or two sentences what you changed and why. " +
+            "Never tell the writer to apply, paste, re-run, or accept a patch; the app already applied it. " +
+            "Never say you cannot see or change the list; the latest snapshot is the list.\n" +
+            "- If the writer says a change is not there, compare the request with the latest snapshot. " +
+            "If the snapshot already has the change, say which proposal has it and quote the changed sentence. " +
+            "If it does not, send the patch again with the complete new text.\n" +
             "- If the writer asks what a field is \"now\" and status is skipped, quote the full Outline text from the snapshot.\n" +
             "- If status is open, quote Proposed (and Outline if they ask what is already on the element).\n" +
             "- If status is accepted, prefer Proposed as what was written.\n" +
-            "- You may only change proposals listed in the snapshot.\n" +
-            "- If the writer wants a field changed, include a JSON block (optionally fenced) of the form: " +
-            "{\"patches\":[{\"key\":\"ElementLabel.Property\",\"value\":\"new text\"}]}\n";
+            "- You may only change proposals listed in the snapshot.\n";
+        // Collaborator #237: the Scorecard chat of 2026-09-05 was asked to make the mother the
+        // protagonist. The run's Description proposal named a stadium employee, the order rule
+        // said later proposals follow earlier ones, and the model kept the employee. The
+        // writer's request outranks the proposals, and a role change starts where the role is set.
+        text +=
+            "- The writer's request outranks every proposal in the snapshot. " +
+            "If the request contradicts an earlier proposal (for example who the protagonist is, what they want, or what happens), " +
+            "rewrite that earlier proposal too, starting at the first proposal that states it, and then every proposal after it. " +
+            "Do not keep a role, a name, or an event from an earlier proposal that the writer asked you to change.\n";
         if (orderedNames.Count > 1)
         {
             text +=

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -102,6 +102,13 @@ namespace StoryCollaborator
         private CollaboratorSettings _settings;
         private readonly StoryCADLib.Services.Logging.ILogService? _auditLogger;
 
+        /// <summary>
+        /// Collaborator #237 item 11: the proposals the writer rejected with Try Again, one
+        /// "Property: value" line each. Null on a first run. When set, RunAsync sends it as
+        /// the RejectedProposals arg and the Worker tells the model to depart from it.
+        /// </summary>
+        internal string? RejectedProposals { get; set; }
+
         // No Kernel field: issue #90 step 8 item 5 retired the direct-OpenAI Semantic Kernel
         // invocation path (InvokeDirectAsync), which was the only reason this class held one.
         // PostToProxyAsync talks to the Worker over plain HttpClient, never through SK.
@@ -193,6 +200,7 @@ namespace StoryCollaborator
 
                 EnrichWithStoryContext(body.Args, gatheredElements, workflowIO);
                 ApplySettings(body.Args);
+                ApplyRejectedProposals(body.Args);
 
                 if (workflowIO.ExampleLists.Count > 0)
                     EnrichWithExamples(body.Args);
@@ -2797,6 +2805,36 @@ namespace StoryCollaborator
                 _logger?.LogWarning($"Failed to enrich story context: {ex.Message}");
                 args["StoryContext"] = string.Empty;
             }
+        }
+
+        /// <summary>
+        /// Collaborator #237 item 11: Try Again means "give me something different". Puts the
+        /// rejected proposals on the wire as RejectedProposals; the Worker appends a TRY AGAIN
+        /// section that tells the model to depart from them. A first run adds nothing.
+        /// </summary>
+        internal void ApplyRejectedProposals(Dictionary<string, string> args)
+        {
+            if (string.IsNullOrWhiteSpace(RejectedProposals)) return;
+            args["RejectedProposals"] = RejectedProposals;
+        }
+
+        /// <summary>
+        /// Renders the pane's proposal rows as the RejectedProposals text: one line per row,
+        /// "DisplayName: proposed value". Rows with no proposed text are skipped. Each value is
+        /// cut at 4,000 characters so a beat sheet cannot double the prompt.
+        /// </summary>
+        internal static string FormatRejectedProposals(IEnumerable<StoryCADLib.Collaborator.Models.PendingUpdateItem> rows)
+        {
+            const int maxValueLength = 4000;
+            var lines = new List<string>();
+            foreach (var row in rows)
+            {
+                var value = (row.ProposedDisplay ?? string.Empty).Trim();
+                if (value.Length == 0) continue;
+                if (value.Length > maxValueLength) value = value[..maxValueLength];
+                lines.Add($"{row.DisplayName}: {value}");
+            }
+            return string.Join("\n", lines);
         }
 
         /// <summary>

--- a/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
+++ b/StoryCADLib/Collaborator/ViewModels/WorkflowViewModel.cs
@@ -190,11 +190,15 @@ public partial class WorkflowViewModel : ObservableRecipient
         }
         else if (HasPendingUpdates && PendingUpdateItems != null)
         {
+            // Collaborator #237 item 9: one count, stated once; the header on the list
+            // carries the total only.
             var total = PendingUpdateItems.Count;
             var needReview = PendingUpdateItems.Count(i => i.IsProtected);
-            var free = total - needReview;
+            var review = needReview > 0
+                ? $" {needReview} would replace text you wrote; review those before accepting."
+                : string.Empty;
             parts.Add(
-                $"{total} property update(s) ({free} free, {needReview} need review). " +
+                $"{total} property update(s) proposed.{review} " +
                 "Use Accept All, Review Each, or Try Again.");
         }
         else if (UpdatesApplied)
@@ -230,10 +234,7 @@ public partial class WorkflowViewModel : ObservableRecipient
             if (PendingUpdateItems == null || PendingUpdateItems.Count == 0)
                 return "Proposed property updates";
 
-            var total = PendingUpdateItems.Count;
-            var needReview = PendingUpdateItems.Count(i => i.IsProtected);
-            var free = total - needReview;
-            return $"Proposed property updates ({total}: {free} free, {needReview} need review)";
+            return $"Proposed property updates ({PendingUpdateItems.Count})";
         }
     }
 

--- a/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
+++ b/StoryCADLib/Collaborator/Views/WorkflowPage.xaml
@@ -282,15 +282,17 @@
             <!-- Accept All: primary action for the table, at the foot of the work column.
                  Accepted updates are written to the outline immediately, so there is no
                  separate Save button on the shell bar. -->
+            <!-- Collaborator #237 item 9: the button carries the same name the status line
+                 and the chat use for it. -->
             <Button Grid.Row="3"
-                    Content="Accept all changes"
+                    Content="Accept All"
                     Command="{x:Bind ViewModel.AcceptAllCommand}"
                     IsEnabled="{x:Bind ViewModel.HasPendingUpdates, Mode=OneWay}"
                     Style="{ThemeResource AccentButtonStyle}"
                     HorizontalAlignment="Stretch"
                     Margin="0,10,0,0"
                     AutomationProperties.AutomationId="WorkflowAcceptAllButton"
-                    AutomationProperties.Name="Accept all changes" />
+                    AutomationProperties.Name="Accept All" />
         </Grid>
 
         <!-- ========== Chat column (own height; input does not affect work column) ========== -->

--- a/StoryCADLib/Controls/RichEditBoxExtended.WinAppSDK.cs
+++ b/StoryCADLib/Controls/RichEditBoxExtended.WinAppSDK.cs
@@ -69,6 +69,18 @@ public partial class RichEditBoxExtended : RichEditBox
             return;
         }
 
+        // Collaborator #237 items 6 and 7. RichEditBox raises TextChanged after a programmatic
+        // SetText returns, so the lock above does not cover it. Without a focus check the
+        // handler then writes the document back over the bound property: as RTF when the box
+        // rendered the plain text Collaborator wrote (the Scorecard S01 file held Concept as RTF
+        // and Premise as plain text, one box realized and one not), and as "" when the box had
+        // not rendered it yet (an empty page over accepted text, and SaveModel then wrote the
+        // empties to the outline). Only the writer changes text, and the writer has focus.
+        if (FocusState == FocusState.Unfocused)
+        {
+            return;
+        }
+
         _lockChangeExecution = true;
         Document.GetText(TextGetOptions.None, out var plain);
         if (string.IsNullOrWhiteSpace(plain))

--- a/StoryCADTests/Collaborator/ChatPatchParserTests.cs
+++ b/StoryCADTests/Collaborator/ChatPatchParserTests.cs
@@ -55,4 +55,16 @@ public class ChatPatchParserTests
         Assert.AreEqual("Overview.Concept", patches[0].Key);
         Assert.IsFalse(display.Contains("```"));
     }
+
+    [TestMethod]
+    public void TryParse_JsonOnly_LeavesTheDisplayEmpty()
+    {
+        // Collaborator #237 item 5: the parser used to write "Updated 2 proposals." for a
+        // JSON-only reply before anything was applied. The caller reports from what it applied.
+        var raw = "{\"patches\":[{\"key\":\"Overview.Concept\",\"value\":\"A\"},{\"key\":\"Overview.Premise\",\"value\":\"B\"}]}";
+
+        Assert.IsTrue(ChatPatchParser.TryParse(raw, out var display, out var patches));
+        Assert.AreEqual(2, patches.Count);
+        Assert.AreEqual(string.Empty, display);
+    }
 }

--- a/StoryCADTests/Collaborator/ChatPatchParserTests.cs
+++ b/StoryCADTests/Collaborator/ChatPatchParserTests.cs
@@ -56,6 +56,42 @@ public class ChatPatchParserTests
         Assert.IsFalse(display.Contains("```"));
     }
 
+    // Collaborator #237: a raw line break inside a JSON string is invalid JSON. The Concept
+    // what-ifs are one per line, so a model that does not escape them dropped every patch.
+    [TestMethod]
+    public void TryParse_RawLineBreaksInsideValue_StillReads()
+    {
+        var raw = "Done.\n{\"patches\":[{\"key\":\"Overview.Concept\",\"value\":\"What if A?\nWhat if B?\"}]}";
+
+        Assert.IsTrue(ChatPatchParser.TryParse(raw, out var display, out var patches));
+        Assert.AreEqual(1, patches.Count);
+        Assert.AreEqual("What if A?\nWhat if B?", patches[0].Value);
+        Assert.AreEqual("Done.", display);
+    }
+
+    [TestMethod]
+    public void TryParse_TrailingComma_StillReads()
+    {
+        var raw = "{\"patches\":[{\"key\":\"Overview.Concept\",\"value\":\"A\"},]}";
+
+        Assert.IsTrue(ChatPatchParser.TryParse(raw, out _, out var patches));
+        Assert.AreEqual(1, patches.Count);
+    }
+
+    [TestMethod]
+    public void HasUnreadPatchBlock_TrueOnlyWhenPatchesNamedButNoneParsed()
+    {
+        var broken = "{\"patches\":[{\"key\":\"Overview.Concept\",\"value\":\"A\"}";
+        ChatPatchParser.TryParse(broken, out _, out var none);
+        Assert.AreEqual(0, none.Count);
+        Assert.IsTrue(ChatPatchParser.HasUnreadPatchBlock(broken, none));
+
+        Assert.IsFalse(ChatPatchParser.HasUnreadPatchBlock("No changes.", none));
+
+        ChatPatchParser.TryParse("{\"patches\":[{\"key\":\"Overview.Concept\",\"value\":\"A\"}]}", out _, out var one);
+        Assert.IsFalse(ChatPatchParser.HasUnreadPatchBlock("irrelevant", one));
+    }
+
     [TestMethod]
     public void TryParse_JsonOnly_LeavesTheDisplayEmpty()
     {

--- a/StoryCADTests/Collaborator/RequiredFieldGapScannerTests.cs
+++ b/StoryCADTests/Collaborator/RequiredFieldGapScannerTests.cs
@@ -23,6 +23,25 @@ public class RequiredFieldGapScannerTests
         Ioc.Default.GetRequiredService<ToolsData>());
 
     [TestMethod]
+    public void MissingFieldCount_SumsFieldsAcrossElements_NotElements()
+    {
+        // Collaborator #237 item 10: the nav row read "Outline gaps (1)" for an Overview with
+        // five empty fields, because it counted elements. The page lists fields, so the count
+        // is fields.
+        var api = CreateApi();
+        var model = new StoryModel();
+        api.CurrentModel = model;
+        _ = new OverviewModel("Scorecard", model, null); // the base constructor registers it
+
+        var details = RequiredFieldGapScanner.FindGapDetails(api, model);
+
+        Assert.AreEqual(1, details.Count, "one element has gaps");
+        Assert.AreEqual(details[0].MissingProperties.Count, RequiredFieldGapScanner.MissingFieldCount(details));
+        Assert.IsTrue(RequiredFieldGapScanner.MissingFieldCount(details) > 1, "the Overview has more than one empty field");
+        Assert.AreEqual(0, RequiredFieldGapScanner.MissingFieldCount(Array.Empty<GapDetail>()));
+    }
+
+    [TestMethod]
     public void Problem_BlankScalars_Includes_ProblemType_ConflictType_Subject()
     {
         var api = CreateApi();

--- a/StoryCADTests/Collaborator/SessionProposalSetTests.cs
+++ b/StoryCADTests/Collaborator/SessionProposalSetTests.cs
@@ -142,4 +142,107 @@ public class SessionProposalSetTests
         StringAssert.Contains(text, "A tries to impose order");
         Assert.IsFalse(text.Contains(partnerGuid.ToString("D"), StringComparison.Ordinal), text);
     }
+
+    // Collaborator #237 item 5: the Scorecard S01 chat said "Updated 2 proposals." while the
+    // list and the file kept the originals. A patch key the session did not know was one way
+    // to get there. Keys now resolve by exact key, by bare property name, or by the property
+    // part of a Label.Property key, when the match is unique.
+    [TestMethod]
+    public void ResolveKey_ExactKey_ReturnsIt()
+    {
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(new[] { Make("Overview", "Concept", "A"), Make("Overview", "Premise", "B") });
+
+        Assert.AreEqual("Overview.Concept", set.ResolveKey("overview.concept"));
+    }
+
+    [TestMethod]
+    public void ResolveKey_BarePropertyName_MatchesTheOneEntry()
+    {
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(new[] { Make("Overview", "Concept", "A"), Make("Overview", "Premise", "B") });
+
+        Assert.AreEqual("Overview.Premise", set.ResolveKey("Premise"));
+        Assert.AreEqual("Overview.Premise", set.ResolveKey("StoryOverview.Premise"));
+    }
+
+    [TestMethod]
+    public void ResolveKey_AmbiguousOrUnknown_IsNull()
+    {
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(new[] { Make("Problem", "Name", "A"), Make("Character", "Name", "B") });
+
+        Assert.IsNull(set.ResolveKey("Name"), "two entries share the property name");
+        Assert.IsNull(set.ResolveKey("Theme"));
+        Assert.IsNull(set.ResolveKey(""));
+    }
+
+    [TestMethod]
+    public void TryApplyPatch_BarePropertyName_PatchesTheEntry()
+    {
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(new[] { Make("Overview", "Concept", "Five what-ifs") });
+
+        Assert.IsTrue(set.TryApplyPatch("Concept", "One what-if and two follow-ons", out _));
+        Assert.AreEqual("One what-if and two follow-ons", set.Get("Overview.Concept")!.ProposedText);
+        Assert.AreEqual("One what-if and two follow-ons", set.OpenAsPendingUpdates().Single().Value);
+    }
+
+    // Collaborator #237 item 3: the run's order is the dependency order, so the chat is told
+    // it and told to re-derive everything after a change.
+    [TestMethod]
+    public void All_And_Snapshot_KeepTheRunOrder_NotAlphabetical()
+    {
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(new[]
+        {
+            Make("Overview", "Description", "idea"),
+            Make("Overview", "Concept", "what if"),
+            Make("Overview", "Premise", "one sentence")
+        });
+
+        CollectionAssert.AreEqual(
+            new[] { "Overview.Description", "Overview.Concept", "Overview.Premise" },
+            set.OrderedKeys.ToList());
+        CollectionAssert.AreEqual(
+            new[] { "Description", "Concept", "Premise" },
+            set.All.Select(e => e.DisplayName).ToList());
+
+        var snap = set.BuildSnapshotText();
+        Assert.IsTrue(snap.IndexOf("### Description", StringComparison.Ordinal) < snap.IndexOf("### Concept", StringComparison.Ordinal));
+        Assert.IsTrue(snap.IndexOf("### Concept", StringComparison.Ordinal) < snap.IndexOf("### Premise", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void BuildSnapshotText_NamesTheProposal_AndCarriesThePatchKeyAside()
+    {
+        // Collaborator #237 item 9: the writer saw "Concept (Overview.Concept)" and "Open" in
+        // chat. The heading leads with the name; the key is labelled as the patch key.
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(new[] { Make("Overview", "Concept", "what if") });
+
+        var snap = set.BuildSnapshotText();
+        StringAssert.Contains(snap, "### Concept [open] (patch key: Overview.Concept)");
+    }
+
+    [TestMethod]
+    public void BuildSystemInstructions_StatesTheOrder_AndTheDownstreamRule()
+    {
+        var text = SessionProposalSet.BuildSystemInstructions(
+            "Ideation (Story idea => Concept => Premise)", new[] { "Description", "Concept", "Premise" });
+
+        StringAssert.Contains(text, "in this order, each from the ones before it: Description, Concept, Premise.");
+        StringAssert.Contains(text, "also rewrite every proposal after it in that order");
+        StringAssert.Contains(text, "call a proposal by its name");
+        StringAssert.Contains(text, "Do not show the writer a patch key or a status word");
+    }
+
+    [TestMethod]
+    public void BuildSystemInstructions_OneProposal_HasNoOrderRule()
+    {
+        var text = SessionProposalSet.BuildSystemInstructions("Story Form", new[] { "StoryType" });
+
+        Assert.IsFalse(text.Contains("in this order"), text);
+        StringAssert.Contains(text, "patches");
+    }
 }

--- a/StoryCADTests/Collaborator/SessionProposalSetTests.cs
+++ b/StoryCADTests/Collaborator/SessionProposalSetTests.cs
@@ -245,4 +245,53 @@ public class SessionProposalSetTests
         Assert.IsFalse(text.Contains("in this order"), text);
         StringAssert.Contains(text, "patches");
     }
+
+    // Collaborator #237: the Scorecard chat of 2026-09-05 said "I can't see or control your
+    // patch system's current state" and told the writer to apply the patches. The model was
+    // never told the app applies its JSON to the list.
+    [TestMethod]
+    public void BuildSystemInstructions_SaysTheAppAppliesPatches_AndForbidsHandingWorkBack()
+    {
+        var text = SessionProposalSet.BuildSystemInstructions("Ideation", new[] { "Concept", "Premise" });
+
+        StringAssert.Contains(text, "The app reads the patches JSON out of your reply");
+        StringAssert.Contains(text, "complete new text");
+        StringAssert.Contains(text, "Never tell the writer to apply");
+        StringAssert.Contains(text, "Never say you cannot see or change the list");
+        StringAssert.Contains(text, "If the writer says a change is not there");
+    }
+
+    // Same session: asked to make the mother the protagonist, the model kept the stadium
+    // employee the run's Description proposal had named, because the order rule said later
+    // proposals follow earlier ones. The writer's request outranks the proposals.
+    [TestMethod]
+    public void BuildSystemInstructions_WriterRequestOutranksEarlierProposals()
+    {
+        var text = SessionProposalSet.BuildSystemInstructions(
+            "Ideation (Story idea => Concept => Premise)", new[] { "Description", "Concept", "Premise" });
+
+        StringAssert.Contains(text, "The writer's request outranks every proposal in the snapshot.");
+        StringAssert.Contains(text, "rewrite that earlier proposal too");
+        StringAssert.Contains(text, "Do not keep a role, a name, or an event from an earlier proposal");
+        Assert.IsTrue(
+            text.IndexOf("outranks every proposal", StringComparison.Ordinal) <
+            text.IndexOf("in this order, each from the ones before it", StringComparison.Ordinal),
+            "the request rule comes before the order rule");
+    }
+
+    // Same session: the model re-sent the text already in the list and the app answered
+    // "Changed Concept, Premise." over a list that looked the same.
+    [TestMethod]
+    public void TryApplyPatch_SameText_AppliesButReportsUnchanged()
+    {
+        var set = new SessionProposalSet();
+        set.ReplaceFromPending(new[] { Make("Overview", "Concept", "What if A?\nWhat if B?") });
+
+        Assert.IsTrue(set.TryApplyPatch("Overview.Concept", "What if A?\r\nWhat if B?\n", out _, out var changed));
+        Assert.IsFalse(changed, "line endings and edge whitespace do not make a change");
+
+        Assert.IsTrue(set.TryApplyPatch("Overview.Concept", "What if C?", out _, out changed));
+        Assert.IsTrue(changed);
+        Assert.AreEqual("What if C?", set.Get("Overview.Concept")!.ProposedText);
+    }
 }

--- a/StoryCADTests/Collaborator/TryAgainRejectedProposalsTests.cs
+++ b/StoryCADTests/Collaborator/TryAgainRejectedProposalsTests.cs
@@ -1,0 +1,120 @@
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StoryCADLib.Collaborator.Models;
+using StoryCADLib.Models;
+using StoryCADLib.Models.Tools;
+using StoryCADLib.Services.API;
+using StoryCADLib.Services.Outline;
+using StoryCADLib.ViewModels;
+using StoryCollaborator;
+using StoryCollaborator.Workflows;
+
+#nullable disable
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>
+///     Collaborator #237 item 11. Try Again means "give me something different". The runner
+///     puts the rejected proposals on the wire as the RejectedProposals arg, and the pane's
+///     rows render to that text one "DisplayName: value" line each. A first run sends nothing.
+/// </summary>
+[TestClass]
+public class TryAgainRejectedProposalsTests
+{
+    private static WorkflowRunner CreateRunner()
+    {
+        var model = new StoryModel();
+        var api = new StoryCADApi(
+            Ioc.Default.GetRequiredService<OutlineService>(),
+            Ioc.Default.GetRequiredService<ListData>(),
+            Ioc.Default.GetRequiredService<ControlData>(),
+            Ioc.Default.GetRequiredService<ToolsData>());
+        api.CurrentModel = model;
+        var workflow = new Workflow("Premise", "Ideation (Story idea => Concept => Premise)", "test", StoryItemType.StoryOverview);
+        return new WorkflowRunner(model, workflow, api);
+    }
+
+    [TestMethod]
+    public void ApplyRejectedProposals_FirstRun_AddsNoArg()
+    {
+        var runner = CreateRunner();
+        var args = new Dictionary<string, string>();
+
+        runner.ApplyRejectedProposals(args);
+
+        Assert.IsFalse(args.ContainsKey("RejectedProposals"), "a first run has nothing to depart from");
+    }
+
+    [TestMethod]
+    public void ApplyRejectedProposals_Blank_AddsNoArg()
+    {
+        var runner = CreateRunner();
+        runner.RejectedProposals = "   ";
+        var args = new Dictionary<string, string>();
+
+        runner.ApplyRejectedProposals(args);
+
+        Assert.IsFalse(args.ContainsKey("RejectedProposals"));
+    }
+
+    [TestMethod]
+    public void ApplyRejectedProposals_TryAgain_SendsTheTextAsIs()
+    {
+        var runner = CreateRunner();
+        runner.RejectedProposals = "Concept: What if a parent chases a lost child?\nPremise: A parent chases a lost child.";
+        var args = new Dictionary<string, string>();
+
+        runner.ApplyRejectedProposals(args);
+
+        Assert.AreEqual(runner.RejectedProposals, args["RejectedProposals"]);
+    }
+
+    [TestMethod]
+    public void FormatRejectedProposals_OneLinePerRow_DisplayNameThenValue()
+    {
+        var rows = new[]
+        {
+            new PendingUpdateItem { Key = "Overview.Concept", PropertyDisplayName = "Concept", ProposedDisplay = "What if a parent chases a lost child?" },
+            new PendingUpdateItem { Key = "Overview.Premise", PropertyDisplayName = "Premise", ProposedDisplay = " A parent chases a lost child. " }
+        };
+
+        var text = WorkflowRunner.FormatRejectedProposals(rows);
+
+        Assert.AreEqual(
+            "Concept: What if a parent chases a lost child?\nPremise: A parent chases a lost child.",
+            text);
+    }
+
+    [TestMethod]
+    public void FormatRejectedProposals_SkipsRowsWithNoProposedText()
+    {
+        var rows = new[]
+        {
+            new PendingUpdateItem { Key = "Overview.Description", PropertyDisplayName = "Story Idea", ProposedDisplay = "" },
+            new PendingUpdateItem { Key = "Overview.Premise", PropertyDisplayName = "Premise", ProposedDisplay = "A parent chases a lost child." }
+        };
+
+        var text = WorkflowRunner.FormatRejectedProposals(rows);
+
+        Assert.AreEqual("Premise: A parent chases a lost child.", text);
+    }
+
+    [TestMethod]
+    public void FormatRejectedProposals_NoRows_IsEmpty()
+    {
+        Assert.AreEqual(string.Empty, WorkflowRunner.FormatRejectedProposals(Array.Empty<PendingUpdateItem>()));
+    }
+
+    [TestMethod]
+    public void FormatRejectedProposals_CutsAValueAtFourThousandCharacters()
+    {
+        var rows = new[]
+        {
+            new PendingUpdateItem { Key = "Problem.BeatSheet", PropertyDisplayName = "Beats", ProposedDisplay = new string('x', 5000) }
+        };
+
+        var text = WorkflowRunner.FormatRejectedProposals(rows);
+
+        Assert.AreEqual("Beats: ".Length + 4000, text.Length);
+    }
+}

--- a/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
+++ b/StoryCADTests/Collaborator/ViewModels/WorkflowViewModelTests.cs
@@ -494,7 +494,9 @@ public class WorkflowViewModelTests
             Item("C", isProtected: true)
         });
 
-        Assert.AreEqual("Proposed property updates (3: 1 free, 2 need review)", _viewModel.PendingUpdatesHeader);
+        // Collaborator #237 item 9: the header carries the total only; the status line
+        // says how many would replace the writer's text.
+        Assert.AreEqual("Proposed property updates (3)", _viewModel.PendingUpdatesHeader);
 
         _viewModel.ClearPendingUpdates();
         Assert.AreEqual("Proposed property updates", _viewModel.PendingUpdatesHeader);
@@ -556,9 +558,23 @@ public class WorkflowViewModelTests
         });
 
         StringAssert.Contains(_viewModel.Explanation, "Selected: Overview: Test Story");
-        StringAssert.Contains(_viewModel.Explanation, "2 property update(s)");
-        StringAssert.Contains(_viewModel.Explanation, "1 free");
-        StringAssert.Contains(_viewModel.Explanation, "1 need review");
+        StringAssert.Contains(_viewModel.Explanation, "2 property update(s) proposed.");
+        StringAssert.Contains(_viewModel.Explanation, "1 would replace text you wrote");
+        Assert.IsFalse(_viewModel.Explanation.Contains("free"), _viewModel.Explanation);
+    }
+
+    [TestMethod]
+    public void RefreshTopicalExplanation_NoProtectedRows_SaysNothingAboutReplacing()
+    {
+        // Collaborator #237 item 9: "0 need review" was noise on a run with nothing to review.
+        _viewModel.SetPendingUpdates(new List<PendingUpdateItem>
+        {
+            Item("A", isProtected: false),
+            Item("B", isProtected: false)
+        });
+
+        StringAssert.Contains(_viewModel.Explanation, "2 property update(s) proposed. Use Accept All, Review Each, or Try Again.");
+        Assert.IsFalse(_viewModel.Explanation.Contains("replace"), _viewModel.Explanation);
     }
 
     [TestMethod]


### PR DESCRIPTION
## What changed

Client side of Collaborator #237, the Ideation faults from the Scorecard S01 manual session.

- **Proposal chat patches reach the list and Accept.** `SessionProposalSet.ResolveKey` accepts the exact key, a bare property name, or the property part of a `Label.Property` key when the match is unique. The reply names what changed and what matched nothing. The sync logs a warning instead of returning in silence. A patch whose text equals the list reports "already reads that way" instead of "Changed".
- **Chat rules.** The system instructions state that the app applies the patches JSON to the list, forbid telling the writer to apply or re-run anything, say the writer's request outranks earlier proposals, and tell the model the run's order so a change to one proposal re-derives the ones after it. The assistant turn enters the history with the applied note.
- **Parser.** `ChatPatchParser` reads raw line breaks inside JSON strings and trailing commas, and the caller reports a patch block it could not read.
- **Try Again** sends the rejected proposals to the Worker.
- **Pane.** One workflow name in the top bar; "Accept All" on the button; plain wording and one count on the status line; the Outline gaps row counts fields.
- **RichEditBoxExtended** writes back only when the box has focus.
- Tests: `SessionProposalSetTests`, `ChatPatchParserTests`, `TryAgainRejectedProposalsTests`, `RequiredFieldGapScannerTests`, `WorkflowViewModelTests`.

## Why

Collaborator #237: chat revisions never reached the list or the file; the model then told the writer to apply patches itself; Try Again could repeat its answer; two names for one workflow; wording and count mismatches.

## How to test

```
"/c/Program Files/Microsoft Visual Studio/18/Community/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe" StoryCADTests/bin/x64/Debug/net10.0-windows10.0.22621/StoryCADTests.dll
```

1553 passed, 15 skipped. Live: open an outline, run Ideation on the Overview, type "Make the parent the child's mother" in the proposal chat. All three rows change in the list, the reply says what changed, and Accept All writes them to the outline.

Part of storybuilder-org/Collaborator#237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnB1fVj8g6nkMy5xWT7mwm
