### PR TITLE
fix(#246): Scene Builder runs on spine-owned scenes

### DIFF
--- a/CollaboratorLib/Collaborator.cs
+++ b/CollaboratorLib/Collaborator.cs
@@ -2540,8 +2540,8 @@ public class Collaborator : ICollaborator
     }
 
     /// <summary>
-    /// Collaborator #208: inject Overview, owner, contributing Problems, neighbors, seats, Setting.
-    /// Sets Failed on Story Problem / empty-category bail. Does not open pickers.
+    /// Collaborator #208 / #246: inject Overview, owner, contributing Problems, neighbors, seats, Setting.
+    /// Sets Failed on empty-category bail. Does not open pickers.
     /// </summary>
     private void InjectSceneBuilder(StoryElement sceneElement, GatherResult result)
     {
@@ -2553,8 +2553,7 @@ public class Collaborator : ICollaborator
         foreach (var line in resolved.StatusLines)
             result.StatusMessages.Add(line);
 
-        if (resolved.OwnerState is Services.SceneStructureNeighborResolver.SceneBuilderOwnerState.StoryProblemBail
-            or Services.SceneStructureNeighborResolver.SceneBuilderOwnerState.EmptyCategoryBail)
+        if (resolved.OwnerState is Services.SceneStructureNeighborResolver.SceneBuilderOwnerState.EmptyCategoryBail)
         {
             result.Failed = true;
             result.BailReason = resolved.BailReason;

--- a/CollaboratorLib/Services/SceneStructureNeighborResolver.cs
+++ b/CollaboratorLib/Services/SceneStructureNeighborResolver.cs
@@ -32,7 +32,6 @@ public sealed class SceneStructureNeighborResolver
         UniqueSubproblem,
         ExplorerParentSubproblem,
         AmbiguousSubproblems,
-        StoryProblemBail,
         EmptyCategoryBail
     }
 
@@ -269,9 +268,6 @@ public sealed class SceneStructureNeighborResolver
         return null;
     }
 
-    public const string SceneBuilderStoryProblemBailMessage =
-        "Scene Builder does not run on a Story Problem. Use Problem Builder for story-problem beats.";
-
     public const string SceneBuilderEmptyCategoryBailMessage =
         "Set Problem Category on the owning problem before Scene Builder.";
 
@@ -296,7 +292,7 @@ public sealed class SceneStructureNeighborResolver
         var overviewStoryProblem = GetOverviewStoryProblemUuid();
         var (state, owner, bail) = ResolveSceneBuilderOwner(owners, explorerParent, overviewStoryProblem);
 
-        if (state is SceneBuilderOwnerState.StoryProblemBail or SceneBuilderOwnerState.EmptyCategoryBail)
+        if (state is SceneBuilderOwnerState.EmptyCategoryBail)
         {
             if (owner != null)
                 status.Add($"Scene Builder: owner Problem = {owner.Name}");
@@ -365,14 +361,12 @@ public sealed class SceneStructureNeighborResolver
         return Guid.Empty;
     }
 
+    /// <summary>
+    /// Collaborator #246: the Spine is Overview.StoryProblem only. ProblemCategory is not identity.
+    /// </summary>
     internal bool IsStoryProblem(ProblemModel problem, Guid overviewStoryProblem)
     {
-        if (overviewStoryProblem != Guid.Empty && problem.Uuid == overviewStoryProblem)
-            return true;
-        return string.Equals(
-            (problem.ProblemCategory ?? string.Empty).Trim(),
-            Collaborator.StoryProblemCategoryListValue,
-            StringComparison.OrdinalIgnoreCase);
+        return overviewStoryProblem != Guid.Empty && problem.Uuid == overviewStoryProblem;
     }
 
     internal (SceneBuilderOwnerState State, ProblemModel? Owner, string? BailReason)
