### PR TITLE
feat(#244): Character Builder registry, stars, and gap ownership

### DIFF
--- a/CollaboratorLib/Context/ContextResolver.cs
+++ b/CollaboratorLib/Context/ContextResolver.cs
@@ -28,9 +28,8 @@ public class ContextResolver
     /// </summary>
     public static readonly HashSet<string> RelatedProblemsWorkflows = new(StringComparer.OrdinalIgnoreCase)
     {
-        // #182 DefineCharacter; #183 StoryFunction; #184 FlawBackstory.
-        "DefineCharacter",
-        "StoryFunction",
+        // #244 CharacterBuilder; #184 FlawBackstory.
+        "CharacterBuilder",
         "FlawBackstory"
     };
 

--- a/CollaboratorLib/Context/GapDetail.cs
+++ b/CollaboratorLib/Context/GapDetail.cs
@@ -19,7 +19,7 @@ public sealed class GapDetail
 
     /// <summary>
     /// Distinct Collaborator workflow labels that help fill these properties
-    /// (e.g. ProblemBuilder, StoryFunction). Empty if only host-element edit applies.
+    /// (e.g. ProblemBuilder, CharacterBuilder). Empty if only host-element edit applies.
     /// </summary>
     public required IReadOnlyList<string> HelperWorkflowLabels { get; init; }
 }

--- a/CollaboratorLib/Context/GapWorkflowOwnership.cs
+++ b/CollaboratorLib/Context/GapWorkflowOwnership.cs
@@ -42,13 +42,13 @@ public static class GapWorkflowOwnership
             (StoryItemType.Problem, "Premise") => new[] { "ProblemBuilder", "StoryProblem" },
             (StoryItemType.Problem, "Description") => new[] { "ProblemBuilder", "StoryProblem" },
 
-            // #182 occupation Role; #183 Story Function + Character Sketch; #107 essentials
-            (StoryItemType.Character, "Role") => new[] { "DefineCharacter" },
-            (StoryItemType.Character, "Age") => new[] { "DefineCharacter" },
-            (StoryItemType.Character, "Sex") => new[] { "DefineCharacter" },
-            (StoryItemType.Character, "Appearance") => new[] { "DefineCharacter" },
-            (StoryItemType.Character, "StoryRole") => new[] { "StoryFunction" },
-            (StoryItemType.Character, "Description") => new[] { "StoryFunction" },
+            // #244 CharacterBuilder owns the sheet and the sketch.
+            (StoryItemType.Character, "Role") => new[] { "CharacterBuilder" },
+            (StoryItemType.Character, "Age") => new[] { "CharacterBuilder" },
+            (StoryItemType.Character, "Sex") => new[] { "CharacterBuilder" },
+            (StoryItemType.Character, "Appearance") => new[] { "CharacterBuilder" },
+            (StoryItemType.Character, "StoryRole") => new[] { "CharacterBuilder" },
+            (StoryItemType.Character, "Description") => new[] { "CharacterBuilder" },
             (StoryItemType.Character, "BackStory") => new[] { "FlawBackstory" },
             (StoryItemType.Character, "Name") => Array.Empty<string>(),
 

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -25,14 +25,15 @@ namespace StoryCollaborator.Workflows
         /// than a catalog. Seeded once by WorkflowStarService; after that the user's choices win.
         /// #77 took GMC and Structure off the band when ProblemBuilder landed, and #211 has now
         /// deleted them along with the Scene micro-workflows the band held for A:B. One workflow
-        /// per stage is the point: ProblemBuilder carries the problem, SceneBuilder the scene.
+        /// per stage is the point: ProblemBuilder carries the problem, CharacterBuilder the
+        /// cast function, SceneBuilder the scene.
         /// </summary>
         public static readonly IReadOnlyList<string> DefaultStarredLabels = new List<string>
         {
             "Premise",
             "StoryProblem",
             "ProblemBuilder",
-            "StoryFunction",
+            "CharacterBuilder",
             "SceneBuilder"
         };
 
