### PR TITLE
feat(#246): create Problem stubs for empty Problem Builder beats

### DIFF
--- a/CollaboratorLib/Models/PropertySpec.cs
+++ b/CollaboratorLib/Models/PropertySpec.cs
@@ -106,6 +106,8 @@ namespace StoryCollaborator.Models
     /// One beat in a BeatSheet output.
     /// SceneName (#150 BeatScenes): when set on an empty beat, create a Scene under the
     /// problem and assign it. Structure and other workflows leave SceneName null.
+    /// ProblemName (#246): when set on an empty beat, create a Problem under the parent
+    /// and assign it. Category must be Complication, Subplot, or Sequence.
     /// </summary>
     public sealed record BeatInfo(
         string Title,
@@ -115,7 +117,10 @@ namespace StoryCollaborator.Models
         string? SceneDescription = null,
         string? SceneNotes = null,
         string? SceneType = null,
-        IReadOnlyList<Guid>? SceneCast = null);
+        IReadOnlyList<Guid>? SceneCast = null,
+        string? ProblemName = null,
+        string? ProblemDescription = null,
+        string? ProblemCategory = null);
 
     /// <summary>
     /// Collaborator #217 section 5.7: the value of one per-beat pending update. Row is the

--- a/CollaboratorLib/Models/ValueDisplay.cs
+++ b/CollaboratorLib/Models/ValueDisplay.cs
@@ -61,9 +61,16 @@ internal static class ValueDisplay
 
             // Collaborator #217 section 5.7: one beat row reads as what Accept will do to it.
             case BeatRowValue row:
-                return row.BindGuid.HasValue
-                    ? $"binds {row.ElementName ?? ResolveName(row.BindGuid.Value, resolveElementName)} ({row.ElementType ?? "element"})"
-                    : $"new Scene \"{row.Row.SceneName?.Trim()}\"";
+                if (row.BindGuid.HasValue)
+                    return $"binds {row.ElementName ?? ResolveName(row.BindGuid.Value, resolveElementName)} ({row.ElementType ?? "element"})";
+                if (!string.IsNullOrWhiteSpace(row.Row.ProblemName))
+                {
+                    var cat = row.Row.ProblemCategory?.Trim();
+                    return string.IsNullOrEmpty(cat)
+                        ? $"new Problem \"{row.Row.ProblemName.Trim()}\""
+                        : $"new Problem \"{row.Row.ProblemName.Trim()}\" ({cat})";
+                }
+                return $"new Scene \"{row.Row.SceneName?.Trim()}\"";
 
             case List<BeatInfo> beats:
                 return string.Join("\n", beats.Select((beat, i) =>

--- a/CollaboratorLib/WorkflowRunner.cs
+++ b/CollaboratorLib/WorkflowRunner.cs
@@ -51,6 +51,8 @@ namespace StoryCollaborator
         Bind,
         /// <summary>No bind applies and the proposal names a Scene stub to create.</summary>
         Create,
+        /// <summary>No bind applies and the proposal names a Problem stub to create.</summary>
+        CreateProblem,
         /// <summary>The proposal's GUID is not a candidate, or was used earlier; stays empty.</summary>
         Refuse,
         /// <summary>Neither a bindable GUID nor a scene name; stays empty.</summary>
@@ -1609,8 +1611,13 @@ namespace StoryCollaborator
                     }
                 }
 
+                var problemName = ReadString(beatElem, "problem_name");
+                var problemDescription = ReadString(beatElem, "problem_description");
+                var problemCategory = ReadString(beatElem, "problem_category");
+
                 beats.Add(new BeatInfo(title, desc, assigned, sceneName,
-                    sceneDescription, sceneNotes, sceneType, sceneCast));
+                    sceneDescription, sceneNotes, sceneType, sceneCast,
+                    problemName, problemDescription, problemCategory));
             }
             return beats;
         }
@@ -1914,8 +1921,16 @@ namespace StoryCollaborator
                     case BeatRowOutcome.Create:
                         sb.Append("new Scene \"").Append(row.ElementName).Append('"');
                         break;