@@ -382,47 +376,38 @@ public sealed class SceneStructureNeighborResolver
             Guid overviewStoryProblem)
     {
         bool IsSp(ProblemModel p) => IsStoryProblem(p, overviewStoryProblem);
-        bool IsCategorizedSubproblem(ProblemModel p) =>
-            !IsSp(p) && !string.IsNullOrWhiteSpace(p.ProblemCategory);
-
         var ownerList = owners?.ToList() ?? new List<ProblemModel>();
 
-        // 5.4 step 1
-        if (explorerParent != null && IsSp(explorerParent))
-            return (SceneBuilderOwnerState.StoryProblemBail, explorerParent, SceneBuilderStoryProblemBailMessage);
-
-        // 5.4 step 2
+        // Collaborator #246: explorer parent with a blank category still aborts, unless one
+        // categorized structure owner can stand in (same fall-through as #208).
         if (explorerParent != null && string.IsNullOrWhiteSpace(explorerParent.ProblemCategory))
         {
-            var categorized = ownerList.Where(IsCategorizedSubproblem).ToList();
+            var categorized = ownerList
+                .Where(p => !string.IsNullOrWhiteSpace(p.ProblemCategory))
+                .ToList();
             if (categorized.Count == 1)
                 return (SceneBuilderOwnerState.UniqueSubproblem, categorized[0], null);
             return (SceneBuilderOwnerState.EmptyCategoryBail, explorerParent, SceneBuilderEmptyCategoryBailMessage);
         }
 
-        // 5.4 step 3
         if (explorerParent != null)
             return (SceneBuilderOwnerState.ExplorerParentSubproblem, explorerParent, null);
 
-        // 5.4 step 4
-        var nonStory = ownerList.Where(o => !IsSp(o)).ToList();
-        if (nonStory.Count == 1)
-        {
-            var only = nonStory[0];
-            if (string.IsNullOrWhiteSpace(only.ProblemCategory))
-                return (SceneBuilderOwnerState.EmptyCategoryBail, only, SceneBuilderEmptyCategoryBailMessage);
-            return (SceneBuilderOwnerState.UniqueSubproblem, only, null);
-        }
+        if (ownerList.Count == 0)
+            return (SceneBuilderOwnerState.None, null, null);
 
-        // 5.4 step 5
-        if (ownerList.Count > 0 && ownerList.All(IsSp))
-            return (SceneBuilderOwnerState.StoryProblemBail, ownerList[0], SceneBuilderStoryProblemBailMessage);
+        var categorizedOwners = ownerList
+            .Where(p => !string.IsNullOrWhiteSpace(p.ProblemCategory))
+            .ToList();
+        if (categorizedOwners.Count == 0)
+            return (SceneBuilderOwnerState.EmptyCategoryBail, ownerList[0], SceneBuilderEmptyCategoryBailMessage);
 
-        // 5.4 step 6
-        if (nonStory.Count >= 2)
+        var nonSpine = categorizedOwners.Where(o => !IsSp(o)).ToList();
+        if (nonSpine.Count >= 2)
             return (SceneBuilderOwnerState.AmbiguousSubproblems, null, null);
+        if (nonSpine.Count == 1)
+            return (SceneBuilderOwnerState.UniqueSubproblem, nonSpine[0], null);
 
-        // 5.4 step 7
-        return (SceneBuilderOwnerState.None, null, null);
+        return (SceneBuilderOwnerState.UniqueSubproblem, categorizedOwners[0], null);
     }
 }

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -174,8 +174,8 @@ namespace StoryCollaborator
                     return WorkflowResult.Failed(gateMessage);
             }
 
-            // Collaborator #208: SceneBuilder Story Problem / empty-category bail. Distinct
-            // from the category gate above: a missing Problem map entry is not empty category.
+            // Collaborator #208 / #246: SceneBuilder empty-category bail. Distinct from the
+            // category gate above: a missing Problem map entry is not empty category.
             if (string.Equals(workflowModel.Label, "SceneBuilder", StringComparison.Ordinal))
             {
                 var sceneBuilderGate = ValidateSceneBuilderOwner(gatheredElements);
@@ -1628,8 +1628,8 @@ namespace StoryCollaborator
         }
 
         /// <summary>