@@ -42,8 +43,9 @@ namespace StoryCollaborator.Workflows
         /// a user could have starred. WorkflowStarService compares it against the number in the
         /// user's preferences and migrates once.
         /// #224 raised this to 2 for the two Setting labels SettingBuilder absorbed.
+        /// #244 raised this to 3 for DefineCharacter and StoryFunction.
         /// </summary>
-        public const int StarMigrationVersion = 2;
+        public const int StarMigrationVersion = 3;
 
         /// <summary>
         /// Deleted workflow label to the workflow that absorbed its job (#211). A user who
@@ -67,7 +69,10 @@ namespace StoryCollaborator.Workflows
                 ["Sequel"] = "SceneBuilder",
                 // #224: SettingBuilder is the one Setting surface.
                 ["SettingTimeSpace"] = "SettingBuilder",
-                ["Sensations"] = "SettingBuilder"
+                ["Sensations"] = "SettingBuilder",
+                // #244: CharacterBuilder is the one Character fill surface.
+                ["DefineCharacter"] = "CharacterBuilder",
+                ["StoryFunction"] = "CharacterBuilder"
             };
 
         /// <summary>
@@ -472,36 +477,36 @@ namespace StoryCollaborator.Workflows
                     InjectsCurrentBeats = true
                 },
                 // === Character Workflows ===
-                // #182 DefineCharacter: world identity + personality. Occupation Role lives here.
+                // #244 CharacterBuilder: sheet then plot function in one pass.
+                // Absorbs #182 DefineCharacter and #183 StoryFunction.
                 new Workflow(
-                    "DefineCharacter", "Define Character",
-                    "Define who this person is in the world: occupation, body, social background, " +
-                    "psychology, personality facets, and traits—kept coherent with each other and with " +
-                    "problems that link this character.",
+                    "CharacterBuilder", "Character Builder",
+                    "Define who this person is in the world and their plot function: occupation, body, " +
+                    "social background, psychology, traits, Story Role, Archetype, and Character Sketch.",
                     StoryItemType.Character,
-                    explanation: "Build a coherent person sheet in one pass. Occupation (Role), appearance, " +
-                                "class and culture, psych profile, and traits must fit together and fit " +
-                                "problems where this character is protagonist or antagonist. " +
-                                "Does not set Story Role, Character Sketch, Flaw, or Backstory.",
+                    explanation: "Build a coherent person sheet and plot function in one pass. Occupation (Role), " +
+                                "appearance, class and culture, psych profile, and traits must fit together and fit " +
+                                "problems where this character is protagonist or antagonist. Then Story Role, " +
+                                "Archetype, and Character Sketch (Description). Does not set Flaw or Backstory.",
                     outputProperties: new List<PropertySpec>
                     {
                         new PropertySpec("Role"),
                         new PropertySpec("Age"),
                         new PropertySpec("Sex"),
+                        new PropertySpec("Economic"),
+                        new PropertySpec("Education"),
+                        new PropertySpec("Ethnic"),
+                        new PropertySpec("Religion"),
                         new PropertySpec("Eyes"),
                         new PropertySpec("Hair"),
                         new PropertySpec("Build"),
                         new PropertySpec("Complexion"),
                         new PropertySpec("Appearance"),
-                        new PropertySpec("Economic"),
-                        new PropertySpec("Education"),
-                        new PropertySpec("Ethnic"),
-                        new PropertySpec("Religion"),
                         new PropertySpec("Enneagram"),
                         new PropertySpec("Intelligence"),
                         new PropertySpec("Values"),
-                        new PropertySpec("Abnormality"),
                         new PropertySpec("Focus"),
+                        new PropertySpec("Abnormality"),
                         new PropertySpec("Adventurousness"),
                         new PropertySpec("Aggression"),
                         new PropertySpec("Confidence"),
@@ -514,7 +519,10 @@ namespace StoryCollaborator.Workflows
                         new PropertySpec("Shrewdness"),
                         new PropertySpec("Sociability"),
                         new PropertySpec("Stability"),
-                        new PropertySpec("TraitList", WriteVia.SimpleList, ListEntryType: typeof(string))
+                        new PropertySpec("TraitList", WriteVia.SimpleList, ListEntryType: typeof(string)),
+                        new PropertySpec("StoryRole"),
+                        new PropertySpec("Archetype"),
+                        new PropertySpec("Description")
                     },
                     exampleLists: new List<string>
                     {
@@ -522,26 +530,9 @@ namespace StoryCollaborator.Workflows
                         "Enneagram", "Intelligence", "Values", "Abnormality", "Focus", "Trait",
                         "Adventurousness", "Aggression", "Confidence", "Conscientiousness",
                         "Creativity", "Dominance", "Enthusiasm", "Assurance", "Sensitivity",
-                        "Shrewdness", "Sociability", "Stability"
+                        "Shrewdness", "Sociability", "Stability",
+                        "StoryRole", "Archetype"
                     }),