+                    case BeatRowOutcome.CreateProblem:
+                        sb.Append("new Problem \"").Append(row.ElementName).Append('"');
+                        var stubCat = beats[row.Index].ProblemCategory?.Trim();
+                        if (!string.IsNullOrEmpty(stubCat))
+                            sb.Append(" (").Append(stubCat).Append(')');
+                        break;
                     case BeatRowOutcome.Refuse:
-                        if (row.ElementName != null)
+                        if (row.ElementGuid is null && row.ElementName != null)
+                            sb.Append(row.ElementName).Append(", stays empty");
+                        else if (row.ElementName != null)
                             sb.Append(row.ElementName).Append(" is already bound on this sheet, stays empty");
                         else
                             sb.Append(row.ElementGuid).Append(" is not a candidate, stays empty");
@@ -1938,7 +1953,7 @@ namespace StoryCollaborator
         /// </summary>
         private static string PlanSummary(List<BeatRowPlan> plan)
         {
-            int kept = 0, bound = 0, created = 0, empty = 0, refused = 0, dropped = 0;
+            int kept = 0, bound = 0, created = 0, createdProblems = 0, empty = 0, refused = 0, dropped = 0;
             foreach (var row in plan)
             {
                 switch (row.Outcome)
@@ -1946,6 +1961,7 @@ namespace StoryCollaborator
                     case BeatRowOutcome.Keep: kept++; break;
                     case BeatRowOutcome.Bind: bound++; break;
                     case BeatRowOutcome.Create: created++; break;
+                    case BeatRowOutcome.CreateProblem: createdProblems++; break;
                     case BeatRowOutcome.Empty: empty++; break;
                     case BeatRowOutcome.Refuse: refused++; break;
                     case BeatRowOutcome.Drop: dropped++; break;
@@ -1954,7 +1970,10 @@ namespace StoryCollaborator
 
             var sb = new System.Text.StringBuilder();
             sb.Append(plan.Count).Append(plan[0].InstallsBeat ? " new " : " ").Append(Plural(plan.Count, "beat")).Append(": ");
-            sb.Append($"{kept} kept, {bound} bound, {created} new {Plural(created, "scene")}, {empty} empty");
+            sb.Append($"{kept} kept, {bound} bound, {created} new {Plural(created, "scene")}");
+            if (createdProblems > 0)
+                sb.Append($", {createdProblems} new {Plural(createdProblems, "problem")}");
+            sb.Append($", {empty} empty");
             if (refused > 0) sb.Append($", {refused} refused");
             if (dropped > 0) sb.Append($", {dropped} dropped");
             return sb.ToString();
@@ -2190,6 +2209,7 @@ namespace StoryCollaborator
             // Collaborator #77: capability, not label. A new workflow that sets SceneName used
             // to create nothing because this line tested for the literal label "BeatScenes".
             bool allowSceneCreate = workflowModel.CreatesScenesForBeats;
+            bool allowProblemCreate = workflowModel.CreatesProblemsForBeats;
 
             // GUIDs on this sheet already, plus each Bind this plan makes: one placement per sheet.
             var usedOnSheet = new HashSet<Guid>(
@@ -2239,9 +2259,36 @@ namespace StoryCollaborator
                     continue;
                 }
 
-                if (allowSceneCreate && !string.IsNullOrWhiteSpace(beat.SceneName))
+                bool hasProblemStub = allowProblemCreate && !string.IsNullOrWhiteSpace(beat.ProblemName);
+                bool hasSceneStub = allowSceneCreate && !string.IsNullOrWhiteSpace(beat.SceneName);
+                if (hasProblemStub && hasSceneStub)
                 {
-                    plan.Add(new BeatRowPlan(i, title, BeatRowOutcome.Create, beat.SceneName.Trim(), null, installs));
+                    plan.Add(new BeatRowPlan(i, title, BeatRowOutcome.Refuse,
+                        "named a Scene stub and a Problem stub", null, installs));
+                    continue;
+                }
+
+                if (hasProblemStub)
+                {
+                    if (!IsSubproblemCategory(beat.ProblemCategory))
+                    {
+                        var cat = string.IsNullOrWhiteSpace(beat.ProblemCategory)
+                            ? "blank"
+                            : beat.ProblemCategory.Trim();
+                        plan.Add(new BeatRowPlan(i, title, BeatRowOutcome.Refuse,
+                            $"Problem stub category '{cat}' is not Complication, Subplot, or Sequence",
+                            null, installs));
+                        continue;
+                    }
+
+                    plan.Add(new BeatRowPlan(i, title, BeatRowOutcome.CreateProblem,
+                        beat.ProblemName!.Trim(), null, installs));
+                    continue;
+                }
+
+                if (hasSceneStub)
+                {
+                    plan.Add(new BeatRowPlan(i, title, BeatRowOutcome.Create, beat.SceneName!.Trim(), null, installs));
                     continue;
                 }
 
@@ -2348,6 +2395,8 @@ namespace StoryCollaborator
                     return AssignBeat(problemUuid, row.Index, row.ElementGuid!.Value, result);
                 case BeatRowOutcome.Create:
                     return CreateSceneStub(problemUuid, row.Index, beat, result);
+                case BeatRowOutcome.CreateProblem:
+                    return CreateProblemStub(problemUuid, row.Index, beat, result);
                 case BeatRowOutcome.Refuse:
                     result.StatusMessages.Add(RefuseStatus(row));
                     return false;
@@ -2356,9 +2405,22 @@ namespace StoryCollaborator
             }
         }
 