-        /// Collaborator #208: refuse POST when OwnerState is StoryProblemBail or EmptyCategoryBail.
-        /// Missing Problem map entry is not empty category.
+        /// Collaborator #208 / #246: refuse POST when OwnerState is EmptyCategoryBail.
+        /// Missing Problem map entry is not empty category. Spine owner is not a bail.
         /// </summary>
         internal string? ValidateSceneBuilderOwner(Dictionary<string, StoryElement> gatheredElements)
         {
@@ -1637,8 +1637,7 @@ namespace StoryCollaborator
                 return null;
 
             var resolved = new SceneStructureNeighborResolver(_storyApi).ResolveForSceneBuilder(scene);
-            if (resolved.OwnerState is SceneStructureNeighborResolver.SceneBuilderOwnerState.StoryProblemBail
-                or SceneStructureNeighborResolver.SceneBuilderOwnerState.EmptyCategoryBail)
+            if (resolved.OwnerState is SceneStructureNeighborResolver.SceneBuilderOwnerState.EmptyCategoryBail)
                 return resolved.BailReason;
             return null;
         }
@@ -1704,10 +1703,6 @@ namespace StoryCollaborator
                 match = problems.Payload.OfType<ProblemModel>().FirstOrDefault(p => p.Uuid == proposed.Value);
             if (match == null)
                 return WriteOrphanProposeNotes(scene, result, "GUID not in ProblemChoices", displayName);
-
-            var overviewSp = resolver.GetOverviewStoryProblemUuid();
-            if (resolver.IsStoryProblem(match, overviewSp))
-                return WriteOrphanProposeNotes(scene, result, "proposed owner is Story Problem", displayName);
 
             var structure = _storyApi.GetProblemStructure(match.Uuid);
             if (!structure.IsSuccess || structure.Payload.Beats == null)

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -770,7 +770,7 @@ namespace StoryCollaborator.Workflows
                     label: "SceneBuilder",
                     title: "Scene Builder",
                     description: "Fill an existing Scene: sketch, type, cast, development, conflict, and sequel.",
-                    explanation: "Scene Builder does not create a Scene. Select a Scene first. The run reads contributing Problems and writes Scene fields the model can infer. It does not run on a Story Problem.",
+                    explanation: "Scene Builder does not create a Scene. Select a Scene first. The run reads contributing Problems and writes Scene fields the model can infer.",
                     workflowIO: new WorkflowIO
                     {
                         RequiredInputs = new List<ElementRequirement>

--- a/StoryCADLib/Models/Elements/OverviewModel.cs
+++ b/StoryCADLib/Models/Elements/OverviewModel.cs
@@ -77,6 +77,12 @@ public class OverviewModel : StoryElement
         set => _storyProblem = value;
     }
 
+    /// <summary>
+    /// Lists.json ProblemCategory value for the Spine. Collaborator #246: category follows
+    /// Overview.StoryProblem; it is not Spine identity.
+    /// </summary>
+    public const string StoryProblemCategoryListValue = "Story problem";
+
     /// The OverviewModel Premise is the story's premise. If a StoryProblem has been created
     /// and selected (which may not be true in the story's early formulation), this
     /// Premise property and the StoryProblem Premise will be synchronized: when you update

--- a/StoryCADLib/ViewModels/OverviewViewModel.cs
+++ b/StoryCADLib/ViewModels/OverviewViewModel.cs
@@ -388,6 +388,7 @@ public class OverviewViewModel : ObservableRecipient, INavigable, ISaveable, IRe
                 Model.Style = Style ?? "";
                 Model.Tone = Tone ?? "";
                 Model.StoryProblem = StoryProblem;
+                ApplySpineCategory();
                 Model.Description = Description ?? "";
                 Model.Concept = Concept ?? "";
                 Model.Premise = Premise ?? "";