-                // #183 StoryFunction: plot function only. Occupation Role is DefineCharacter.
-                new Workflow(
-                    "StoryFunction", "Character Story Function",
-                    "Define the character's plot function: Story Role, Archetype, and Character Sketch.",
-                    StoryItemType.Character,
-                    explanation: "Story Role is narrative function (Protagonist, Antagonist, Supporting). " +
-                                "Archetype is the universal pattern (Hero, Mentor, Shadow). " +
-                                "Character Sketch (Description) is short story-function prose from those choices, " +
-                                "Related Problems, Flaw when present, and story premise—not a physical biography. " +
-                                "Occupation Role is set by Define Character, not this workflow.",
-                    outputProperties: new List<PropertySpec>
-                    {
-                        new PropertySpec("StoryRole"),
-                        new PropertySpec("Archetype"),
-                        // Character Sketch (gap label); Collaborator #142
-                        new PropertySpec("Description")
-                    },
-                    exampleLists: new List<string> { "StoryRole", "Archetype" }),
                 // #184 FlawBackstory: wound + history together. Retires Flaw and Backstory.
                 new Workflow(
                     "FlawBackstory", "Flaw and Backstory",
@@ -563,7 +554,7 @@ namespace StoryCollaborator.Workflows
                     label: "Relationship",
                     title: "Character Relationship",
                     description: "Develop the dynamics, history, and tension between two characters.",
-                    explanation: "Name both people. Prefer some sheet fill from Define Character, Character Story Function, or Flaw and Backstory on each side. " +
+                    explanation: "Name both people. Prefer some sheet fill from Character Builder or Flaw and Backstory on each side. " +
                                 "The run still proceeds if sheets are thin. The model uses filled traits when they exist. It does not invent missing bulk fields. " +
                                 "Accept writes the short type, Trait, Attitude, and Relationship Notes on both people.",
                     workflowIO: new WorkflowIO

--- a/StoryCADTests/Collaborator/RequiredFieldGapScannerTests.cs
+++ b/StoryCADTests/Collaborator/RequiredFieldGapScannerTests.cs
@@ -166,7 +166,7 @@ public class RequiredFieldGapScannerTests
         {
             var owners = GapWorkflowOwnership.WorkflowsFor(StoryItemType.Character, prop);
             Assert.AreEqual(1, owners.Count, prop);
-            Assert.AreEqual("DefineCharacter", owners[0], prop);
+            Assert.AreEqual("CharacterBuilder", owners[0], prop);
         }
 
         var backStory = GapWorkflowOwnership.WorkflowsFor(StoryItemType.Character, "BackStory");

--- a/StoryCADTests/Collaborator/StoryFunctionSketchTests.cs
+++ b/StoryCADTests/Collaborator/StoryFunctionSketchTests.cs
@@ -5,68 +5,55 @@ using StoryCollaborator.Workflows;
 namespace StoryCADTests.Collaborator;
 
 /// <summary>
-/// Collaborator #142 / #183: StoryFunction owns Character Sketch (Description).
-/// Occupation Role is DefineCharacter (#182).
+/// Collaborator #244: CharacterBuilder owns Character Sketch (Description) and occupation Role.
 /// </summary>
 [TestClass]
 public class StoryFunctionSketchTests
 {
     [TestMethod]
-    public void StoryFunction_Outputs_IncludeDescription_NotOccupationRole()
+    public void CharacterBuilder_Outputs_IncludeDescriptionAndOccupationRole()
     {
-        var wf = WorkflowRegistry.Get("StoryFunction");
+        var wf = WorkflowRegistry.Get("CharacterBuilder");
         Assert.IsNotNull(wf);
-        Assert.AreEqual("Character Story Function", wf!.Title);
+        Assert.AreEqual("Character Builder", wf!.Title);
         var props = wf.GetIO().Outputs
             .SelectMany(o => o.PropertiesToUpdate)
             .Select(p => p.Property)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        Assert.IsFalse(props.Contains("Role"), "Occupation Role is DefineCharacter (#182)");
+        Assert.IsTrue(props.Contains("Role"), "Occupation Role is CharacterBuilder (#244)");
         Assert.IsTrue(props.Contains("StoryRole"));
         Assert.IsTrue(props.Contains("Archetype"));
         Assert.IsTrue(props.Contains("Description"),
             "Character Sketch is Description on Character");
         Assert.IsNull(WorkflowRegistry.Get("RoleAndStoryRole"));
+        Assert.IsNull(WorkflowRegistry.Get("StoryFunction"));
+        Assert.IsNull(WorkflowRegistry.Get("DefineCharacter"));
     }
 
     [TestMethod]
-    public void DefineCharacter_Outputs_IncludeOccupationRole()
-    {
-        var wf = WorkflowRegistry.Get("DefineCharacter");
-        Assert.IsNotNull(wf);
-        var props = wf!.GetIO().Outputs
-            .SelectMany(o => o.PropertiesToUpdate)
-            .Select(p => p.Property)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        Assert.IsTrue(props.Contains("Role"));
-        Assert.IsFalse(props.Contains("StoryRole"));
-        Assert.IsFalse(props.Contains("Description"));
-    }
-
-    [TestMethod]
-    public void GapOwnership_CharacterSketchAndStoryRole_PointToStoryFunction()
+    public void GapOwnership_CharacterSketchAndStoryRole_PointToCharacterBuilder()
     {
         var desc = GapWorkflowOwnership.WorkflowsFor(
             StoryItemType.Character, "Description");
         Assert.AreEqual(1, desc.Count);
-        Assert.AreEqual("StoryFunction", desc[0]);
+        Assert.AreEqual("CharacterBuilder", desc[0]);
         Assert.AreEqual("Character Sketch",
             GapWorkflowOwnership.DisplayLabel(StoryItemType.Character, "Description"));
 
         var storyRole = GapWorkflowOwnership.WorkflowsFor(
             StoryItemType.Character, "StoryRole");
         Assert.AreEqual(1, storyRole.Count);
-        Assert.AreEqual("StoryFunction", storyRole[0]);
+        Assert.AreEqual("CharacterBuilder", storyRole[0]);
     }
 
     [TestMethod]
-    public void GapOwnership_CharacterRole_PointsToDefineCharacter()
+    public void GapOwnership_CharacterRole_PointsToCharacterBuilder()
     {
         var owners = GapWorkflowOwnership.WorkflowsFor(
             StoryItemType.Character, "Role");
         Assert.AreEqual(1, owners.Count);
-        Assert.AreEqual("DefineCharacter", owners[0]);
+        Assert.AreEqual("CharacterBuilder", owners[0]);
     }
 
     [TestMethod]

--- a/StoryCADTests/Collaborator/WorkflowStarServiceTests.cs
+++ b/StoryCADTests/Collaborator/WorkflowStarServiceTests.cs
@@ -168,6 +168,27 @@ public class WorkflowStarServiceTests
     }
 
     [TestMethod]
+    public async Task GetStarredAsync_WithCharacterFillStars_MapsBothToCharacterBuilder()
+    {
+        _preferences.Model.CollaboratorStarDefaultsApplied = true;
+        _preferences.Model.CollaboratorStarMigrationVersion = 2;
+        _preferences.Model.StarredCollaboratorWorkflows = new List<string>
+        {
+            "Premise", "DefineCharacter", "StoryFunction", "SceneBuilder"
+        };
+
+        var starred = await _service.GetStarredAsync(
+            WorkflowRegistry.DefaultStarredLabels.ToArray(),
+            WorkflowRegistry.RetiredWorkflowReplacements,
+            WorkflowRegistry.StarMigrationVersion);
+
+        CollectionAssert.AreEqual(
+            new[] { "Premise", "CharacterBuilder", "SceneBuilder" },
+            starred.ToArray());
+        Assert.AreEqual(3, _preferences.Model.CollaboratorStarMigrationVersion);
+    }
+
+    [TestMethod]
     public async Task GetStarredAsync_AfterMigrating_DoesNotRunAgain()
     {
         _preferences.Model.CollaboratorStarDefaultsApplied = true;

--- a/docs/StoryCAD Collaborator/Opening_Collaborator.md
+++ b/docs/StoryCAD Collaborator/Opening_Collaborator.md
@@ -41,12 +41,12 @@ A **status** strip at the bottom carries short messages when needed (for example
 
 ## What the workflow list shows
 
-Collaborator ships with about twenty workflows. Showing all of them at once is not much help when you only want to run one, so the list opens short and grows only when you ask it to. From the top:
+Collaborator ships with twelve workflows. Showing all of them at once is not much help when you only want to run one, so the list opens short and grows only when you ask it to. From the top:
 
 | Band | What it holds |
 |------|---------------|
 | **Outline gaps** | Required fields you have not filled in yet, with a count. Appears only when there are gaps. This is usually the most useful thing to do next. |
-| **Starred** | The workflows you have marked as yours. Seven sensible ones are starred to begin with. |
+| **Starred** | The workflows you have marked as yours. Five are starred to begin with. |
 | **Story element groups** | Everything else, filed under Overview, Problem, Character, Setting, and Scene. These start closed. Click a group to open it and browse. |
 
 Nothing is hidden. The rest of the catalog is one click away, in the groups.

--- a/docs/StoryCAD Collaborator/Tutorial/A_Path_to_Try.md
+++ b/docs/StoryCAD Collaborator/Tutorial/A_Path_to_Try.md
@@ -10,13 +10,13 @@ has_toc: false
 
 # A Path to Try
 
-Collaborator has thirteen workflows. You do not need all of them on day one. The path below matches the craft order in [Writing with StoryCAD](../../Writing%20with%20StoryCAD/Writing_with_StoryCAD.html): idea and premise first, then problem and character force, then structure and scenes.
+Collaborator has twelve workflows. You do not need all of them on day one. The path below matches the craft order in [Writing with StoryCAD](../../Writing%20with%20StoryCAD/Writing_with_StoryCAD.html): idea and premise first, then problem and character force, then structure and scenes.
 
 You can skip steps, but this order usually wastes less time.
 
 ## The starred band is a head start
 
-Collaborator starts with five of these workflows starred, so they sit at the top of the workflow list before you touch anything: **Premise**, **Story Problem**, **Problem Builder**, **Character Story Function**, and **Scene Builder**. That is one per stage of the spine below, so the top of the list reads as a next step rather than a catalog.
+Collaborator starts with five of these workflows starred, so they sit at the top of the workflow list before you touch anything: **Premise**, **Story Problem**, **Problem Builder**, **Character Builder**, and **Scene Builder**. That is one per stage of the spine below, so the top of the list reads as a next step rather than a catalog.
 
 Treat it as a starting point, not a rule. As you learn which workflows your writing turns on, star those and unstar the rest. [Opening Collaborator](../Opening_Collaborator.html) shows how. Everything not starred is still there, filed under its story element.
 
@@ -42,7 +42,7 @@ Treat it as a starting point, not a rule. As you learn which workflows your writ
    Craft: outer and inner problems in the same Defining Problems material
 
 6. **One character path**  
-   For example **Character Story Function**, then **Flaw and Backstory**.  
+   For example **Character Builder**, then **Flaw and Backstory**.  
    Craft: [Defining Characters](../../Writing%20with%20StoryCAD/Defining_Characters.html)
 
 7. **Scene Builder**  

--- a/docs/StoryCAD Collaborator/Workflows_and_Writing_Craft.md
+++ b/docs/StoryCAD Collaborator/Workflows_and_Writing_Craft.md
@@ -29,7 +29,7 @@ StoryCAD’s manual already teaches the craft spine: idea and premise, problems,
 | What’s the main story problem? | [Defining Problems](../Writing%20with%20StoryCAD/Defining_Problems.html), [Problem and Character Development](../Writing%20with%20StoryCAD/Problem_and_Character_Development.html) | Story Problem; Problem Builder |
 | Outer want vs inner need? | [Defining Problems](../Writing%20with%20StoryCAD/Defining_Problems.html) (outer and inner problems) | Inner and Outer Problems |
 | How is the story shaped? | [Plotting with StoryCAD](../Writing%20with%20StoryCAD/Plotting_with_StoryCAD.html), Overview Structure | Problem Builder (it picks the beat sheet) |
-| Who is this character? | [Defining Characters](../Writing%20with%20StoryCAD/Defining_Characters.html) | Character Story Function; Flaw and Backstory; Define Character |
+| Who is this character? | [Defining Characters](../Writing%20with%20StoryCAD/Defining_Characters.html) | Character Builder; Flaw and Backstory |
 | What happens in this scene? | [Defining Scenes](../Writing%20with%20StoryCAD/Defining_Scenes.html), [Plotting in Scenes](../Writing%20with%20StoryCAD/Plotting_in_Scenes.html) | Scene Builder |
 
 Names on the list may be slightly longer in the app (for example, a full “Ideation…” label). The work is the same: one craft focus per run.


### PR DESCRIPTION
## What changed

Client half of Collaborator **Character Builder**.

- `WorkflowRegistry`: one `CharacterBuilder` entry. `DefineCharacter` and `StoryFunction` removed.
- Default stars: `StoryFunction` replaced by `CharacterBuilder`. Band stays five.
- `StarMigrationVersion` 2 to 3. Stored stars on either old label become one Character Builder star.
- Gap ownership for Role, Age, Sex, Appearance, StoryRole, Description points at `CharacterBuilder`.
- `RelatedProblems` gather lists `CharacterBuilder` and `FlawBackstory`.
- User-facing Collaborator pages name Character Builder. Workflow count is twelve.

## Why

Implements the client for [Collaborator #244](https://github.com/storybuilder-org/Collaborator/issues/244). Pair: [Collaborator #245](https://github.com/storybuilder-org/Collaborator/pull/245).

Does not close #244 (issue lives in Collaborator).

## How to test

1. Build StoryCADTests / CollaboratorTests. Collaborator slice: 62 passed, 1 skipped (live integration). StoryCAD `Collaborator` tests: 471 passed, 10 skipped.
2. Against the deployed **dev** Worker, select an existing Character and run **Character Builder**. Confirm Define Character and Character Story Function are gone from the list.
3. A stored star on Character Story Function should become Character Builder after one launch (`StarMigrationVersion` 3).