-        private static string RefuseStatus(BeatRowPlan row) => row.ElementName != null
-            ? $"Beat {row.Index} assigned_element {row.ElementGuid} already used on this sheet; left unassigned"
-            : $"Beat {row.Index} assigned_element {row.ElementGuid} not in candidate set; left unassigned";
+        private static string RefuseStatus(BeatRowPlan row)
+        {
+            if (row.ElementGuid is null && row.ElementName != null)
+                return $"Beat {row.Index} {row.ElementName}; left unassigned";
+            return row.ElementName != null
+                ? $"Beat {row.Index} assigned_element {row.ElementGuid} already used on this sheet; left unassigned"
+                : $"Beat {row.Index} assigned_element {row.ElementGuid} not in candidate set; left unassigned";
+        }
+
+        internal static bool IsSubproblemCategory(string? category)
+        {
+            var value = (category ?? string.Empty).Trim();
+            return value.Equals("Complication", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("Subplot", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("Sequence", StringComparison.OrdinalIgnoreCase);
+        }
 
         /// <summary>
         /// Collaborator #217 section 5.7: apply one accepted beat row. Earlier rows of the same
@@ -2400,7 +2462,11 @@ namespace StoryCollaborator
             }
             // The row applies only as what the pane showed it as: a Bind row binds the same
             // candidate, a Create row creates. Anything else changed under the writer.
-            var expected = row.BindGuid.HasValue ? BeatRowOutcome.Bind : BeatRowOutcome.Create;
+            var expected = row.BindGuid.HasValue
+                ? BeatRowOutcome.Bind
+                : !string.IsNullOrWhiteSpace(row.Row.ProblemName)
+                    ? BeatRowOutcome.CreateProblem
+                    : BeatRowOutcome.Create;
             var sameBinding = !row.BindGuid.HasValue || planned.ElementGuid == row.BindGuid;
             if (planned.Outcome != expected || !sameBinding)
             {
@@ -2469,6 +2535,7 @@ namespace StoryCollaborator
                     {
                         case BeatRowOutcome.Bind:
                         case BeatRowOutcome.Create:
+                        case BeatRowOutcome.CreateProblem:
                             var binds = row.Outcome == BeatRowOutcome.Bind;
                             var value = new BeatRowValue(
                                 row.Index, row.Title, beats[row.Index], beats,
@@ -2553,6 +2620,50 @@ namespace StoryCollaborator
 
             var assigned = AssignBeat(problemUuid, beatIndex, newGuid, result);
             result.StatusMessages.Add($"Beat {beatIndex}: created Scene '{name}' ({newGuid})");
+            return assigned;
+        }
+
+        /// <summary>
+        /// Collaborator #246: create the Problem stub a CreateProblem row names, set category
+        /// and description, copy seats from the parent Problem, and assign it to the beat.
+        /// </summary>
+        private bool CreateProblemStub(Guid problemUuid, int beatIndex, BeatInfo beat, WorkflowResult result)
+        {
+            if (!IsSubproblemCategory(beat.ProblemCategory))
+            {
+                var cat = string.IsNullOrWhiteSpace(beat.ProblemCategory)
+                    ? "blank"
+                    : beat.ProblemCategory.Trim();
+                result.StatusMessages.Add(
+                    $"Beat {beatIndex} Problem stub category '{cat}' is not Complication, Subplot, or Sequence");
+                return false;
+            }
+
+            var name = beat.ProblemName!.Trim();
+            var addResult = _storyApi.AddElement(StoryItemType.Problem, problemUuid.ToString(), name);
+            if (!addResult.IsSuccess)
+            {
+                result.StatusMessages.Add(
+                    $"Beat {beatIndex} problem create failed: {addResult.ErrorMessage}");
+                return false;
+            }
+
+            var newGuid = addResult.Payload;
+            _storyApi.UpdateElementProperty(newGuid, "ProblemCategory", beat.ProblemCategory!.Trim());
+            if (!string.IsNullOrWhiteSpace(beat.ProblemDescription))
+                _storyApi.UpdateElementProperty(newGuid, "Description", beat.ProblemDescription.Trim());
+
+            var parentResult = _storyApi.GetStoryElement(problemUuid);
+            if (parentResult.IsSuccess && parentResult.Payload is ProblemModel parent)
+            {
+                if (parent.Protagonist != Guid.Empty)
+                    _storyApi.UpdateElementProperty(newGuid, "Protagonist", parent.Protagonist);
+                if (parent.Antagonist != Guid.Empty)
+                    _storyApi.UpdateElementProperty(newGuid, "Antagonist", parent.Antagonist);
+            }
+
+            var assigned = AssignBeat(problemUuid, beatIndex, newGuid, result);
+            result.StatusMessages.Add($"Beat {beatIndex}: created Problem '{name}' ({newGuid})");
             return assigned;
         }
 

--- a/CollaboratorLib/Workflows/Workflow.cs
+++ b/CollaboratorLib/Workflows/Workflow.cs
@@ -45,6 +45,13 @@ namespace StoryCollaborator.Workflows
         public bool CreatesScenesForBeats { get; set; }
 
         /// <summary>
+        /// Collaborator #246: this workflow may create a Problem for an empty beat from
+        /// <see cref="StoryCollaborator.Models.BeatInfo.ProblemName"/>. Category must be
+        /// Complication, Subplot, or Sequence. Never a Spine.
+        /// </summary>
+        public bool CreatesProblemsForBeats { get; set; }
+
+        /// <summary>
         /// Collaborator #77: this workflow needs Problem.ProblemCategory before it runs.
         /// The category picks the beat sheet class. Nothing sets it on a ProblemBuilder run.
         /// </summary>

--- a/CollaboratorLib/Workflows/WorkflowRegistry.cs
+++ b/CollaboratorLib/Workflows/WorkflowRegistry.cs
@@ -470,6 +470,7 @@ namespace StoryCollaborator.Workflows
                 {
                     PrimaryElementType = StoryItemType.Problem,
                     CreatesScenesForBeats = true,
+                    CreatesProblemsForBeats = true,
                     RequiresProblemCategory = true,
                     InjectsConflictTaxonomy = true,
                     InjectsBeatSheets = true,

--- a/StoryCADTests/Collaborator/BeatListParsingTests.cs
+++ b/StoryCADTests/Collaborator/BeatListParsingTests.cs
@@ -63,5 +63,27 @@ public class BeatListParsingTests
 
         Assert.IsNull(beat.SceneType);
         Assert.IsNull(beat.SceneCast);
+        Assert.IsNull(beat.ProblemName);
+    }
+
+    [TestMethod]
+    public void ExtractBeatList_ReadsProblemStubFields()
+    {
+        using var doc = JsonDocument.Parse("""
+        [
+          {
+            "title": "Midpoint",
+            "description": "the nested fight",
+            "problem_name": "The Yellow Brick Road",
+            "problem_description": "Dorothy must reach the Emerald City.",
+            "problem_category": "Sequence"
+          }
+        ]
+        """);
+        var beat = WorkflowRunner.ExtractBeatList(doc.RootElement).Single();
+
+        Assert.AreEqual("The Yellow Brick Road", beat.ProblemName);
+        Assert.AreEqual("Dorothy must reach the Emerald City.", beat.ProblemDescription);
+        Assert.AreEqual("Sequence", beat.ProblemCategory);
     }
 }

--- a/StoryCADTests/Collaborator/ProblemBuilderRegistryTests.cs
+++ b/StoryCADTests/Collaborator/ProblemBuilderRegistryTests.cs
@@ -33,6 +33,7 @@ public class ProblemBuilderRegistryTests
         var workflow = Builder();
 
         Assert.IsTrue(workflow.CreatesScenesForBeats, "it creates Scene stubs for empty beats");
+        Assert.IsTrue(workflow.CreatesProblemsForBeats, "it creates Problem stubs for empty beats");
         Assert.IsTrue(workflow.RequiresProblemCategory, "the category picks the beat sheet class");
         Assert.IsTrue(workflow.InjectsConflictTaxonomy, "the #483 taxonomy feeds the conflict fields");
         Assert.IsTrue(workflow.InjectsBeatSheets, "the model picks from the built-in sheets");

--- a/StoryCADTests/Collaborator/ProblemStubContractTests.cs
+++ b/StoryCADTests/Collaborator/ProblemStubContractTests.cs
@@ -1,0 +1,128 @@
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StoryCADLib.Models;
+using StoryCADLib.Models.Tools;
+using StoryCADLib.Services.API;
+using StoryCADLib.Services.Outline;
+using StoryCADLib.ViewModels;
+using StoryCollaborator;
+using StoryCollaborator.Models;
+using StoryCollaborator.Workflows;
+
+#nullable disable
+
+namespace StoryCADTests.Collaborator;
+
+/// <summary>Collaborator #246: Problem Builder may stub a Problem on an empty beat.</summary>
+[TestClass]
+public class ProblemStubContractTests
+{
+    private static StoryCADApi CreateApi() => new(
+        Ioc.Default.GetRequiredService<OutlineService>(),
+        Ioc.Default.GetRequiredService<ListData>(),
+        Ioc.Default.GetRequiredService<ControlData>(),
+        Ioc.Default.GetRequiredService<ToolsData>());
+
+    private static (StoryModel Model, ProblemModel Parent, WorkflowRunner Runner) Arrange()
+    {
+        var model = new StoryModel();
+        var parent = new ProblemModel("Story Problem", model, null);
+        var prot = new CharacterModel("Hero", model, null);
+        var antag = new CharacterModel("Villain", model, null);
+        parent.Protagonist = prot.Uuid;
+        parent.Antagonist = antag.Uuid;
+        var api = CreateApi();
+        api.CurrentModel = model;
+        var workflow = new Workflow("ProblemBuilder", "Problem Builder", "test", StoryItemType.Problem)
+        {
+            CreatesScenesForBeats = true,
+            CreatesProblemsForBeats = true
+        };
+        return (model, parent, new WorkflowRunner(model, workflow, api));
+    }
+
+    [TestMethod]
+    public void CreateProblemStub_WritesCategoryDescriptionSeatsAndBeat()
+    {
+        var (model, parent, runner) = Arrange();
+        var result = new WorkflowResult();
+
+        runner.ApplyBeatSheetMerge(
+            parent.Uuid,
+            new List<BeatInfo>
+            {
+                new("Midpoint", "the nested fight",
+                    ProblemName: "The Yellow Brick Road",
+                    ProblemDescription: "Dorothy must reach the Emerald City.",
+                    ProblemCategory: "Sequence")
+            },
+            result);
+
+        var stub = model.StoryElements.OfType<ProblemModel>().Single(p => p.Uuid != parent.Uuid);
+        Assert.AreEqual("The Yellow Brick Road", stub.Name);
+        Assert.AreEqual("Sequence", stub.ProblemCategory);
+        Assert.AreEqual("Dorothy must reach the Emerald City.", stub.Description);
+        Assert.AreEqual(parent.Protagonist, stub.Protagonist);
+        Assert.AreEqual(parent.Antagonist, stub.Antagonist);
+        Assert.AreEqual(stub.Uuid, parent.StructureBeats[0].Guid);
+        StringAssert.Contains(string.Join('\n', result.StatusMessages), "created Problem");
+    }
+
+    [TestMethod]
+    public void CreateProblemStub_StoryProblemCategory_DoesNotCreate()
+    {
+        var (model, parent, runner) = Arrange();
+
+        runner.ApplyBeatSheetMerge(
+            parent.Uuid,
+            new List<BeatInfo>
+            {
+                new("Midpoint", "bad",
+                    ProblemName: "Another spine",
+                    ProblemCategory: "Story problem")
+            },
+            new WorkflowResult());
+
+        Assert.AreEqual(1, model.StoryElements.OfType<ProblemModel>().Count());
+        Assert.AreEqual(Guid.Empty, parent.StructureBeats[0].Guid);
+    }
+
+    [TestMethod]
+    public void Plan_BothStubKinds_RefusesAndCreatesNeither()
+    {
+        var (model, parent, runner) = Arrange();
+        var proposal = new List<BeatInfo>
+        {
+            new("Midpoint", "both",
+                SceneName: "Leave Kansas",
+                ProblemName: "The Yellow Brick Road",
+                ProblemCategory: "Sequence")
+        };
+
+        var plan = runner.PlanBeatSheetMerge(parent.Uuid, proposal);
+
+        Assert.AreEqual(BeatRowOutcome.Refuse, plan[0].Outcome);
+        StringAssert.Contains(plan[0].ElementName, "Scene stub and a Problem stub");
+
+        runner.ApplyBeatSheetMerge(parent.Uuid, proposal, new WorkflowResult());
+
+        Assert.AreEqual(0, model.StoryElements.OfType<SceneModel>().Count());
+        Assert.AreEqual(1, model.StoryElements.OfType<ProblemModel>().Count());
+    }
+
+    [TestMethod]
+    public void Plan_ProblemStub_DisplaysCategory()
+    {
+        var (_, parent, runner) = Arrange();
+        var text = runner.FormatBeatSheetDisplay(
+            parent.Uuid,
+            new List<BeatInfo>
+            {
+                new("Midpoint", "the nested fight",
+                    ProblemName: "The Yellow Brick Road",
+                    ProblemCategory: "Sequence")
+            });
+
+        StringAssert.Contains(text, "new Problem \"The Yellow Brick Road\" (Sequence)");
+    }
+}


### PR DESCRIPTION
## What changed

Client second slice of Collaborator **#246** (Problem stubs). Stacked on [StoryCAD #1559](https://github.com/storybuilder-org/StoryCAD/pull/1559).

- `Workflow.CreatesProblemsForBeats` on Problem Builder only.
- `BeatInfo` reads `problem_name`, `problem_description`, `problem_category`.
- Empty beat plan: bind first, then Create Problem, then Create Scene. Both stub kinds on one row refuses. Category Story problem or unknown refuses.
- `CreateProblemStub` writes category and description, copies parent seats, assigns the beat. No GMC, Premise, Notes, or child sheet.
- Review pane shows `new Problem "Name" (Sequence)`.

Does not close Collaborator #246 (issue lives in Collaborator; Worker pair is the Collaborator PR).

## Why

[Collaborator #246](https://github.com/storybuilder-org/Collaborator/issues/246): Problem Builder could bind a free Problem (`#217`) but could not create one. Oz needs a Sequence (Yellow Brick Road) as a beat of the Story Problem.

## How to test

1. StoryCADTests filter `ProblemStubContractTests|BeatListParsingTests|ProblemBuilderRegistryTests|BeatSheetPlanTests`: 29 passed locally.
2. After the Worker PR is on **dev**: run Problem Builder on a Story Problem with empty beats. Accept a Problem stub row. Confirm a child Problem with category Sequence/Subplot/Complication, copied seats, and the beat bound.
3. A row that names both a Scene stub and a Problem stub stays empty.