@@ -419,6 +420,43 @@ public class OverviewViewModel : ObservableRecipient, INavigable, ISaveable, IRe
             _logger.LogException(LogLevel.Error,
                 ex, $"Failed to save overview model - {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Collaborator #246: selecting a Spine on Overview writes ProblemCategory Story problem
+    /// on that Problem. Clearing the picker does not change the old Problem's category.
+    /// </summary>
+    private void ApplySpineCategory()
+    {
+        if (StoryProblem == Guid.Empty || _storyModel == null)
+            return;
+
+        if (StoryElement.GetByGuid(StoryProblem, _storyModel) is not ProblemModel spine)
+            return;
+
+        if (!string.Equals(
+                (spine.ProblemCategory ?? string.Empty).Trim(),
+                OverviewModel.StoryProblemCategoryListValue,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            spine.ProblemCategory = OverviewModel.StoryProblemCategoryListValue;
+        }
+    }
+
+    /// <summary>
+    /// Collaborator #246: ProblemViewModel writes Overview.StoryProblem on category change.
+    /// Copy that GUID onto the picker so the ComboBox does not keep the previous Problem.
+    /// </summary>
+    public void SyncPickerFromModel()
+    {
+        if (Model == null || Problems == null)
+            return;
+
+        var was = _changeable;
+        _changeable = false;
+        StoryProblem = Model.StoryProblem;
+        SelectedProblem = Problems.FirstOrDefault(p => p.Uuid == StoryProblem);
+        _changeable = was;
     }
 
     public void ReloadFromModel()

--- a/StoryCADLib/ViewModels/ProblemViewModel.cs
+++ b/StoryCADLib/ViewModels/ProblemViewModel.cs
@@ -466,7 +466,9 @@ public class ProblemViewModel : ObservableRecipient, INavigable, ISaveable, IRel
             Model.Name = Name;
             Model.ProblemType = ProblemType;
             Model.ConflictType = ConflictType;
+            var previousCategory = Model.ProblemCategory;
             Model.ProblemCategory = ProblemCategory;
+            SyncSpineWithCategory(previousCategory);
             Model.Subject = Subject;
             Model.ProblemSource = ProblemSource;
             Model.Protagonist = Protagonist;
@@ -497,6 +499,54 @@ public class ProblemViewModel : ObservableRecipient, INavigable, ISaveable, IRel
             _logger.LogException(LogLevel.Error,
                 ex, $"Failed to save problem model - {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Collaborator #246: Overview.StoryProblem follows ProblemCategory.
+    /// Category Story problem writes this Problem as the Spine (the Overview picker
+    /// target). Leaving Story problem for a Subplot, Complication, Sequence, or blank
+    /// clears the Overview link when it pointed here. A no-op save of a GUID spine
+    /// that still has a blank category does not clear.
+    /// </summary>
+    private void SyncSpineWithCategory(string previousCategory)
+    {
+        if (_overviewModel == null || Model == null)
+            return;
+
+        var incoming = (ProblemCategory ?? string.Empty).Trim();
+        bool isStoryProblemCategory = string.Equals(
+            incoming,
+            OverviewModel.StoryProblemCategoryListValue,
+            StringComparison.OrdinalIgnoreCase);
+        bool isSubproblemCategory =
+            incoming.Equals("Complication", StringComparison.OrdinalIgnoreCase)
+            || incoming.Equals("Subplot", StringComparison.OrdinalIgnoreCase)
+            || incoming.Equals("Sequence", StringComparison.OrdinalIgnoreCase);
+        bool wasStoryProblemCategory = string.Equals(
+            (previousCategory ?? string.Empty).Trim(),
+            OverviewModel.StoryProblemCategoryListValue,
+            StringComparison.OrdinalIgnoreCase);
+
+        if (isStoryProblemCategory)
+        {
+            _overviewModel.StoryProblem = Model.Uuid;
+            _syncPremise = true;
+            PushSpineToOverviewPicker();
+            return;
+        }
+
+        if (_overviewModel.StoryProblem == Model.Uuid
+            && (isSubproblemCategory || wasStoryProblemCategory))
+        {
+            _overviewModel.StoryProblem = Guid.Empty;
+            _syncPremise = false;
+            PushSpineToOverviewPicker();
+        }
+    }
+
+    private void PushSpineToOverviewPicker()
+    {
+        Ioc.Default.GetService<OverviewViewModel>()?.SyncPickerFromModel();
     }
 
     public void ReloadFromModel()

--- a/StoryCADTests/Collaborator/SceneBuilderResolverTests.cs
+++ b/StoryCADTests/Collaborator/SceneBuilderResolverTests.cs
@@ -46,7 +46,7 @@ public class SceneBuilderResolverTests
     }
 
     [TestMethod]
-    public async Task ExplorerParentStoryProblem_BailsEvenWhenComplicationAlsoOwns()
+    public async Task ExplorerParentStoryProblem_RunsWithSpineOwner()
     {
         var api = CreateApi();
         var fx = await BuildThreeSceneComplication(api);
@@ -58,13 +58,15 @@ public class SceneBuilderResolverTests
 
         var resolved = new SceneStructureNeighborResolver(api).ResolveForSceneBuilder(underSp);
 
-        Assert.AreEqual(SceneStructureNeighborResolver.SceneBuilderOwnerState.StoryProblemBail, resolved.OwnerState);
+        Assert.AreEqual(
+            SceneStructureNeighborResolver.SceneBuilderOwnerState.ExplorerParentSubproblem,
+            resolved.OwnerState);
         Assert.AreEqual(fx.StoryProblem.Uuid, resolved.OwnerProblem!.Uuid);
-        StringAssert.Contains(resolved.BailReason, "does not run on a Story Problem");
+        Assert.IsNull(resolved.BailReason);
     }
 
     [TestMethod]
-    public async Task OnlyStructureOwnerIsStoryProblem_Bails()
+    public async Task OnlyStructureOwnerIsStoryProblem_Runs()
     {
         var api = CreateApi();
         await api.CreateEmptyOutline("SP only", "Author", "0");
@@ -82,7 +84,11 @@ public class SceneBuilderResolverTests
 
         var resolved = new SceneStructureNeighborResolver(api).ResolveForSceneBuilder(scene);
 
-        Assert.AreEqual(SceneStructureNeighborResolver.SceneBuilderOwnerState.StoryProblemBail, resolved.OwnerState);
+        Assert.AreEqual(
+            SceneStructureNeighborResolver.SceneBuilderOwnerState.UniqueSubproblem,
+            resolved.OwnerState);
+        Assert.AreEqual(sp.Uuid, resolved.OwnerProblem!.Uuid);
+        Assert.IsNull(resolved.BailReason);
         Assert.IsNull(resolved.PrecedingScene);
         Assert.IsNull(resolved.NextScene);
     }
@@ -169,7 +175,7 @@ public class SceneBuilderResolverTests
     }
 
     [TestMethod]
-    public async Task MixedCaseStoryProblemCategory_Bails()
+    public async Task CategoryOnlyStoryProblem_IsNotSpine_Runs()
     {
         var api = CreateApi();
         await api.CreateEmptyOutline("Mixed case", "Author", "0");
@@ -180,9 +186,14 @@ public class SceneBuilderResolverTests
         var scAdd = api.AddElement(StoryItemType.Scene, problem.Uuid.ToString(), "Child");
         var scene = api.GetStoryElement(scAdd.Payload).Payload!;
 
-        var resolved = new SceneStructureNeighborResolver(api).ResolveForSceneBuilder(scene);
+        var resolver = new SceneStructureNeighborResolver(api);
+        var resolved = resolver.ResolveForSceneBuilder(scene);
 
-        Assert.AreEqual(SceneStructureNeighborResolver.SceneBuilderOwnerState.StoryProblemBail, resolved.OwnerState);
+        Assert.IsFalse(resolver.IsStoryProblem(problem, resolver.GetOverviewStoryProblemUuid()));
+        Assert.AreEqual(
+            SceneStructureNeighborResolver.SceneBuilderOwnerState.ExplorerParentSubproblem,
+            resolved.OwnerState);
+        Assert.IsNull(resolved.BailReason);
     }
 
     [TestMethod]
@@ -285,7 +296,7 @@ public class SceneBuilderResolverTests
     }
 
     [TestMethod]
-    public async Task OrphanAccept_StoryProblemGuid_WritesNotesWhenEmpty()
+    public async Task OrphanAccept_StoryProblemGuid_BindsFirstEmptyBeat()
     {
         var api = CreateApi();
         await api.CreateEmptyOutline("SP bind", "Author", "0");
@@ -303,15 +314,37 @@ public class SceneBuilderResolverTests
         var runner = new WorkflowRunner(api.CurrentModel!, WorkflowRegistry.Get("SceneBuilder")!, api);
         var result = WorkflowResult.Succeeded();
         result.ProposedOwnerGuid = sp.Uuid;
+        result.ProposedOwnerName = sp.Name;
         var gathered = new Dictionary<string, StoryElement> { ["Scene"] = scene };
 
         var msg = runner.TryApplySceneBuilderOrphanBind(result, gathered);
 
-        StringAssert.Contains(msg, "could not bind");
+        Assert.IsNotNull(msg);
+        StringAssert.Contains(msg, "assigned Scene");
         var structure = api.GetProblemStructure(sp.Uuid);
-        var linked = structure.Payload.Beats.First().LinkedElement;
-        Assert.IsTrue(linked is not Guid assigned || assigned == Guid.Empty);
-        Assert.IsFalse(string.IsNullOrEmpty(((SceneModel)api.GetStoryElement(scene.Uuid).Payload!).Notes));
+        Assert.AreEqual(scene.Uuid, structure.Payload.Beats.First().LinkedElement);
+        Assert.AreEqual(folder.Uuid, scene.Node!.Parent!.Uuid);
+    }
+
+    [TestMethod]
+    public async Task GuidMatch_IsSpine_CategoryAlone_IsNot()
+    {
+        var api = CreateApi();
+        await api.CreateEmptyOutline("Identity", "Author", "0");
+        var overview = api.CurrentModel!.StoryElements.First(e => e.ElementType == StoryItemType.StoryOverview);
+        var linkedAdd = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "Linked");
+        var linked = (ProblemModel)api.GetStoryElement(linkedAdd.Payload).Payload!;
+        api.UpdateElementProperty(linked.Uuid, "ProblemCategory", "Subplot");
+        api.UpdateElementProperty(overview.Uuid, "StoryProblem", linked.Uuid);
+        var catAdd = api.AddElement(StoryItemType.Problem, overview.Uuid.ToString(), "Category only");
+        var catOnly = (ProblemModel)api.GetStoryElement(catAdd.Payload).Payload!;
+        api.UpdateElementProperty(catOnly.Uuid, "ProblemCategory", "Story problem");
+
+        var resolver = new SceneStructureNeighborResolver(api);
+        var spine = resolver.GetOverviewStoryProblemUuid();
+
+        Assert.IsTrue(resolver.IsStoryProblem(linked, spine));
+        Assert.IsFalse(resolver.IsStoryProblem(catOnly, spine));
     }
 
     [TestMethod]

--- a/StoryCADTests/Collaborator/SceneBuilderWorkflowRegistryTests.cs
+++ b/StoryCADTests/Collaborator/SceneBuilderWorkflowRegistryTests.cs
@@ -59,6 +59,16 @@ public class SceneBuilderWorkflowRegistryTests
     }
 
     [TestMethod]
+    public void SceneBuilder_Explanation_DoesNotRefuseSpine()
+    {
+        var workflow = WorkflowRegistry.Get("SceneBuilder");
+        Assert.IsNotNull(workflow);
+        Assert.IsFalse(
+            workflow!.Explanation.Contains("does not run on a Story Problem"),
+            workflow.Explanation);
+    }
+
+    [TestMethod]
     public void DefaultStarredLabels_IncludeSceneBuilder_WithoutTheMicroWorkflows()
     {
         var starred = WorkflowRegistry.DefaultStarredLabels.ToList();

--- a/StoryCADTests/Services/IReloadableTests.cs
+++ b/StoryCADTests/Services/IReloadableTests.cs
@@ -165,5 +165,25 @@ public class IReloadableTests
         Assert.AreEqual("External Edit", viewModel.Description);
     }
 
+    [TestMethod]
+    public void OverviewViewModel_SaveModel_SetsSpineProblemCategory()
+    {
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var storyModel = new StoryModel();
+        var overview = new OverviewModel("Test Story", storyModel, null);
+        storyModel.ExplorerView.Add(overview.Node);
+        var problem = new ProblemModel("Candidate", storyModel, overview.Node);
+        problem.ProblemCategory = "Subplot";
+        appState.CurrentDocument = new StoryDocument(storyModel);
+
+        var viewModel = Ioc.Default.GetRequiredService<OverviewViewModel>();
+        viewModel.Activate(overview);
+        viewModel.SelectedProblem = problem;
+        viewModel.SaveModel();
+
+        Assert.AreEqual(problem.Uuid, overview.StoryProblem);
+        Assert.AreEqual(OverviewModel.StoryProblemCategoryListValue, problem.ProblemCategory);
+    }
+
     #endregion
 }

--- a/StoryCADTests/ViewModels/ProblemViewModelTests.cs
+++ b/StoryCADTests/ViewModels/ProblemViewModelTests.cs
@@ -359,6 +359,123 @@ public class ProblemViewModelTests
     }
 
     [TestMethod]
+    public void SaveModel_SpineCategoryToSubplot_ClearsOverviewStoryProblem()
+    {
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var overview = (OverviewModel)_storyModel.StoryElements
+            .First(e => e.ElementType == StoryItemType.StoryOverview);
+
+        var storyProblem = new ProblemModel("Main Story Problem", _storyModel, overview.Node);
+        storyProblem.ProblemCategory = OverviewModel.StoryProblemCategoryListValue;
+        overview.StoryProblem = storyProblem.Uuid;
+
+        appState.CurrentDocument = new StoryDocument(_storyModel);
+
+        _viewModel.Activate(storyProblem);
+        _viewModel.ProblemCategory = "Subplot";
+        _viewModel.Deactivate(null);
+
+        Assert.AreEqual("Subplot", storyProblem.ProblemCategory);
+        Assert.AreEqual(Guid.Empty, overview.StoryProblem);
+    }
+
+    [TestMethod]
+    public void SaveModel_EmptyOverview_StoryProblemCategory_SetsSpine()
+    {
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var overview = (OverviewModel)_storyModel.StoryElements
+            .First(e => e.ElementType == StoryItemType.StoryOverview);
+        overview.StoryProblem = Guid.Empty;
+
+        var problem = new ProblemModel("Candidate", _storyModel, overview.Node);
+        problem.ProblemCategory = string.Empty;
+
+        appState.CurrentDocument = new StoryDocument(_storyModel);
+
+        _viewModel.Activate(problem);
+        _viewModel.ProblemCategory = OverviewModel.StoryProblemCategoryListValue;
+        _viewModel.Deactivate(null);
+
+        Assert.AreEqual(problem.Uuid, overview.StoryProblem);
+        Assert.AreEqual(OverviewModel.StoryProblemCategoryListValue, problem.ProblemCategory);
+    }
+
+    [TestMethod]
+    public void SaveModel_StoryProblemCategory_SetsOverviewToThisProblem()
+    {
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var overview = (OverviewModel)_storyModel.StoryElements
+            .First(e => e.ElementType == StoryItemType.StoryOverview);
+
+        var spine = new ProblemModel("Spine", _storyModel, overview.Node);
+        spine.ProblemCategory = OverviewModel.StoryProblemCategoryListValue;
+        overview.StoryProblem = spine.Uuid;
+
+        var other = new ProblemModel("Other", _storyModel, overview.Node);
+        other.ProblemCategory = "Subplot";
+
+        appState.CurrentDocument = new StoryDocument(_storyModel);
+
+        _viewModel.Activate(other);
+        _viewModel.ProblemCategory = OverviewModel.StoryProblemCategoryListValue;
+        _viewModel.Deactivate(null);
+
+        Assert.AreEqual(other.Uuid, overview.StoryProblem);
+        Assert.AreEqual(OverviewModel.StoryProblemCategoryListValue, other.ProblemCategory);
+    }
+
+    [TestMethod]
+    public void SaveModel_LeaveStoryProblem_ClearsOverviewPicker()
+    {
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var overview = (OverviewModel)_storyModel.StoryElements
+            .First(e => e.ElementType == StoryItemType.StoryOverview);
+
+        var storyProblem = new ProblemModel("Main Story Problem", _storyModel, overview.Node);
+        storyProblem.ProblemCategory = OverviewModel.StoryProblemCategoryListValue;
+        overview.StoryProblem = storyProblem.Uuid;
+
+        appState.CurrentDocument = new StoryDocument(_storyModel);
+
+        var overviewVm = Ioc.Default.GetRequiredService<OverviewViewModel>();
+        overviewVm.Activate(overview);
+        Assert.AreEqual(storyProblem.Uuid, overviewVm.SelectedProblem?.Uuid);
+
+        _viewModel.Activate(storyProblem);
+        _viewModel.ProblemCategory = "Subplot";
+        _viewModel.Deactivate(null);
+
+        Assert.AreEqual(Guid.Empty, overview.StoryProblem);
+        Assert.AreEqual("(none)", overviewVm.SelectedProblem?.Name);
+        Assert.AreEqual(Guid.Empty, overviewVm.StoryProblem);
+    }
+
+    [TestMethod]
+    public void SaveModel_SetStoryProblemCategory_UpdatesOverviewPicker()
+    {
+        var appState = Ioc.Default.GetRequiredService<AppState>();
+        var overview = (OverviewModel)_storyModel.StoryElements
+            .First(e => e.ElementType == StoryItemType.StoryOverview);
+        overview.StoryProblem = Guid.Empty;
+
+        var problem = new ProblemModel("Candidate", _storyModel, overview.Node);
+        problem.ProblemCategory = string.Empty;
+
+        appState.CurrentDocument = new StoryDocument(_storyModel);
+
+        var overviewVm = Ioc.Default.GetRequiredService<OverviewViewModel>();
+        overviewVm.Activate(overview);
+
+        _viewModel.Activate(problem);
+        _viewModel.ProblemCategory = OverviewModel.StoryProblemCategoryListValue;
+        _viewModel.Deactivate(null);
+
+        Assert.AreEqual(problem.Uuid, overview.StoryProblem);
+        Assert.AreEqual(problem.Uuid, overviewVm.SelectedProblem?.Uuid);
+        Assert.AreEqual(problem.Uuid, overviewVm.StoryProblem);
+    }
+
+    [TestMethod]
     public void SelectedElementSource_WhenSetToScene_SetsCurrentElementSourceToScenes()
     {
         // Arrange - Setup AppState with CurrentDocument

--- a/docs/StoryCAD Collaborator/Tutorial/A_Path_to_Try.md
+++ b/docs/StoryCAD Collaborator/Tutorial/A_Path_to_Try.md
@@ -46,7 +46,7 @@ Treat it as a starting point, not a rule. As you learn which workflows your writ
    Craft: [Defining Characters](../../Writing%20with%20StoryCAD/Defining_Characters.html)
 
 7. **Scene Builder**  
-   Sketch, type, cast, development, conflict, and sequel for one scene. Select the scene first: Scene Builder fills a scene you already made, and does not run on the story problem itself.  
+   Sketch, type, cast, development, conflict, and sequel for one scene. Select the scene first: Scene Builder fills a scene you already made.  
    Craft: [Defining Scenes](../../Writing%20with%20StoryCAD/Defining_Scenes.html), [Plotting in Scenes](../../Writing%20with%20StoryCAD/Plotting_in_Scenes.html)
 
 ![The workflow pane with the starred workflows at the top, in running order](../../media/Collaborator-Workflow-Pane.png)


### PR DESCRIPTION
## What changed

Client first slice of Collaborator **#246** (orthogonal Problem and Scene workflows).

- Scene Builder no longer bails when the Scene owner is the Spine (`Overview.StoryProblem`). Empty Problem Category still aborts.
- `IsStoryProblem` is the Overview GUID only. Category is not identity.
- Changing Problem Category to Story problem sets Overview Story Problem and the picker to that Problem. Leaving it for Subplot / Complication / Sequence / blank clears Overview and the picker shows `(none)`.
- Orphan Accept may bind a Scene to a Spine beat.
- Tutorial no longer says Scene Builder does not run on the story problem.

## Why

[Collaborator #246](https://github.com/storybuilder-org/Collaborator/issues/246): Scene Builder refused Scenes under the Story Problem (Friday under Stuck in a time loop). Pair design: `Collaborator/devdocs/issue_246_orthogonal_problem_workflows_design.md`.

Does not close #246 (issue lives in Collaborator; Problem Builder stubs are a later pair).

## How to test

1. StoryCADTests filter `SceneBuilderResolverTests|SceneBuilderWorkflowRegistryTests|SaveModel_SpineCategory|SaveModel_EmptyOverview|SaveModel_StoryProblemCategory_SetsOverview|SaveModel_LeaveStoryProblem|SaveModel_SetStoryProblemCategory|SaveModel_StoryProblem_StillSyncs|SaveModel_NonStoryProblem|OverviewViewModel_SaveModel_SetsSpine`: 34 + 8 passed locally.
2. Open `C:\temp\THE TEST STORY.stbx`. Leave **Stuck in a time loop** as Story problem. Run Scene Builder on **Friday (loop start)**. It should run.
3. Change that Problem Category to Subplot. Overview Story Problem should show `(none)`. Set it back to Story problem. Overview should point at that Problem.